### PR TITLE
P0009: Italicize "exposition only" comments

### DIFF
--- a/P0009/P0009.bs
+++ b/P0009/P0009.bs
@@ -763,12 +763,12 @@ Y8b.     .d8""8b. Y88b. Y8b.     888  888 Y88b.       X88
 <!-- TODO comparison operators -->
 <!-- TODO initializer list constructor? -->
 
-```c++
+<pre highlight="c++">
 namespace std {
 namespace experimental {
 namespace fundamentals_v3 {
 
-template<ptrdiff_t... StaticExtents>
+template&lt;ptrdiff_t... StaticExtents>
 class extents {
 public:
   // types
@@ -778,18 +778,18 @@ public:
   constexpr extents() noexcept;
   constexpr extents(const extents&) noexcept;
   constexpr extents(extents&&) noexcept;
-  template<class... IndexType>
+  template&lt;class... IndexType>
   constexpr extents(IndexType... dynamic_extents) noexcept;
-  template<class IndexType, size_t N>
-  constexpr extents(const array<IndexType, N>&) noexcept;
-  template<ptrdiff_t... OtherStaticExtents>
-  constexpr extents(const extents<OtherStaticExtents...>& other) noexcept;
+  template&lt;class IndexType, size_t N>
+  constexpr extents(const array&lt;IndexType, N>&) noexcept;
+  template&lt;ptrdiff_t... OtherStaticExtents>
+  constexpr extents(const extents&lt;OtherStaticExtents...>& other) noexcept;
   ~extents() = default;
 
   constexpr extents& operator=(const extents&) noexcept = default;
   constexpr extents& operator=(extents&&) noexcept = default;
-  template<ptrdiff_t... OtherStaticExtents>
-  constexpr extents& operator=(const extents<OtherStaticExtents...>& other) noexcept;
+  template&lt;ptrdiff_t... OtherStaticExtents>
+  constexpr extents& operator=(const extents&lt;OtherStaticExtents...>& other) noexcept;
 
   // 26.7.�.3 Observers of the index space domain:
   static constexpr size_t rank() noexcept;
@@ -798,12 +798,11 @@ public:
   constexpr index_type extent(int) const noexcept;
 
 private:
-  array<index_type, rank_dynamic()> dynamic_extents_; // exposition only
+  array&lt;index_type, rank_dynamic()> dynamic_extents_; // <i>exposition only</i>
 };
 
 }}}
-
-```
+</pre>
 
 <b>26.7.�.2 Constructors and assignment [mdspan.extents.cons]</b>
 
@@ -1074,28 +1073,28 @@ Table � — Layout mapping policy and layout mapping requirements
 2. `layout_left` gives a layout mapping where the left-most extent is stride one and strides increase left-to-right as the product of extents.
 3. If `Extents` is not a (possibly cv-qualified) specialization of `extents`, the program is ill-formed.
 
-```c++
+<pre highlight="c++">
 struct layout_left {
-  template<class Extents>
+  template&lt;class Extents>
   class mapping {
   public:
     constexpr mapping() noexcept;
     constexpr mapping(const mapping& other) noexcept;
     constexpr mapping(mapping&& other) noexcept;
     constexpr mapping(const Extents& e) noexcept;
-    template<class OtherExtents>
-      constexpr mapping(const mapping<OtherExtents>& other);
+    template&lt;class OtherExtents>
+      constexpr mapping(const mapping&lt;OtherExtents>& other);
 
     mapping& operator=() noexcept = default;
     mapping& operator=(const mapping& other) noexcept = default;
-    template<class OtherExtents>
-      constexpr mapping& operator=(const mapping<OtherExtents>& other);
+    template&lt;class OtherExtents>
+      constexpr mapping& operator=(const mapping&lt;OtherExtents>& other);
 
     Extents get_extents() const noexcept;
 
     constexpr typename Extents::index_type required_span_size() const noexcept;
 
-    template<class... Indices>
+    template&lt;class... Indices>
       typename Extents::index_type operator()(Indices... is) const;
 
     static constexpr bool is_always_unique();
@@ -1110,10 +1109,10 @@ struct layout_left {
     constexpr bool operator!=(const mapping& other) const;
 
   private:
-    Extents extents_; // exposition only
+    Extents extents_; // <i>exposition only</i>
   };
 };
-```
+</pre>
 
 
 <br/>
@@ -1308,28 +1307,28 @@ constexpr bool operator!=(const mapping& other) const noexcept;
 2. The layout mapping property `layout_right` gives a layout mapping where the right-most extent is stride one and strides increase right-to-left as the product of extents.
 3. If `Extents` is not a (possibly cv-qualified) specialization of `extents`, the program is ill-formed.
 
-```c++
+<pre highlight="c++">
 struct layout_right {
-  template<class Extents>
+  template&lt;class Extents>
   class mapping {
   public:
     constexpr mapping() noexcept;
     constexpr mapping(const mapping& other) noexcept;
     constexpr mapping(mapping&& other) noexcept;
     constexpr mapping(Extents e) noexcept;
-    template<class OtherExtents>
-      constexpr mapping(const mapping<OtherExtents>& other);
+    template&lt;class OtherExtents>
+      constexpr mapping(const mapping&lt;OtherExtents>& other);
 
     mapping& operator=() noexcept = default;
     mapping& operator=(const mapping& other) noexcept = default;
-    template<class OtherExtents>
-      constexpr mapping& operator=(const mapping<OtherExtents>& other);
+    template&lt;class OtherExtents>
+      constexpr mapping& operator=(const mapping&lt;OtherExtents>& other);
 
     Extents get_extents() const noexcept;
 
     constexpr typename Extents::index_type required_span_size() const noexcept;
 
-    template<class... Indices>
+    template&lt;class... Indices>
       typename Extents::index_type operator()(Indices... is) const;
 
     static constexpr bool is_always_unique() noexcept;
@@ -1343,10 +1342,10 @@ struct layout_right {
     ptrdiff_t stride(size_t rank) const noexcept;
 
   private:
-    Extents extents_; // exposition only
+    Extents extents_; // <i>exposition only</i>
   };
 };
-```
+</pre>
 
 
 <br/>
@@ -1545,29 +1544,29 @@ layout_stride
 
 <br/>
 
-```c++
+<pre highlight="c++">
 struct layout_stride {
-  template <typename Extents>
+  template&lt;typename Extents>
   class mapping {
   public:
     constexpr mapping() noexcept;
     constexpr mapping(mapping const& other) noexcept;
     constexpr mapping(mapping&& other) noexcept;
-    constexpr mapping(Extents e, array<ptrdiff_t, Extents::rank()> s) noexcept;
-    template<class OtherExtents>
-      constexpr mapping(const mapping<OtherExtents>& other);
+    constexpr mapping(Extents e, array&lt;ptrdiff_t, Extents::rank()> s) noexcept;
+    template&lt;class OtherExtents>
+      constexpr mapping(const mapping&lt;OtherExtents>& other);
 
     mapping& operator=() noexcept = default;
     mapping& operator=(mapping const& other) noexcept = default;
-    template<class OtherExtents>
-      constexpr mapping& operator=(const mapping<OtherExtents>& other);
+    template&lt;class OtherExtents>
+      constexpr mapping& operator=(const mapping&lt;OtherExtents>& other);
 
     Extents get_extents() const noexcept;
-    array<ptrdiff_t, Extents::rank()> get_strides() const noexcept;
+    array&lt;ptrdiff_t, Extents::rank()> get_strides() const noexcept;
 
     constexpr typename Extents::index_type required_span_size() const noexcept;
 
-    template <class... Indices>
+    template&lt;class... Indices>
       typename Extents::index_type operator()(Indices... is) const;
 
     static constexpr bool is_always_unique() noexcept;
@@ -1581,12 +1580,12 @@ struct layout_stride {
     ptrdiff_t stride(size_t rank) const noexcept;
 
   private:
-    Extents extents_; // exposition only
-    //TODO: should this be extents<dynamic_extent,...,dynamic_extent> ?
-    array<ptrdiff_t, Extents::rank()> strides_; // exposition only
+    Extents extents_; // <i>exposition only</i>
+    //TODO: should this be extents&lt;dynamic_extent,...,dynamic_extent> ?
+    array&lt;ptrdiff_t, Extents::rank()> strides_; // <i>exposition only</i>
   };
 };
-```
+</pre>
 
 <br/>
 
@@ -1898,21 +1897,21 @@ constexpr reference operator()(pointer p, ptrdiff_t i) const noexcept;
 8. If `Accessor` does not meet the accessor requirements, or if `Accessor::value_type` is not exactly `ElementType`, the program is ill-formed.
 
 
-```c++
+<pre highlight="c++">
 namespace std {
 namespace experimental {
 namespace fundamentals_v3 {
 
-template<class ElementType, class Extents, class LayoutPolicy, class Accessor>
+template&lt;class ElementType, class Extents, class LayoutPolicy, class Accessor>
 class basic_mdspan {
 public:
 
   // Domain and codomain types
   using layout = LayoutPolicy;
-  using mapping = typename layout::mapping<Extents>;
+  using mapping = typename layout::mapping&lt;Extents>;
   using accessor = Accessor;
   using element_type = typename accessor::value_type;
-  using value_type = remove_cv_t<element_type>;
+  using value_type = remove_cv_t&lt;element_type>;
   using index_type = ptrdiff_t ;
   using difference_type = ptrdiff_t ;
   using pointer = typename accessor::pointer;
@@ -1922,32 +1921,32 @@ public:
   constexpr basic_mdspan() noexcept;
   constexpr basic_mdspan(const basic_mdspan&) noexcept;
   constexpr basic_mdspan(basic_mdspan&&) noexcept;
-  template<class... IndexType>
+  template&lt;class... IndexType>
     explicit constexpr basic_mdspan(pointer, IndexType... dynamic_extents);
-  template<class... IndexType>
-    explicit constexpr basic_mdspan(span<element_type>, IndexType... dynamic_extents);
+  template&lt;class... IndexType>
+    explicit constexpr basic_mdspan(span&lt;element_type>, IndexType... dynamic_extents);
   constexpr basic_mdspan(pointer p, const mapping& m);
   constexpr basic_mdspan(pointer p, const mapping& m, const accessor& a);
-  template<class OtherElementType, class OtherExtents, class OtherLayoutPolicy, class OtherAccessor>
-    constexpr basic_mdspan(const basic_mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessor>& other);
-  template<class IndexType, size_t N>
-    explicit constexpr basic_mdspan(const pointer& p,const array<IndexType, N>& dynamic_extents);
-  template<class IndexType, size_t N>
-    explicit constexpr basic_mdspan(const span<element_type>& sp,const array<IndexType, N>& dynamic_extents) noexcept;
+  template&lt;class OtherElementType, class OtherExtents, class OtherLayoutPolicy, class OtherAccessor>
+    constexpr basic_mdspan(const basic_mdspan&lt;OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessor>& other);
+  template&lt;class IndexType, size_t N>
+    explicit constexpr basic_mdspan(const pointer& p,const array&lt;IndexType, N>& dynamic_extents);
+  template&lt;class IndexType, size_t N>
+    explicit constexpr basic_mdspan(const span&lt;element_type>& sp,const array&lt;IndexType, N>& dynamic_extents) noexcept;
 
   ~basic_mdspan();
 
   constexpr basic_mdspan& operator=(const basic_mdspan&) noexcept = default;
   constexpr basic_mdspan& operator=(basic_mdspan&&) noexcept = default;
-  template<class OtherElementType, class OtherExtents, class OtherLayoutPolicy, class OtherAccessor>
-    constexpr basic_mdspan& operator=(const basic_mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessor>& other) noexcept;
+  template&lt;class OtherElementType, class OtherExtents, class OtherLayoutPolicy, class OtherAccessor>
+    constexpr basic_mdspan& operator=(const basic_mdspan&lt;OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessor>& other) noexcept;
 
   // Mapping domain multi-index to access codomain element
   constexpr reference operator[](index_type) const noexcept;
-  template<class... IndexType>
+  template&lt;class... IndexType>
     constexpr reference operator()(IndexType... indices) const noexcept;
-  template<class IndexType, size_t N>
-    constexpr reference operator()(const array<IndexType, N>& indices) const noexcept;
+  template&lt;class IndexType, size_t N>
+    constexpr reference operator()(const array&lt;IndexType, N>& indices) const noexcept;
   accessor get_accessor() const;
 
   // Observers of the domain multi-index space
@@ -1961,7 +1960,7 @@ public:
   constexpr index_type unique_size() const noexcept;
 
   // Observers of the codomain:
-  constexpr span<element_type> span() const noexcept;
+  constexpr span&lt;element_type> span() const noexcept;
 
   // Observers of the mapping : domain -> codomain
   static constexpr bool is_always_unique() noexcept;
@@ -1975,13 +1974,13 @@ public:
   constexpr index_type stride(int) const;
 
 private:
-  accessor acc_; // exposition only
-  mapping map_; // exposition only
-  pointer ptr_; // exposition only
+  accessor acc_; // <i>exposition only</i>
+  mapping map_; // <i>exposition only</i>
+  pointer ptr_; // <i>exposition only</i>
 };
 
 }}}
-```
+</pre>
 
 <!--
 


### PR DESCRIPTION
This unfortunately requires a `<pre>` block instead of triple-backticks or `<xmp>`, hence the removal of left angle brackets.