### PR TITLE
Introduce beginnings of prototype/reference implementation, adjust wording

### DIFF
--- a/P0009/P0009.bs
+++ b/P0009/P0009.bs
@@ -1869,7 +1869,7 @@ static constexpr reference deref( accessor_type acc , size_t i ) noexcept ;
 * *Returns:* `acc[i]` <br/>
 
 ```c++
-static constexpr pointer deref( accessor_type acc , size_t i ) noexcept ;
+static constexpr pointer decay( accessor_type acc , size_t i ) noexcept ;
 ```
 
 * *Returns:* `acc` <br/>

--- a/P0009/P0009.bs
+++ b/P0009/P0009.bs
@@ -1786,6 +1786,12 @@ Table �: Accessor requirements
   <td></td>
   <td>*Requires:* `p` is a pointer to a contiguous set of objects.</td>
 </tr>
+<tr>
+  <td>`a = A(p);`</td>
+  <td></td>
+  <td>*Requires:* `p` is a pointer to a contiguous set of objects.</td>
+</tr>
+<tr>
 </table>
 
 <!--
@@ -1930,8 +1936,8 @@ public:
   static constexpr index_type required_span_size(const array&lt;IndexType, N>& dynamic_extents) noexcept;
 
 private:
-  mapping_type map_; // <i>exposition only</i>
-  pointer ptr_; // <i>exposition only</i>
+  mapping_type  map_; // <i>exposition only</i>
+  accessor_type acc_; // <i>exposition only</i>
 };
 
 }}}
@@ -1957,7 +1963,7 @@ constexpr basic_mdspan() noexcept = default;
 <!-- TODO check for periods, commas, and "and" here. -->
 <!-- TODO: decide if we want to include invocation of `span()` in the postconditions. An accessor may want to make this undefined behavior. -->
 * *Effects:*
-    * zero-initializes `ptr_`
+    * zero-initializes `acc_`
     * value-initializes `map_`
 * *Postconditions:* 
     + `size()==0`
@@ -1971,7 +1977,7 @@ constexpr basic_mdspan(const basic_mdspan& other) noexcept = default;
 ```
 
 * *Effects:*
-    + initializes `ptr_` with `other.ptr_`
+    + initializes `acc_` with `other.acc_`
     + initializes `map_` with `other.map_`
 * *Postconditions:*
     + `size()==other.size()`
@@ -1985,7 +1991,7 @@ constexpr basic_mdspan(basic_mdspan&& other) noexcept;
 ```
 
 * *Effects:*
-    + initializes `ptr_` with `move(other.ptr_)`
+    + initializes `acc_` with `move(other.acc_)`
     + initializes `map_` with `move(other.map_)`
 
 <br/>
@@ -1997,7 +2003,7 @@ template<class... IndexType>
 
 * *Requires:* `[ptr, ptr+required_span_size(dynamic_extents...))` shall be a valid range.
 * *Effects:*
-    + initializes `ptr_` with `ptr`
+    + initializes `acc_` with `ptr`
     + initializes `map_` with `extents_type(dynamic_extents...)`
 * *Postconditions:* 
     + `extents()==extents_type(dynamic_extents...)`
@@ -2017,7 +2023,7 @@ template<class... IndexType>
 
 * *Requires:* `sp.size()==required_span_size(dynamic_extents...)`
 * *Effects:*
-    + initializes `ptr_` with `sp.data()`
+    + initializes `acc_` with `sp.data()`
     + value-initializes `map_`
 * *Postconditions:* 
     + `extents()==extents_type(dynamic_extents...)`
@@ -2066,7 +2072,7 @@ constexpr basic_mdspan(pointer p, const mapping& m);
 
 * *Requires:* `[ptr, ptr+m.required_span_size())` shall be a valid range.
 * *Effects:*
-    + initializes `ptr_` with `p`
+    + initializes `acc_` with `p`
     + initializes `map_` with `m`
 * *Postconditions:* 
     + `extents()==m.extents()`
@@ -2092,7 +2098,7 @@ constexpr basic_mdspan(pointer p, const mapping& m, const accessor& a);
 
 * *Requires:* `[ptr, ptr+m.required_span_size())` shall be a valid range.
 * *Effects:*
-    + initializes `ptr_` with `p`
+    + initializes `acc_` with `p`
     + initializes `map_` with `m`
 * *Postconditions:* 
     + `extents()==m.extents()`
@@ -2122,7 +2128,7 @@ template<class OtherElementType, class OtherExtents, class OtherLayoutPolicy, cl
 * *Requires:*
     + For all `r` in the range `[0, rank())`, if `other.static_extent(r)==dynamic_extent` or `static_extent(r)==dynamic_extent`, then `other.extent(r)==extent(r)`
 * *Effects:*
-    + initializes `ptr_` with `other.ptr_`
+    + initializes `acc_` with `other.acc_`
     + initializes `map_` with `other.map_`
 * *Postconditions:* 
     + `extents()==extents_type(other.extents())`
@@ -2131,7 +2137,6 @@ template<class OtherElementType, class OtherExtents, class OtherLayoutPolicy, cl
     + `OtherElementType(*)[]` is convertible to `ElementType(*)[]`, <!-- lifted directly from span wording -->
     + `OtherLayoutPolicy::template mapping<OtherExtents>` is convertible to `mapping`
     + `OtherAccessor` is convertible to `Accessor`, and
-    + `OtherAccessor::pointer` is convertible to `pointer`.
 * *Throws:* Nothing.
 
 <br/>
@@ -2144,7 +2149,7 @@ template<class OtherElementType, class OtherExtents, class OtherLayoutPolicy, cl
 * *Requires:*
     + For all `r` in the range `[0, rank())`, if `other.static_extent(r)==dynamic_extent` or `static_extent(r)==dynamic_extent`, then `other.extent(r)==extent(r)`
 * *Effects:*
-    + assigns `other.ptr_` to `ptr_`.
+    + assigns `other.acc_` to `acc_`.
     + assigns `other.map_` to `map_`
 * *Postconditions:* 
     + `extents()==extents_type(other.extents())`
@@ -2153,7 +2158,6 @@ template<class OtherElementType, class OtherExtents, class OtherLayoutPolicy, cl
     + `OtherElementType(*)[]` is assignable to `ElementType(*)[]`, <!-- lifted directly from span wording -->
     + `OtherLayoutPolicy::template mapping<OtherExtents>` is assignable to `mapping`
     + `OtherAccessor` is assignable to `Accessor`, and
-    + `OtherAccessor::pointer` is assignable to `pointer`.
 * *Throws:* Nothing.
 
 
@@ -2184,7 +2188,7 @@ template<class... IndexType>
 ```
 
 * *Requires:* 0 <= `array<index_type, sizeof...(indices)>{indices...}[r]` < `extent(r)` for all `r` in the range `[0, rank())`.
-* *Effects:* Equivalent to `return ptr_[ map_(indices...)];`
+* *Effects:* Equivalent to `return acc_[ map_(indices...)];`
 * *Remarks:* This operator does not participate in overload resolution unless
     + `is_convertible_v<IndexType, index_type> && ...`
     + `sizeof...(IndexType)==rank()`
@@ -2435,7 +2439,7 @@ Requires: <br/>
 Postcondition: <br/>
     * `E::rank()==Extents::rank()-C` <br/>
     * If <em>ranges[r]</em> is the nth value of `ranges` convertible to `alltype_t` or `pair<ptrdiff_t,ptrdiff_t>` and `slices[k]` is the `n`th value of `slices` convertible to `all type_t` or  `pair<ptrdiff_t,ptrdiff_t>` then `sub.extent(r)==last[k]-first[k]` and `sub.stride(r)==src.stride(k)` <br/> 
-    * `sub.ptr_==src.ptr_+first[0]*src.stride(0)+`...`+first[Extents::rank()-1]*src.stride(Extents::rank()-1)` <br/>
+    * `(pointer)sub.acc_==((pointer)src.acc_)+first[0]*src.stride(0)+`...`+first[Extents::rank()-1]*src.stride(Extents::rank()-1)` <br/>
     * Note: it is quality of implementation whether static extents are preserved if possible.  <br/>
 
 

--- a/P0009/P0009.bs
+++ b/P0009/P0009.bs
@@ -731,15 +731,15 @@ namespace fundamentals_v3 {
   class layout_right;
   class layout_stride;
 
-  // [mdspan.accessor.traits]
-  template<class Accessor>
-  class accessor_traits;
+  // [mdspan.accessor.basic]
+  template<class ElementType>
+  class accessor_basic;
 
   // [mdspan.basic], class template mdspan
   template<class ElementType,
            class Extents,
            class LayoutPolicy = layout_right,
-           class Accessor = T*>
+           class AccessorPolicy = accessor_basic<ElementType> >
     class basic_mdspan;
 
   template<class T, ptrdiff_t... Extents>
@@ -753,9 +753,9 @@ namespace fundamentals_v3 {
 
   // [mdspan.subspan], subspan creation
   template<class ElementType, class Extents, class LayoutPolicy,
-           class Accessor, class... SliceSpecifiers>
+           class AccessorPolicy, class... SliceSpecifiers>
     basic_mdspan<ElementType, /* see-below */>
-      subspan(const basic_mdspan<ElementType, Extents, LayoutPolicy, Accessor>&, SliceSpecifiers...) noexcept;
+      subspan(const basic_mdspan<ElementType, Extents, LayoutPolicy, AccessorPolicy>&, SliceSpecifiers...) noexcept;
 
   // tag supporting subspan
   struct all_type { explicit all_type() = default; };
@@ -1739,32 +1739,32 @@ template<class OtherExtents>
 <br/>
 <br/>
 
-<b>26.7.� Accessor [mdspan.accessor]</b>
+<b>26.7.� Accessor Policy [mdspan.accessor]</b>
 
-An *accessor* is an object through which a contiguous set of objects of type *T* 
-that the accessor does not own are accessed. 
-An accessor is similar to an *array of unknown bound of T* [dcl.array] 
-when it is used as a *function parameter* [dcl.fct].
-
+An *accessor policy* defines types and operations by which
+a contiguous set of objects of type *ElementType* are accessed. 
 
 <br/>
-<b>26.7.�.1 Accessor requirements [mdspan.accessor.reqs]</b>
+<b>26.7.�.1 Accessor policy requirements [mdspan.accessor.reqs]</b>
 
-An accessor supports subscripting operator [expr.sub], conversion to pointer [conv.array],
-and is constructable from a pointer to a contiguous set of objects of type `T`.
-The subscripting operator returns an object which provides access to the indexed element,
-this return type may be a type that is not `T&`.
+An accessor policy defines an accessor type and operations for applying
+subscripting-like [expr.sub],
+conversion to pointer [conv.array],
+and offset operations to an accessor.
+The subscript operation returns an object which provides access to the indexed element,
+this return type may not be `T&`.
+The offset operation returns an accessor for the contiguous subset of elements beginning at the offste value,
+this return type may not be the same accessor type..
 An accessor constructor may impose additional restrictions on the 
 contiguous set of objects; e.g., restrict `T` to be trivially copyable or have a wider alignment.
 
 In Table �:
-  * `A` denotes an accessor type.
-  * `a` denotes an object of type `const A`.
-  * `T` denotes the element type of the accessor `typename accessor_traits<T>::element_type`,.
-  * `p` denotes an object of type `T*`.
+  * `A` denotes an accessor policy.
+  * `a` denotes an object of type `const typename A::accessor_type`.
+  * `p` denotes an object of type `typename A::pointer`.
   * `i` denotes a `size_t` value.
 
-Table �: Accessor requirements
+Table �: Accessor policy requirements
 <table border=1>
 <tr>
   <th>Expression</th>
@@ -1772,26 +1772,50 @@ Table �: Accessor requirements
   <th>Requirements/Notes</th>
 </tr>
 <tr>
-  <td>`a[i]`</td>
-  <td>`typename accessor_traits<A>::reference`
+  <td>A::element_type</td>
+  <td></td>
+  <td>Type of elements accessed</td>
+</tr>
+<tr>
+  <td>A::accessor_type</td>
+  <td></td>
+  <td>Type through which the contiguous set of elements are accessed</td>
+</tr>
+<tr>
+  <td>A::reference</td>
+  <td></td>
+  <td>Type through which an element is accessed</td>
+</tr>
+<tr>
+  <td>A::pointer</td>
+  <td></td>
+  <td>Pointer type to which the accessor type decays</td>
+</tr>
+<tr>
+  <td>A::offset_policy</td>
+  <td></td>
+  <td>Accessor policy of an offset of an accessor_type object.</td>
+</tr>
+<tr>
+  <td>`A::decay(a)`</td>
+  <td>`A::pointer`
+  <td>*Returns:* A pointer to the contiguous set of objects accessed by `a`.</td>
+</tr>
+<tr>
+  <td>`A::deref(a,i)`</td>
+  <td>`A::reference</td>
   <td>*Returns:* An object which provides access to the `i`*th* element in the contiguous set.</td>
 </tr>
 <tr>
-  <td>`a+i`</td>
-  <td>`typename accessor_traits<A>::offset`
-  <td>*Returns:* An accessor which provides access to the contiguous set of elements starting at the `i`*th* element. *[Note:* The type of returned accessor may be different than `a`. *--end node]*</td>
+  <td>`A::offset(a,i)`</td>
+  <td>`A::offset_policy::accessor_type</td>
+  <td>*Returns:* An accessor for the contiguous span of elements offset by `i`.  *Requires:* `A::decay(p)+i == A::offset_policy::decay(A::offset(a,i))`.</td>
 </tr>
 <tr>
-  <td>`(T*)a;`</td>
-  <td>`typename accessor_traits<A>::pointer`</td>
-  <td>*Returns:* A pointer to the contiguous set of objects referenced by `a`.</td>
+  <td>`A::accessor_type(p)`</td>
+	<td></td>
+	<td>Construct an accessor for a contiguous span of elements starting at `p`.</td>
 </tr>
-<tr>
-  <td>`A(p)`</td>
-  <td></td>
-  <td>*Requires:* `p` is a pointer to a contiguous set of objects.</td>
-</tr>
-<tr>
 </table>
 
 <!--
@@ -1804,36 +1828,56 @@ Table �: Accessor requirements
 -->
 
 <br/>
-<b>26.7.�.2 Class `accessor_traits` [mdspan.accessor.traits]</b>
+<b>26.7.�.2 Class `accessor_basic` [mdspan.accessor.basic]</b>
 
 ```c++
 namespace std {
 namespace experimental {
 namespace fundamentals_v3 {
 
-template<class Accessor>
-struct accessor_traits ;
+template<class ElementType>
+struct accessor_basic {
+  using accessor_type = ElementType*;
+  using offset_policy = accessor_basic;
+  using element_type  = ElementType;
+  using reference     = ElementType&;
+  using pointer       = ElementType*;
 
-template<class T>
-struct accessor_traits<T*> {
-  using accessor = T*;
-	using element_type = T;
-	using pointer = T*;
-	using reference = T&;
-	using offset = T*;
-};
+  static constexpr typename offset_policy::accessor_type
+    offset( accessor_type acc , size_t i ) noexcept
+      { return acc+i; }
 
-template<class Accessor>
-struct accessor_traits {
-  using accessor = Accessor;
-	using element_type = typename Accessor::element_type;
-	using pointer = typename Accessor::pointer;
-	using reference = typename Accessor::reference;
-	using offset = typename Accessor::offset;
+  static constexpr reference deref( accessor_type acc , size_t i ) noexcept
+    { return acc[i]; }
+
+  static constexpr pointer decay( accessor_type acc ) noexcept
+    { return acc; }
 };
 
 }}}
 ```
+
+```c++
+static constexpr typename offset_policy::accessor_type
+  offset( accessor_type acc , size_t i ) noexcept ;
+```
+
+* *Returns:* `acc+i`
+</br>
+
+```c++
+static constexpr reference deref( accessor_type acc , size_t i ) noexcept ;
+```
+
+* *Returns:* `acc[i]`
+</br>
+
+```c++
+static constexpr pointer deref( accessor_type acc , size_t i ) noexcept ;
+```
+
+* *Returns:* `acc`
+</br>
 
 <!--
 888                        d8b                                      888
@@ -2416,9 +2460,9 @@ namespace fundamentals_v3 {
 
   // [mdspan.subspan], subspan creation
   template<class ElementType, class Extents, class LayoutPolicy,
-           class Accessor, class... SliceSpecifiers>
+           class AccessorPolicy, class... SliceSpecifiers>
     basic_mdspan<ElementType, E /* see-below */, L /* see-below */, A /* see-below */ >
-      subspan(const basic_mdspan<ElementType, Extents, LayoutPolicy, Accessor>& src, SliceSpecifiers ... slices) noexcept;
+      subspan(const basic_mdspan<ElementType, Extents, LayoutPolicy, AccessorPolicy>& src, SliceSpecifiers ... slices) noexcept;
 
 }}}
 ```
@@ -2460,7 +2504,7 @@ Postcondition: <br/>
     * If `LayoutPolicy` is `layout_left` and `Extents::rank() <= 1` then `L` is `layout_left`.
     * If `LayoutPolicy` is `layout_left` or `layout_right` and `1 < Extents::rank()` then `L` is `layout_stride`.
     * If `LayoutPolicy` is `layout_stride` then `L` is `layout_stride`.
-    * `A` is `typename accessor_traits<Accessor>::offset`.
+    * `A` is `typename AccessorPolicy::offset_policy`.
     * Let `I...` be a multi-index such that `I[k] < sub.extents(k)` and `J` be a multi-index where `J[R[k]]=first[R[k]]+I[k]` or `J[r]=first[r]` for `r` not in `R[k]`, then `sub(I...)` and `src(J...)` refer to the same element.
     * `sub.extent(k)==last[R[k]]-first[R[k]]`.
     * If `src.is_strided()` then `sub.is_strided()` and `sub.stride(k)==src.stride(R[k])` <br/> 
@@ -2522,8 +2566,7 @@ Related Work
 
 The `reference` type may be a proxy for accessing an `element_type`
 object. For example, the *atomic* `AccessorPolicy` in **P0860** defines
-`AccessorPolicy::template accessor<T>::reference` to be `atomic_ref<T>` from
-**P0019**.
+`AccessorPolicy::reference` to be `atomic_ref<T>` from **P0019**.
 
 **Related papers:**
 

--- a/P0009/P0009.bs
+++ b/P0009/P0009.bs
@@ -1,8 +1,8 @@
 <pre class='metadata'>
 Title:  <code>mdspan</code>: A Non-Owning Multidimensional Array Reference
-Shortname: P0009
-URL: wg21.link/P0009r7
-Revision: 7
+Shortname: D0009
+URL: wg21.link/P0009r8
+Revision: 8
 Audience: LWG
 Status: D
 Group: WG21
@@ -25,6 +25,10 @@ Editor: Mark Hoemmen, mhoemme@sandia.gov
 
 Revision History
 ================
+ 
+## P0009r8: Pre 2018-11-SanDiego Mailing
+
+- Refinement based upon updated [prototype](https://github.com/ORNL/cpp-proposals-pub/blob/master/P0009/prototype) / reference implementation
 
 ## P0009r7: Post 2018-06-Rapperswil Mailing
 
@@ -728,14 +732,13 @@ namespace fundamentals_v3 {
   class layout_stride;
 
   // [mdspan.accessor.basic], class template accessor_basic
-  template<class ElementType>
   class accessor_basic;
 
   // [mdspan.basic], class template mdspan
   template<class ElementType,
            class Extents,
            class LayoutPolicy = layout_right,
-           class Accessor = accessor_basic<ElementType>>
+           class Accessor = accessor_basic>
     class basic_mdspan;
 
   template<class T, ptrdiff_t... Extents>
@@ -980,7 +983,6 @@ template<ptrdiff_t... LHS, ptrdiff_t... RHS>
 4. In Table �:
     * `MP` denotes a layout mapping policy.
     * `E` denotes a specialization of `extents`.
-    * `e` denotes an object of type `E` defining a domain multi-index space.
     * `r` is a value of an integral type such that 0 <= `r` < `e.rank()`.
     * `i...` and `j...` are packs of an integer type denoting values in the multi-index space `e`, the `r`*th member of packs `i...` and `j...` are denoted by `i[r]` and `j[r]`, and `sizeof...(i)==E::rank()`, 0 <= `i[r]` < `e.extent(r)`, `sizeof...(j)==E::rank()`, and 0 <= `j[r]` < `e.extent(r)`.
     * `M` denotes a layout mapping class.
@@ -1001,13 +1003,9 @@ Table � — Layout mapping policy and layout mapping requirements
   <td></td>
 </tr>
 <tr>
-  <td>`m.get_extents()`</td>
-  <td>`E`</td>
-  <td>
-  
-  *Returns:* `e`.
-  
-  </td>
+  <td>`m.extents()`</td>
+  <td>convertable to `E`</td>
+  <td></td>
   <td></td>
 </tr>
 <tr>
@@ -1112,7 +1110,7 @@ struct layout_left {
       constexpr mapping& operator=(const mapping&lt;OtherExtents>& other);
 
     // [mdspan.layout.left.ops], layout_left::mapping operations
-    Extents get_extents() const noexcept;
+    const Extents & extents() const noexcept;
 
     constexpr typename Extents::index_type required_span_size() const noexcept;
 
@@ -1157,7 +1155,7 @@ constexpr mapping() noexcept;
 ```
 
 * *Effects:* Default-initializes `extents_`.
-* *Postconditions:* `get_extents()==Extents()`
+* *Postconditions:* `extents()==Extents()`
 
 <!-- --- -->
 
@@ -1168,7 +1166,7 @@ constexpr mapping(const mapping& other) noexcept;
 ```
 
 * *Effects:* Initializes `extents_` with `other.extents_`.
-* *Postconditions:* `get_extents()==other.get_extents()`.
+* *Postconditions:* `extents()==other.extents()`.
 
 <!-- --- -->
 
@@ -1179,7 +1177,7 @@ constexpr mapping(mapping&& other) noexcept;
 ```
 
 * *Effects:* Initializes `extents_` with `move(other.extents_)`.
-* *Postconditions:* `get_extents()` returns a copy of an `Extents` that is equal to the copy returned by `other.get_extents()` before the invocation of the move.
+* *Postconditions:* `extents()` returns a copy of an `Extents` that is equal to the copy returned by `other.extents()` before the invocation of the move.
 
 <!-- --- -->
 
@@ -1190,7 +1188,7 @@ constexpr mapping(const Extents & e) noexcept;
 ```
 
 * *Effects:* Initializes `extents_` with `e`.
-* *Postconditions:* `get_extents()==e`.
+* *Postconditions:* `extents()==e`.
 
 
 <br/>
@@ -1200,9 +1198,9 @@ template<class OtherExtents>
 constexpr mapping(const mapping<OtherExtents>& other);
 ```
 
-* *Requires:* `other.get_extents()` meets the requirements for use in the initialization of `extents_`.
-* *Effects:* Initializes `extents_` with `other.get_extents()`.
-* *Postconditions:* `get_extents()==other.extents_`.
+* *Requires:* `other.extents()` meets the requirements for use in the initialization of `extents_`.
+* *Effects:* Initializes `extents_` with `other.extents()`.
+* *Postconditions:* `extents()==other.extents_`.
 * *Throws:* nothing.
 
 <br/>
@@ -1216,7 +1214,7 @@ constexpr mapping(const mapping<OtherExtents>& other);
 <br/>
 
 ```c++
-Extents get_extents() const noexcept;
+const Extents & extents() const noexcept;
 ```
 
 * *Returns:* `extents_`.
@@ -1229,7 +1227,7 @@ Extents get_extents() const noexcept;
 typename Extents::index_type required_span_size() const noexcept;
 ```
 
-* *Returns:* The product of `get_extents().extent(r)` for all `r` where 0 <= `r` < `get_extents().rank()`
+* *Returns:* The product of `extents().extent(r)` for all `r` where 0 <= `r` < `extents().rank()`
 
 <!-- --- -->
 
@@ -1245,12 +1243,12 @@ Let `i[k]` denote the `k`*th* member of `i...`.
 
 ```
 Extents::index_type offset = 0 ;
-for(size_t k=0; k<get_extents.rank(); ++k) 
+for(size_t k=0; k<extents.rank(); ++k) 
   offset += i[k]*stride(k);
 ```
 
 * *Remarks:* This operator shall not participate in overload resolution unless
-    * `sizeof...(Indices)==get_extents().rank()`,
+    * `sizeof...(Indices)==extents().rank()`,
     * and `is_convertible_v<Indices, typename Extents::index_type> && ...`
 
 
@@ -1280,7 +1278,7 @@ typename Extents::index_type stride(size_t r) const
 ```
 Extents::index_type s = 1;
 for(size_t k=0; k<r; ++k)
-  s *= get_extents().extent(k);
+  s *= extents().extent(k);
 ```
 
 <br/>
@@ -1289,7 +1287,7 @@ template<class OtherExtents>
   constexpr bool operator==(const mapping<OtherExtents>& other) const noexcept;
 ```
 
-* *Returns:* `get_extents()==other.get_extents()`.
+* *Returns:* `extents()==other.extents()`.
 
 <br/>
 ```c++
@@ -1297,7 +1295,7 @@ template<class OtherExtents>
   constexpr bool operator!=(const mapping<OtherExtents>& other) const noexcept;
 ```
 
-* *Returns:* `get_extents()!=other.get_extents()`.
+* *Returns:* `extents()!=other.extents()`.
 
 
 <!--
@@ -1340,7 +1338,7 @@ struct layout_right {
       constexpr mapping& operator=(const mapping&lt;OtherExtents>& other);
 
     // [mdspan.layout.right.ops], layout_right::mapping operations
-    Extents get_extents() const noexcept;
+    const Extents & extents() const noexcept;
 
     constexpr typename Extents::index_type required_span_size() const noexcept;
 
@@ -1384,7 +1382,7 @@ constexpr mapping() noexcept;
 ```
 
 * *Effects:* Default-initializes `extents_`.
-* *Postconditions:* `get_extents()==Extents()`
+* *Postconditions:* `extents()==Extents()`
 
 <!-- --- -->
 
@@ -1395,7 +1393,7 @@ constexpr mapping(const mapping& other) noexcept;
 ```
 
 * *Effects:* Initializes `extents_` with `other.extents_`.
-* *Postconditions:* `get_extents()==other.get_extents()`.
+* *Postconditions:* `extents()==other.extents()`.
 
 <!-- --- -->
 
@@ -1406,7 +1404,7 @@ constexpr mapping(mapping&& other) noexcept;
 ```
 
 * *Effects:* Initializes `extents_` with `move(other.extents_)`.
-* *Postconditions:* `get_extents()` returns a copy of an `Extents` that is equal to the copy returned by `other.get_extents()` before the invocation of the move.
+* *Postconditions:* `extents()` returns a copy of an `Extents` that is equal to the copy returned by `other.extents()` before the invocation of the move.
 
 <!-- --- -->
 
@@ -1417,7 +1415,7 @@ constexpr mapping(Extents e) noexcept;
 ```
 
 * *Effects:* Initializes `extents_` with `e`.
-* *Postconditions:* `get_extents()==e`.
+* *Postconditions:* `extents()==e`.
 
 <br/>
 
@@ -1426,9 +1424,9 @@ template<class OtherExtents>
   constexpr mapping(const mapping<OtherExtents>& other);
 ```
 
-* *Requires:* `other.get_extents()` meets the requirements for use in the initialization of `extents_`.
-* *Effects:* Initializes `extents_` with `other.get_extents()`.
-* *Postconditions:* `get_extents()==other.extents_`.
+* *Requires:* `other.extents()` meets the requirements for use in the initialization of `extents_`.
+* *Effects:* Initializes `extents_` with `other.extents()`.
+* *Postconditions:* `extents()==other.extents_`.
 * *Throws:* nothing.
 <!-- --- -->
 
@@ -1443,7 +1441,7 @@ template<class OtherExtents>
 <br/>
 
 ```c++
-Extents get_extents() const noexcept;
+const Extents & extents() const noexcept;
 ```
 
 * *Returns:* `extents_`.
@@ -1456,7 +1454,7 @@ Extents get_extents() const noexcept;
 typename Extents::index_type required_span_size() const noexcept;
 ```
 
-* *Returns:* The product of `get_extents().extent(r)` for all `r` where 0 <= `r` < `get_extents().rank()`
+* *Returns:* The product of `extents().extent(r)` for all `r` where 0 <= `r` < `extents().rank()`
 
 <!-- --- -->
 
@@ -1478,7 +1476,7 @@ for(size_t k=0; k<Extents::rank(); ++k)
 ```
 
 * *Remarks:* This operator shall not participate in overload resolution unless
-    * `sizeof...(Indices)==get_extents().rank()`,
+    * `sizeof...(Indices)==extents().rank()`,
     * and `is_convertible_v<Indices, typename Extents::index_type> && ...`
 
 
@@ -1505,8 +1503,8 @@ typename Extents::index_type stride(size_t r) const noexcept;
 
 ```
 Extents::index_type s = 1;
-for(size_t k=r+1; k<get_extents.rank(); ++k)
-  s *= get_extents(k);
+for(size_t k=r+1; k<extents.rank(); ++k)
+  s *= extents(k);
 ```
 
 <br/>
@@ -1515,7 +1513,7 @@ template<class OtherExtents>
   constexpr bool operator==(const mapping<OtherExtents>& other) const noexcept;
 ```
 
-* *Returns:* `get_extents()==other.get_extents()`.
+* *Returns:* `extents()==other.extents()`.
 
 <br/>
 ```c++
@@ -1523,7 +1521,7 @@ template<class OtherExtents>
   constexpr bool operator!=(const mapping<OtherExtents>& other) const noexcept;
 ```
 
-* *Returns:* `get_extents()!=other.get_extents()`.
+* *Returns:* `extents()!=other.extents()`.
 
 
 <!-- 
@@ -1566,7 +1564,7 @@ struct layout_stride {
     constexpr mapping() noexcept;
     constexpr mapping(mapping const& other) noexcept;
     constexpr mapping(mapping&& other) noexcept;
-    constexpr mapping(Extents e, array&lt;typename Extents::index_type, Extents::rank()> s) noexcept;
+    constexpr mapping(const Extents & e, const array&lt;typename Extents::index_type, Extents::rank()> & s) noexcept;
     template&lt;class OtherExtents>
       constexpr mapping(const mapping&lt;OtherExtents>& other);
 
@@ -1576,8 +1574,8 @@ struct layout_stride {
       constexpr mapping& operator=(const mapping&lt;OtherExtents>& other);
 
     // [mdspan.layout.stride.ops], layout_stride::mapping operations
-    Extents get_extents() const noexcept;
-    array&lt;typename Extents::index_type, Extents::rank()> get_strides() const noexcept;
+    const Extents & extents() const noexcept;
+    const array&lt;typename Extents::index_type, Extents::rank()> & strides() const noexcept;
 
     constexpr typename Extents::index_type required_span_size() const noexcept;
 
@@ -1614,19 +1612,19 @@ struct layout_stride {
 constexpr mapping() noexcept;
 ```
 * Effects: Default-initializes extents_.
-* Postconditions: `get_extents()==Extents()` and `get_strides()==array<typename Extents::index_type, Extents::rank()>()`
+* Postconditions: `extents()==Extents()` and `strides()==array<typename Extents::index_type, Extents::rank()>()`
 
 ```c++
 constexpr mapping(const mapping& other) noexcept;
 ```
 * Effects: Initializes extents_ with other.extents_.
-* Postconditions: `get_extents()==other.get_extents()` and `get_strides()==other.get_strides()`
+* Postconditions: `extents()==other.extents()` and `strides()==other.strides()`
 
 ```c++
 constexpr mapping(mapping&& other) noexcept;
 ```
 * Effects: Initializes extents_ with `move(other.extents_)`.
-* Postconditions: `get_extents()` returns a copy of an Extents that is equal to the copy returned by `other.get_extents()` before the invocation of the move and `get_strides()` returns a copy of an `array<typename Extents::index_type,Extents::rank()>` that is equal to the copy returned by `other.get_strides()` before the invocation of the move
+* Postconditions: `extents()` returns a copy of an Extents that is equal to the copy returned by `other.extents()` before the invocation of the move and `strides()` returns a copy of an `array<typename Extents::index_type,Extents::rank()>` that is equal to the copy returned by `other.strides()` before the invocation of the move
 
 
 ```c++
@@ -1636,42 +1634,42 @@ constexpr mapping(Extents e, array<typename Extents::index_type, Extents::rank()
    + `s[i]>0` for 0 < `i` <= `Extents::rank()`
    + there is a permutation of the numbers `0,`...`,Extents::rank()-1` `o(i)` with 0 <= `i` < `Extents::rank()` such that `stride(o(i))>=stride(o(i-1))*get_extent.extent(o(i-1))` for 1 <= `i` < `Extents::rank()`
 * Effects: Initializes `extents_` with `e` and `strides_` with `s`
-* Postconditions: `get_extents()==e` and `get_strides()==s`.
+* Postconditions: `extents()==e` and `strides()==s`.
 * Throws: nothing
 
 ```c++
 template<class OtherExtents>
   constexpr mapping(const mapping<OtherExtents>& other);
 ```
-* Requires: other.get_extents() meets the requirements for use in the initialization of extents_.
-* Effects: Initializes `extents_` with `other.get_extents()` and initializes `strides_` with `other.get_strides()`.
-* Postconditions: `get_extents()==other.get_extents()` and `get_strides()==other.get_strides()`.
+* Requires: other.extents() meets the requirements for use in the initialization of extents_.
+* Effects: Initializes `extents_` with `other.extents()` and initializes `strides_` with `other.strides()`.
+* Postconditions: `extents()==other.extents()` and `strides()==other.strides()`.
 * Throws: nothing.
 
 
 <b>26.7.�.4.2 layout_stride::mapping operations [mdspan.layout.stride.ops]</b>
 
 ```c++
-Extents get_extents() const noexcept;
+const Extents & extents() const noexcept;
 ```
 * Returns: extents_.
 
 ```c++
-array<typename Extents::index_type, Extents::rank()> get_strides() const noexcept;
+const array<typename Extents::index_type, Extents::rank()> & strides() const noexcept;
 ```
 * Returns: strides_.
 
 ```c++
 typename Extents::index_type required_span_size() const noexcept;
 ```
-* Returns: The maximum of `get_extents().extent(r)*stride(r)` for all `r` where 0 <= `r` < `get_extents().rank()`
+* Returns: The maximum of `extents().extent(r)*stride(r)` for all `r` where 0 <= `r` < `extents().rank()`
 
 
 ```c++
 template <class... Indices>
   typename Extents::index_type operator()(Indices... i) const noexcept;
 ```
-* Returns: If `i...` is `i0, i1, i2,`...`, ik` (where `k==Extents::rank() - 1`) and `s = get_strides()`, returns `i0*s[1]+i1*s[2]+`...`+ik*s[k]`
+* Returns: If `i...` is `i0, i1, i2,`...`, ik` (where `k==Extents::rank() - 1`) and `s = strides()`, returns `i0*s[1]+i1*s[2]+`...`+ik*s[k]`
 * Remarks: This operator shall not participate in overload resolution unless
   * `sizeof...(Indices)==Extents::rank()`,
   * and `is_convertible_v<Indices, typename Extents::index_type> && ...`
@@ -1708,7 +1706,7 @@ template<class OtherExtents>
   constexpr bool operator==(const mapping<OtherExtents>& other) const noexcept;
 ```
 
-* *Returns:* `get_extents()==other.get_extents()`.
+* *Returns:* `extents()==other.extents()`.
 
 <br/>
 ```c++
@@ -1716,7 +1714,7 @@ template<class OtherExtents>
   constexpr bool operator!=(const mapping<OtherExtents>& other) const noexcept;
 ```
 
-* *Returns:* `get_extents()!=other.get_extents()`.
+* *Returns:* `extents()!=other.extents()`.
 
 
 
@@ -1745,15 +1743,13 @@ template<class OtherExtents>
 <br/>
 <b>26.7.�.1 Accessor requirements [mdspan.accessor.reqs]</b>
 
-1. An *accessor* is a class that converts a pointer and an offset into a reference. *[Note:* The intended semantic is that the reference refers to a value at the given offset from the given pointer. *—end note]*
-
-5. An *accessor* shall meet the requirements of `DefaultConstructible`, `CopyAssignable`, and the requirements in table �.
+An *accessor* is a class that defines `pointer` and `reference` types. *[Note:* The intended semantic is that the reference refers to a value at the given offset from the given pointer. *—end note]*
 
 In Table �:
-  * `A` denotes an accessor.
-  * `a` denotes a value of type `A`.
-  * `p` denotes a value of type `A::pointer`.
-  * `i` denotes an integer.
+  * `A` denotes an accessor type.
+  * `T` denotes an object type and is not an array type.
+  * `p` denotes a value of type `A::pointer<T>`.
+  * `i` denotes an integer value.
 
 Table �: Accessor requirements
 <table border=1>
@@ -1763,24 +1759,19 @@ Table �: Accessor requirements
   <th>Requirements/Notes</th>
 </tr>
 <tr>
-  <td>`A::value_type`</td>
+  <td>`A::reference<T>`</td>
   <td></td>
-  <td></td>
+  <td>*Requires:* `A::reference<T>` shall be convertable to `T` and, if `!is_const_v<T>`, assignable from `T`. *[Note:* This may be `T&` or a proxy that operates like `T&`. *--end note]*</td>
 </tr>
 <tr>
-  <td>`A::pointer`</td>
+  <td>`A::pointer<T>`</td>
   <td></td>
-  <td>*Requires:* `A::pointer` shall meet the requirements of random access iterator (**[random.access.iterators]**), and `iterator_traits<A::pointer>::value_type` shall be exactly `A::value_type`.</td>
+  <td>*Requires:* `A::pointer<T>` shall be `DefaultConstructible` and `CopyAssignable`. *[Note:* This may be `T*` or a proxy that operates like `T*`. *--end note]*</td>
 </tr>
 <tr>
-  <td>`A::reference`</td>
-  <td></td>
-  <td>*Requires:* `iterator_traits<A::pointer>::reference` shall be convertible to `A::reference` </td>
-</tr>
-<tr>
-  <td>`a(p, i)`</td>
-  <td>`A::reference`</td>
-  <td>*[Note:* `basic_mdspan` implementations behave as if they use this expression in place of `p[i]`. *- end note]*</td>
+  <td>`p[i]`</td>
+  <td>`A::reference<T>`</td>
+  <td>*Returns:* `A::reference<T>` corresponding to offset `i` from `p`.
 </tr>
 </table>
 
@@ -1805,27 +1796,15 @@ namespace std {
 namespace experimental {
 namespace fundamentals_v3 {
 
-template<class T>
 struct accessor_basic {
-  using value_type = T;
+  template<class T>
   using pointer = T*;
+  template<class T>
   using reference = T&;
-
-  // [mdspan.accessor.basic.ops], `accessor_basic` operations
-  constexpr reference operator()(pointer p, ptrdiff_t i) const noexcept;
 };
 
 }}}
 ```
-
-<br/>
-<b>26.7.�.2.1 `accessor_basic` operations [mdspan.accessor.basic.ops]</b>
-
-```c++
-constexpr reference operator()(pointer p, ptrdiff_t i) const noexcept;
-```
-
-* *Returns:* `p[i]`
 
 <!--
 888                        d8b                                      888
@@ -1844,7 +1823,7 @@ constexpr reference operator()(pointer p, ptrdiff_t i) const noexcept;
 <!-- TODO: Consider moving Accessor to replace ElementType, since it's never used -->
 <!-- TODO: section references in synopsis -->
 <!-- TODO: Shouldn't we also have converting move constructors? -->
-<!-- TODO: review addition of get_mapping() and get_extents() -->
+<!-- TODO: review addition of mapping() and extents() -->
 
 <br/>
 <br/>
@@ -1871,15 +1850,16 @@ class basic_mdspan {
 public:
 
   // Domain and codomain types
-  using layout = LayoutPolicy;
-  using mapping = typename layout::template mapping&lt;Extents>;
-  using accessor = Accessor;
-  using element_type = typename accessor::value_type;
+  using extents_type = Extents;
+  using layout_type = LayoutPolicy;
+  using mapping_type = typename layout_type::template mapping_type&lt;extents_type>;
+  using accessor_type = Accessor;
+  using element_type = ElementType ;
   using value_type = remove_cv_t&lt;element_type>;
   using index_type = ptrdiff_t ;
   using difference_type = ptrdiff_t ;
-  using pointer = typename accessor::pointer;
-  using reference = typename accessor::reference;
+  using pointer = typename accessor_type::template pointer&lt;element_type>;
+  using reference = typename accessor_type::template reference&lt;element_type>;
 
   // [mdspan.basic.cons], basic_mdspan constructors, assignment, and destructor
   constexpr basic_mdspan() noexcept = default;
@@ -1893,10 +1873,10 @@ public:
     explicit constexpr basic_mdspan(pointer p, const array&lt;IndexType, N>& dynamic_extents);
   template&lt;class IndexType, size_t N>
     explicit constexpr basic_mdspan(const span&lt;element_type>& sp, const array&lt;IndexType, N>& dynamic_extents);
-  constexpr basic_mdspan(pointer p, const mapping& m);
-  constexpr basic_mdspan(const span&lt;element_type>& sp, const mapping& m);
-  constexpr basic_mdspan(pointer p, const mapping& m, const accessor& a);
-  constexpr basic_mdspan(const span&lt;element_type>& sp, const mapping& m, const accessor& a);
+  constexpr basic_mdspan(pointer p, const mapping_type& m);
+  constexpr basic_mdspan(const span&lt;element_type>& sp, const mapping_type& m);
+  constexpr basic_mdspan(pointer p, const mapping_type& m, const accessor& a);
+  constexpr basic_mdspan(const span&lt;element_type>& sp, const mapping_type& m, const accessor& a);
   template&lt;class OtherElementType, class OtherExtents, class OtherLayoutPolicy, class OtherAccessor>
     constexpr basic_mdspan(const basic_mdspan&lt;OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessor>& other);
 
@@ -1913,17 +1893,14 @@ public:
     constexpr reference operator()(IndexType... indices) const noexcept;
   template&lt;class IndexType, size_t N>
     constexpr reference operator()(const array&lt;IndexType, N>& indices) const noexcept;
-  accessor get_accessor() const;
 
   // [mdspan.basic.domobs], basic_mdspan observers of the domain multi-index space
   static constexpr int rank() noexcept;
   static constexpr int rank_dynamic() noexcept;
   static constexpr index_type static_extent(size_t) noexcept;
 
-  constexpr Extents get_extents() const noexcept;
+  constexpr const Extents & extents() const noexcept;
   constexpr index_type extent(size_t) const noexcept;
-  constexpr index_type size() const noexcept;
-  constexpr index_type unique_size() const noexcept;
 
   // [mdspan.basic.codomain], basic_mdspan observers of the codomain
   constexpr span&lt;element_type> span() const noexcept;
@@ -1933,15 +1910,18 @@ public:
   static constexpr bool is_always_contiguous() noexcept;
   static constexpr bool is_always_strided() noexcept;
 
-  constexpr mapping get_mapping() const noexcept;
+  constexpr const mapping_type & mapping() const noexcept;
   constexpr bool is_unique() const noexcept;
   constexpr bool is_contiguous() const noexcept;
   constexpr bool is_strided() const noexcept;
   constexpr index_type stride(size_t) const;
+  template&lt;class... IndexType>
+  static constexpr index_type required_span_size(IndexType... dynamic_extents) noexcept;
+  template&lt;class IndexType, size_t N>
+  static constexpr index_type required_span_size(const array&lt;IndexType, N>& dynamic_extents) noexcept;
 
 private:
-  accessor acc_; // <i>exposition only</i>
-  mapping map_; // <i>exposition only</i>
+  mapping_type map_; // <i>exposition only</i>
   pointer ptr_; // <i>exposition only</i>
 };
 
@@ -1970,11 +1950,10 @@ constexpr basic_mdspan() noexcept = default;
 * *Effects:*
     * zero-initializes `ptr_`
     * value-initializes `map_`
-    * value-initializes `acc_`
 * *Postconditions:* 
     + `size()==0`
-    + `get_extents()==Extents()`
-    + `get_mapping()==mapping()`
+    + `extents()==extents_type()`
+    + `mapping()==mapping_type()`
 
 <br/>
 
@@ -1985,11 +1964,10 @@ constexpr basic_mdspan(const basic_mdspan& other) noexcept = default;
 * *Effects:*
     + initializes `ptr_` with `other.ptr_`
     + initializes `map_` with `other.map_`
-    + initializes `acc_` with `other.acc_`
 * *Postconditions:*
     + `size()==other.size()`
-    + `get_extents()==other.get_extents()`
-    + `get_mapping()==other.get_mapping()`
+    + `extents()==other.extents()`
+    + `mapping()==other.mapping()`
 
 <br/>
 
@@ -2000,7 +1978,6 @@ constexpr basic_mdspan(basic_mdspan&& other) noexcept;
 * *Effects:*
     + initializes `ptr_` with `move(other.ptr_)`
     + initializes `map_` with `move(other.map_)`
-    + initializes `acc_` with `move(other.acc_)`
 
 <br/>
 
@@ -2009,14 +1986,13 @@ template<class... IndexType>
   explicit constexpr basic_mdspan(pointer ptr, IndexType... dynamic_extents);
 ```
 
-* *Requires:* `[ptr, ptr+mapping(Extents(dynamic_extents...)).required_span_size())` shall be a valid range.
+* *Requires:* `[ptr, ptr+required_span_size(dynamic_extents...))` shall be a valid range.
 * *Effects:*
     + initializes `ptr_` with `ptr`
-    + initializes `map_` with `Extents(dynamic_extents...)`
-    + value-initializes `acc_`
+    + initializes `map_` with `extents_type(dynamic_extents...)`
 * *Postconditions:* 
-    + `get_extents()==Extents(dynamic_extents...)`
-    + `get_mapping()==mapping(Extents(dynamic_extents...))`
+    + `extents()==extents_type(dynamic_extents...)`
+    + `mapping()==mapping_type(extents_type(dynamic_extents...))`
 * *Remarks:* This constructor will not participate in overload resolution unless:
     + `(is_convertible_v<IndexType, index_type> && ...)`,
     + `sizeof...(dynamic_extents)==rank_dynamic()`, and
@@ -2030,14 +2006,13 @@ template<class... IndexType>
   explicit constexpr basic_mdspan(const span<element_type>& sp, IndexType... dynamic_extents);
 ```
 
-* *Requires:* `sp.size()==mapping(Extents(dynamic_extents...)).required_span_size()`
+* *Requires:* `sp.size()==required_span_size(dynamic_extents...)`
 * *Effects:*
     + initializes `ptr_` with `sp.data()`
     + value-initializes `map_`
-    + value-initializes `acc_`
 * *Postconditions:* 
-    + `get_extents()==Extents(dynamic_extents...)`
-    + `get_mapping()==mapping(Extents(dynamic_extents...))`
+    + `extents()==extents_type(dynamic_extents...)`
+    + `mapping()==mapping_type(extents_type(dynamic_extents...))`
 * *Remarks:* This constructor will not participate in overload resolution unless:
     + `(is_convertible_v<IndexType, index_type> && ...)`,
     + `sizeof...(dynamic_extents)==rank_dynamic()`,
@@ -2051,7 +2026,7 @@ template<class IndexType, size_t N>
   explicit constexpr basic_mdspan(pointer p, const array<IndexType, N>& dynamic_extents);
 ```
 
-* *Requires:* `[ptr, ptr+mapping(Extents(dynamic_extents)).required_span_size())` shall be a valid range.
+* *Requires:* `[ptr, ptr+required_span_size(dynamic_extents))` shall be a valid range.
 * *Effects:* Equivalent to `basic_mdspan(p, dynamic_extents[Rs]...)`, with `Rs...` from `index_sequence<Rs...>` matching `make_index_sequence<N>`.
 * *Remarks:* This constructor does not participate in overload resolution unless
     + `IndexType` is convertible to `index_type`, and
@@ -2066,7 +2041,7 @@ template<class IndexType, size_t N>
   explicit constexpr basic_mdspan(const span<element_type>& sp, const array<IndexType, N>& dynamic_extents);
 ```
 
-* *Requires:* `sp.size()==mapping(Extents(dynamic_extents)).required_span_size()`
+* *Requires:* `sp.size()==required_span_size(dynamic_extents)`
 * *Effects:* Equivalent to `basic_mdspan(sp.data(), dynamic_extents[Rs]...)`, with `Rs...` from `index_sequence<Rs...>` matching `make_index_sequence<N>`.
 * *Remarks:* This constructor does not participate in overload resolution unless
     + `IndexType` is convertible to `index_type`,
@@ -2084,10 +2059,9 @@ constexpr basic_mdspan(pointer p, const mapping& m);
 * *Effects:*
     + initializes `ptr_` with `p`
     + initializes `map_` with `m`
-    + value-initializes `acc_`
 * *Postconditions:* 
-    + `get_extents()==m.get_extents()`
-    + `get_mapping()==m`
+    + `extents()==m.extents()`
+    + `mapping()==m`
 * *Throws:* Nothing.
 
 <br/>
@@ -2111,10 +2085,9 @@ constexpr basic_mdspan(pointer p, const mapping& m, const accessor& a);
 * *Effects:*
     + initializes `ptr_` with `p`
     + initializes `map_` with `m`
-    + initializes `acc_` with `a`
 * *Postconditions:* 
-    + `get_extents()==m.get_extents()`
-    + `get_mapping()==m`
+    + `extents()==m.extents()`
+    + `mapping()==m`
 * *Throws:* Nothing.
 
 <br/>
@@ -2142,10 +2115,9 @@ template<class OtherElementType, class OtherExtents, class OtherLayoutPolicy, cl
 * *Effects:*
     + initializes `ptr_` with `other.ptr_`
     + initializes `map_` with `other.map_`
-    + initializes `acc_` with `other.acc_`
 * *Postconditions:* 
-    + `get_extents()==Extents(other.get_extents())`
-    + `get_mapping()==mapping(other.get_mapping())`
+    + `extents()==extents_type(other.extents())`
+    + `mapping()==mapping_type(other.mapping())`
 * *Remarks:* This constructor will not participate in overload resolution unless all of the following conditions are met:
     + `OtherElementType(*)[]` is convertible to `ElementType(*)[]`, <!-- lifted directly from span wording -->
     + `OtherLayoutPolicy::template mapping<OtherExtents>` is convertible to `mapping`
@@ -2165,10 +2137,9 @@ template<class OtherElementType, class OtherExtents, class OtherLayoutPolicy, cl
 * *Effects:*
     + assigns `other.ptr_` to `ptr_`.
     + assigns `other.map_` to `map_`
-    + assigns `other.acc_` to `acc_`
 * *Postconditions:* 
-    + `get_extents()==Extents(other.get_extents())`
-    + `get_mapping()==mapping(other.get_mapping())`
+    + `extents()==extents_type(other.extents())`
+    + `mapping()==mapping_type(other.mapping())`
 * *Remarks:* This constructor will not participate in overload resolution unless all of the following conditions are met:
     + `OtherElementType(*)[]` is assignable to `ElementType(*)[]`, <!-- lifted directly from span wording -->
     + `OtherLayoutPolicy::template mapping<OtherExtents>` is assignable to `mapping`
@@ -2204,7 +2175,7 @@ template<class... IndexType>
 ```
 
 * *Requires:* 0 <= `array<index_type, sizeof...(indices)>{indices...}[r]` < `extent(r)` for all `r` in the range `[0, rank())`.
-* *Effects:* Equivalent to `return acc_(ptr_, indices...);`
+* *Effects:* Equivalent to `return ptr_[ map_(indices...)];`
 * *Remarks:* This operator does not participate in overload resolution unless
     + `is_convertible_v<IndexType, index_type> && ...`
     + `sizeof...(IndexType)==rank()`
@@ -2224,12 +2195,6 @@ template<class IndexType, size_t N>
     + `rank()==N`
 * *Throws:* nothing.
 
-
-```c++
-accessor get_accessor() const;
-```
-
-* *Returns:* `acc_`.
 
 <!--
 
@@ -2267,10 +2232,10 @@ static constexpr index_type static_extent(size_t r) noexcept;
 <br/>
 
 ```c++
-constexpr Extents get_extents() const noexcept;
+constexpr const extents_type & extents() const noexcept;
 ```
 
-* *Returns:* `get_mapping().get_extents()`.
+* *Returns:* `mapping().extents()`.
 
 <br/>
 
@@ -2278,22 +2243,9 @@ constexpr Extents get_extents() const noexcept;
 constexpr index_type extent(size_t r) const noexcept;
 ```
 
-* *Returns:* `get_extents().extent(r)`.
+* *Returns:* `extents().extent(r)`.
 
 <br/>
-
-```c++
-constexpr index_type size() const noexcept;
-```
-
-* *Returns:* Product of `extent(r)` for all `r` where 0 <= `r` < `get_extents().rank()`.
-
-```c++
-constexpr index_type unique_size() const noexcept;
-```
-
-* *Returns:* The number of unique elements in the codomain. *[Note:* If `get_mapping().is_unique()` is `true`, this is identical to `size()` *—end note]*
-
 
 <!--
 
@@ -2353,7 +2305,7 @@ static constexpr bool is_always_strided() noexcept;
 <br/>
 
 ```c++
-constexpr mapping get_mapping() const noexcept;
+constexpr const mapping_type & mapping() const noexcept;
 ```
 
 * *Returns:* `map_`
@@ -2364,7 +2316,7 @@ constexpr mapping get_mapping() const noexcept;
 constexpr bool is_unique() const noexcept;
 ```
 
-* *Returns:* `get_mapping().is_unique()`
+* *Returns:* `mapping().is_unique()`
 
 <br/>
 
@@ -2372,7 +2324,7 @@ constexpr bool is_unique() const noexcept;
 constexpr bool is_contiguous() const noexcept;
 ```
 
-* *Returns:* `get_mapping().is_contiguous()`
+* *Returns:* `mapping().is_contiguous()`
 
 <br/>
 
@@ -2380,7 +2332,7 @@ constexpr bool is_contiguous() const noexcept;
 constexpr bool is_strided() const noexcept;
 ```
 
-* *Returns:* `get_mapping().is_strided()`
+* *Returns:* `mapping().is_strided()`
 
 <br/>
 
@@ -2388,8 +2340,27 @@ constexpr bool is_strided() const noexcept;
 constexpr index_type stride(size_t r) const;
 ```
 
-* *Returns:* `get_mapping().stride(r)`
+* *Returns:* `mapping().stride(r)`
 
+<br/>
+
+```c++
+template<class... IndexType>
+static constexpr index_type required_span_size(IndexType... dynamic_extents) noexcept;
+```
+
+* *Returns:* 'mapping_type(dynamic_extents...).required_span_size();`
+
+<br/>
+
+```c++
+template<class IndexType, size_t N>
+static constexpr index_type required_span_size(const array<IndexType, N>& dynamic_extents) noexcept;
+```
+
+* *Returns:* 'mapping_type(dynamic_extents).required_span_size();`
+
+<br/>
 
 <!--
 subspan

--- a/P0009/P0009.bs
+++ b/P0009/P0009.bs
@@ -2423,6 +2423,7 @@ namespace fundamentals_v3 {
 }}}
 ```
 
+
 `subspan` creates a `basic_mdspan` that is a view on a (potentially trivial) subset of another `basic_mdspan`.
 The SliceSpecifier parameters indicate the subset that the return value references.
 Let slices[r] denote the rth value in the parameter pack slices.
@@ -2431,9 +2432,8 @@ The third template parameter of the return type, `L`, is a layout mapping policy
 The fourth template paramter of the return type, `A`, is an accessor [mdspan.accessor].
 <br/>
 
-Let <em>ranges[r]</em> denote the `r`<em>th</em> value in the parameter pack slices, which is not convertible to `ptrdiff_t` <br/>
-Let <em>sub</em> be the return value of `subspan` <br/>
-Let <em>first[r]</em> denote the `r`<em>th</em> lower bound of `slices[r]`. <br/>
+Let `slices[r]` denote the `r`<em>th</em> value in the parameter pack `slices...`.<br/>
+Let `first[r]` denote the `r`<em>th</em> lower bound of `slices[r]`. <br/>
     * If `slices[r]` is convertible to `ptrdiff_t` `first[r]==slices[r]` <br/>
     * If `slices[r]` is convertible to `pair<ptrdiff_t,ptrdiff_t>` `first[r]==pair<ptrdiff_t,ptrdiff_t>(slices[r]).first()` <br/>
     * If `slices[r]` is convertible to `all_type` `first[r]==0` <br/>
@@ -2441,29 +2441,33 @@ Let `last[r]` denote the rth upper bound of `slices[r]`. <br/>
     * If `slices[r]` is convertible to `ptrdiff_t` `last[r]==slices[r]+1` <br/>
     * If `slices[r]` is convertible to `pair<ptrdiff_t,ptrdiff_t>` `last[r]==pair<ptrdiff_t,ptrdiff_t>(slices[r]).second()` <br/>
     * If `slices[r]` is convertible to `all_type` `last[r]==src.extent(r)` <br/>
-Let `C` be the number of parameters in `SliceSpecifiers` which are convertible to `ptrdiff_t` <br/>
-Let `0 <= k < Extents::rank()-C` and let `R[k]` be <br/>
-<code>for ( size_t k=r=0; i<Extents::rank(); ++i )</code><br/>
-<code>  if ( slices[r] </code><em>convertable to</em> <code> ptrdiff_t ) R[k++] = r ;</code>
+Let an array `R[K]` be <br/>
+<!--
+  size_t k = 0;
+  for(size_t r=0; r&lt;sizeof...(slices); r++)
+    if ( slices[r] <i>convertable to</i> pair&lt;ptrdiff_t,ptrdiff_t> <i>or</i> all_type ) R[k++] = r;
+  size_t K = k;
+-->
+Let `sub` be the return value of `subspan` <br/>
 
 Requires: <br/>
-    * `sizeof(slices...)==Extents::rank()` <br/>
+    * `sizeof(slices...)==src.rank()` <br/>
     * `slices[r]` is convertible to `ptrdiff_t`, `pair<ptrdiff_t,ptrdiff_t>` or `all_type` <br/>
-    * 0 <= `first[r]` < `src.extent(r)` <br/>
-    * 0 < `last[r]` <= `src.extent(r)` <br/>
+    * 0 <= `first[r]` < `last[r]` <= `src.extent(r)` <br/>
 
 Postcondition: <br/>
-    * `E::rank()==Extents::rank()-C` <br/>
-		* If `LayoutPolicy` is `layout_right` and `E::rank() <= 1` then `L` is `layout_right`.
-		* If `LayoutPolicy` is `layout_left` and `E::rank() <= 1` then `L` is `layout_left`.
-		* If `LayoutPolicy` is `layout_left` or `layout_right` and `1 < E::rank()` then `L` is `layout_stride`.
-		* If `LayoutPolicy` is `layout_stride` then `L` is `layout_stride`.
-		* `A` is `typename accessor_traits<Accessor>::offset`.
-		* Let `0...` be the multi-index of `E::rank()` zeros and let `first...` be the multi-index of `first[r]` values, then `sub(0...)` and `src(first...)` refer to the same element.
+    * `E::rank()==K` <br/>
+    * If `LayoutPolicy` is `layout_right` and `Extents::rank() <= 1` then `L` is `layout_right`.
+    * If `LayoutPolicy` is `layout_left` and `Extents::rank() <= 1` then `L` is `layout_left`.
+    * If `LayoutPolicy` is `layout_left` or `layout_right` and `1 < Extents::rank()` then `L` is `layout_stride`.
+    * If `LayoutPolicy` is `layout_stride` then `L` is `layout_stride`.
+    * `A` is `typename accessor_traits<Accessor>::offset`.
+    * Let `I...` be a multi-index such that `I[k] < sub.extents(k)` and `J` be a multi-index where `J[R[k]]=first[R[k]]+I[k]` or `J[r]=first[r]` for `r` not in `R[k]`, then `sub(I...)` and `src(J...)` refer to the same element.
     * `sub.extent(k)==last[R[k]]-first[R[k]]`.
-		* If `src.is_strided()` then `sub.is_strided()` and `sub.stride(k)==src.stride(R[k])` <br/> 
-		* If `src.static_extent(R[k]) != dynamic_extent` and `slices[R[k]]` is convertable to `all_type` then `sub.static_extent(k) == src.static_extent(R[k])`.
+    * If `src.is_strided()` then `sub.is_strided()` and `sub.stride(k)==src.stride(R[k])` <br/> 
+    * If `src.static_extent(R[k]) != dynamic_extent` and `slices[R[k]]` is convertable to `all_type` then `sub.static_extent(k) == src.static_extent(R[k])`.
 <br/>
+
 
 * Examples:
 

--- a/P0009/P0009.bs
+++ b/P0009/P0009.bs
@@ -2426,7 +2426,6 @@ namespace fundamentals_v3 {
 
 `subspan` creates a `basic_mdspan` that is a view on a (potentially trivial) subset of another `basic_mdspan`.
 The SliceSpecifier parameters indicate the subset that the return value references.
-Let slices[r] denote the rth value in the parameter pack slices.
 The second template parameter of the return type, `E`, is a specialization of `extents`.
 The third template parameter of the return type, `L`, is a layout mapping policy [mdspan.layout].
 The fourth template paramter of the return type, `A`, is an accessor [mdspan.accessor].
@@ -2442,12 +2441,12 @@ Let `last[r]` denote the rth upper bound of `slices[r]`. <br/>
     * If `slices[r]` is convertible to `pair<ptrdiff_t,ptrdiff_t>` `last[r]==pair<ptrdiff_t,ptrdiff_t>(slices[r]).second()` <br/>
     * If `slices[r]` is convertible to `all_type` `last[r]==src.extent(r)` <br/>
 Let an array `R[K]` be <br/>
-<!--
+<pre highlight="c++">
   size_t k = 0;
   for(size_t r=0; r&lt;sizeof...(slices); r++)
     if ( slices[r] <i>convertable to</i> pair&lt;ptrdiff_t,ptrdiff_t> <i>or</i> all_type ) R[k++] = r;
   size_t K = k;
--->
+</pre>
 Let `sub` be the return value of `subspan` <br/>
 
 Requires: <br/>

--- a/P0009/P0009.bs
+++ b/P0009/P0009.bs
@@ -1756,6 +1756,8 @@ An accessor supports subscripting operator [expr.sub], conversion to pointer [co
 and is constructable from a pointer to a contiguous set of objects of type `T`.
 The subscripting operator returns an object which provides access to the indexed element,
 this return type may be a type that is not `T&`.
+An accessor constructor may impose additional restrictions on the 
+contiguous set of objects; e.g., restrict `T` to be trivially copyable or have a wider alignment.
 
 In Table �:
   * `A` denotes an accessor type.

--- a/P0009/P0009.bs
+++ b/P0009/P0009.bs
@@ -733,9 +733,7 @@ namespace fundamentals_v3 {
 
   // [mdspan.accessor.traits]
   template<class Accessor>
-  class accessor_reference;
-  template<class Accessor>
-  using accessor_reference_t = typename accessor_reference<Accessor>::type;
+  class accessor_traits;
 
   // [mdspan.basic], class template mdspan
   template<class ElementType,
@@ -1761,10 +1759,10 @@ contiguous set of objects; e.g., restrict `T` to be trivially copyable or have a
 
 In Table �:
   * `A` denotes an accessor type.
-  * `a` denotes an object of type `A`
-  * `T` denotes an object type and is not an array type.
+  * `a` denotes an object of type `const A`.
+  * `T` denotes the element type of the accessor `typename accessor_traits<T>::element_type`,.
   * `p` denotes an object of type `T*`.
-  * `i` denotes an integer value.
+  * `i` denotes a `size_t` value.
 
 Table �: Accessor requirements
 <table border=1>
@@ -1775,21 +1773,21 @@ Table �: Accessor requirements
 </tr>
 <tr>
   <td>`a[i]`</td>
-  <td>`accessor_reference_t<A>`
+  <td>`typename accessor_traits<A>::reference`
   <td>*Returns:* An object which provides access to the `i`*th* element in the contiguous set.</td>
 </tr>
 <tr>
-  <td>`p = a;`</td>
-  <td>`T*`</td>
-  <td>*Returns:* a pointer to the contiguous set of objects referenced by `a`.</td>
+  <td>`a+i`</td>
+  <td>`typename accessor_traits<A>::offset`
+  <td>*Returns:* An accessor which provides access to the contiguous set of elements starting at the `i`*th* element. *[Note:* The type of returned accessor may be different than `a`. *--end node]*</td>
 </tr>
 <tr>
-  <td>`A a(p)`</td>
-  <td></td>
-  <td>*Requires:* `p` is a pointer to a contiguous set of objects.</td>
+  <td>`(T*)a;`</td>
+  <td>`typename accessor_traits<A>::pointer`</td>
+  <td>*Returns:* A pointer to the contiguous set of objects referenced by `a`.</td>
 </tr>
 <tr>
-  <td>`a = A(p);`</td>
+  <td>`A(p)`</td>
   <td></td>
   <td>*Requires:* `p` is a pointer to a contiguous set of objects.</td>
 </tr>
@@ -1806,18 +1804,32 @@ Table �: Accessor requirements
 -->
 
 <br/>
-<b>26.7.�.2 Class `accessor_reference` [mdspan.accessor.traits]</b>
+<b>26.7.�.2 Class `accessor_traits` [mdspan.accessor.traits]</b>
 
 ```c++
 namespace std {
 namespace experimental {
 namespace fundamentals_v3 {
 
+template<class Accessor>
+struct accessor_traits ;
+
 template<class T>
-struct accessor_reference ;
-template<class T>
-struct accessor_reference<T*> {
-  using type = T&;
+struct accessor_traits<T*> {
+  using accessor = T*;
+	using element_type = T;
+	using pointer = T*;
+	using reference = T&;
+	using offset = T*;
+};
+
+template<class Accessor>
+struct accessor_traits {
+  using accessor = Accessor;
+	using element_type = typename Accessor::element_type;
+	using pointer = typename Accessor::pointer;
+	using reference = typename Accessor::reference;
+	using offset = typename Accessor::offset;
 };
 
 }}}
@@ -2419,32 +2431,39 @@ The third template parameter of the return type, `L`, is a layout mapping policy
 The fourth template paramter of the return type, `A`, is an accessor [mdspan.accessor].
 <br/>
 
-Let <em>C</em> be the number of parameters in `SliceSpecifiers` which are convertible to `ptrdiff_t` <br/>
-Let <em>ranges[r]</em> denote the rth value in the parameter pack slices, which is not convertible to `ptrdiff_t` <br/>
+Let <em>ranges[r]</em> denote the `r`<em>th</em> value in the parameter pack slices, which is not convertible to `ptrdiff_t` <br/>
 Let <em>sub</em> be the return value of `subspan` <br/>
-Let <em>first[r]</em> denote the rth lower bound of `slices[r]`. <br/>
+Let <em>first[r]</em> denote the `r`<em>th</em> lower bound of `slices[r]`. <br/>
     * If `slices[r]` is convertible to `ptrdiff_t` `first[r]==slices[r]` <br/>
     * If `slices[r]` is convertible to `pair<ptrdiff_t,ptrdiff_t>` `first[r]==pair<ptrdiff_t,ptrdiff_t>(slices[r]).first()` <br/>
-    * If `slices[r]` is convertible to `alltype_t` `first[r]==0` <br/>
+    * If `slices[r]` is convertible to `all_type` `first[r]==0` <br/>
 Let `last[r]` denote the rth upper bound of `slices[r]`. <br/>
     * If `slices[r]` is convertible to `ptrdiff_t` `last[r]==slices[r]+1` <br/>
     * If `slices[r]` is convertible to `pair<ptrdiff_t,ptrdiff_t>` `last[r]==pair<ptrdiff_t,ptrdiff_t>(slices[r]).second()` <br/>
-    * If `slices[r]` is convertible to `alltype_t` `last[r]==src.extent(r)` <br/>
+    * If `slices[r]` is convertible to `all_type` `last[r]==src.extent(r)` <br/>
+Let `C` be the number of parameters in `SliceSpecifiers` which are convertible to `ptrdiff_t` <br/>
+Let `0 <= k < Extents::rank()-C` and let `R[k]` be <br/>
+<code>for ( size_t k=r=0; i<Extents::rank(); ++i )</code><br/>
+<code>  if ( slices[r] </code><em>convertable to</em> <code> ptrdiff_t ) R[k++] = r ;</code>
 
 Requires: <br/>
     * `sizeof(slices...)==Extents::rank()` <br/>
-    * `slices[r]` is convertible to `ptrdiff_t`, `pair<ptrdiff_t,ptrdiff_t>` or `alltype_t` <br/>
+    * `slices[r]` is convertible to `ptrdiff_t`, `pair<ptrdiff_t,ptrdiff_t>` or `all_type` <br/>
     * 0 <= `first[r]` < `src.extent(r)` <br/>
     * 0 < `last[r]` <= `src.extent(r)` <br/>
-    * `LayoutPolicy` is `layout_right`, `layout_left`, or `layout_stride` <br/>
 
 Postcondition: <br/>
     * `E::rank()==Extents::rank()-C` <br/>
-    * If <em>ranges[r]</em> is the nth value of `ranges` convertible to `alltype_t` or `pair<ptrdiff_t,ptrdiff_t>` and `slices[k]` is the `n`th value of `slices` convertible to `all type_t` or  `pair<ptrdiff_t,ptrdiff_t>` then `sub.extent(r)==last[k]-first[k]` and `sub.stride(r)==src.stride(k)` <br/> 
-    * `(pointer)sub.acc_==((pointer)src.acc_)+first[0]*src.stride(0)+`...`+first[Extents::rank()-1]*src.stride(Extents::rank()-1)` <br/>
-    * Note: it is quality of implementation whether static extents are preserved if possible.  <br/>
-
-
+		* If `LayoutPolicy` is `layout_right` and `E::rank() <= 1` then `L` is `layout_right`.
+		* If `LayoutPolicy` is `layout_left` and `E::rank() <= 1` then `L` is `layout_left`.
+		* If `LayoutPolicy` is `layout_left` or `layout_right` and `1 < E::rank()` then `L` is `layout_stride`.
+		* If `LayoutPolicy` is `layout_stride` then `L` is `layout_stride`.
+		* `A` is `typename accessor_traits<Accessor>::offset`.
+		* Let `0...` be the multi-index of `E::rank()` zeros and let `first...` be the multi-index of `first[r]` values, then `sub(0...)` and `src(first...)` refer to the same element.
+    * `sub.extent(k)==last[R[k]]-first[R[k]]`.
+		* If `src.is_strided()` then `sub.is_strided()` and `sub.stride(k)==src.stride(R[k])` <br/> 
+		* If `src.static_extent(R[k]) != dynamic_extent` and `slices[R[k]]` is convertable to `all_type` then `sub.static_extent(k) == src.static_extent(R[k])`.
+<br/>
 
 * Examples:
 

--- a/P0009/P0009.bs
+++ b/P0009/P0009.bs
@@ -1779,7 +1779,7 @@ Table �: Accessor policy requirements
 <tr>
   <td>`A::accessor_type`</td>
   <td></td>
-  <td>Type through which the contiguous set of elements are accessed</td>
+  <td>Type through which the contiguous set of elements are accessed. *Requires:* Is DefaultConstructible, CopyConstructible, and CopyAssignable </td>
 </tr>
 <tr>
   <td>`A::reference`</td>
@@ -1902,10 +1902,8 @@ static constexpr pointer deref( accessor_type acc , size_t i ) noexcept ;
 2. As with `span`, the storage of the objects in the codomain `span` of a `basic_mdspan` is owned by some other object.
 3. `ElementType` is required to be a complete object type that is not an abstract class type or an array type.
 4. `Extents` is required to be a (cv-unqualified) specialization of `extents`.
-5. `LayoutPolicy` is required to be a cv-unqualified object type.
-6. If `LayoutPolicy` does not meet the layout mapping policy requirements, the program is ill-formed.
-7. `Accessor` is required to be a cv-unqualified object type.
-8. If `Accessor` does not meet the accessor requirements, or if `Accessor::value_type` is not exactly `ElementType`, the program is ill-formed.
+5. `LayoutPolicy` is required meet the layout mapping policy requirements, otherwise the program is ill-formed.
+6. `AccessorPolicy` is required meet the accessor policy requirements and `!std::is_same_v<typename AccessorPolicy::element_type,ElementType>`, otherwise the program is ill-formed.
 
 
 <pre highlight="c++">
@@ -1913,21 +1911,21 @@ namespace std {
 namespace experimental {
 namespace fundamentals_v3 {
 
-template&lt;class ElementType, class Extents, class LayoutPolicy, class Accessor>
+template&lt;class ElementType, class Extents, class LayoutPolicy, class AccessorPolicy>
 class basic_mdspan {
 public:
 
   // Domain and codomain types
   using extents_type = Extents;
   using layout_type = LayoutPolicy;
+  using accessor_type = AccessorPolicy;
   using mapping_type = typename layout_type::template mapping_type&lt;extents_type>;
-  using accessor_type = Accessor;
-  using element_type = ElementType ;
+  using element_type = typename accessor_type::element_type;
   using value_type = remove_cv_t&lt;element_type>;
   using index_type = ptrdiff_t ;
   using difference_type = ptrdiff_t;
-  using pointer = ElementType*;
-  using reference = typename accessor_reference_t&lt;ElementType>;
+  using pointer = typename accessor_type::pointer;
+  using reference = typename accessor_type::reference;
 
   // [mdspan.basic.cons], basic_mdspan constructors, assignment, and destructor
   constexpr basic_mdspan() noexcept = default;
@@ -1945,15 +1943,15 @@ public:
   constexpr basic_mdspan(const span&lt;element_type>& sp, const mapping_type& m);
   constexpr basic_mdspan(pointer p, const mapping_type& m, const accessor& a);
   constexpr basic_mdspan(const span&lt;element_type>& sp, const mapping_type& m, const accessor& a);
-  template&lt;class OtherElementType, class OtherExtents, class OtherLayoutPolicy, class OtherAccessor>
-    constexpr basic_mdspan(const basic_mdspan&lt;OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessor>& other);
+  template&lt;class OtherElementType, class OtherExtents, class OtherLayoutPolicy, class OtherAccessorPolicy>
+    constexpr basic_mdspan(const basic_mdspan&lt;OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessorPolicy>& other);
 
   ~basic_mdspan() = default;
 
   constexpr basic_mdspan& operator=(const basic_mdspan&) noexcept = default;
   constexpr basic_mdspan& operator=(basic_mdspan&&) noexcept = default;
-  template&lt;class OtherElementType, class OtherExtents, class OtherLayoutPolicy, class OtherAccessor>
-    constexpr basic_mdspan& operator=(const basic_mdspan&lt;OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessor>& other) noexcept;
+  template&lt;class OtherElementType, class OtherExtents, class OtherLayoutPolicy, class OtherAccessorPolicy>
+    constexpr basic_mdspan& operator=(const basic_mdspan&lt;OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessorPolicy>& other) noexcept;
 
   // [mdspan.basic.mapping], basic_mdspan mapping domain multi-index to access codomain element
   constexpr reference operator[](index_type) const noexcept;
@@ -1989,8 +1987,8 @@ public:
   static constexpr index_type required_span_size(const array&lt;IndexType, N>& dynamic_extents) noexcept;
 
 private:
-  mapping_type  map_; // <i>exposition only</i>
-  accessor_type acc_; // <i>exposition only</i>
+  mapping_type map_; // <i>exposition only</i>
+  typename accessor_type::accessor_type acc_; // <i>exposition only</i>
 };
 
 }}}
@@ -2174,8 +2172,8 @@ constexpr basic_mdspan(const span<element_type>& sp, const mapping& m, const acc
 
 <!-- TODO review this wording! -->
 ```c++
-template<class OtherElementType, class OtherExtents, class OtherLayoutPolicy, class OtherAccessor>
-  constexpr basic_mdspan(const basic_mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessor>& other);
+template<class OtherElementType, class OtherExtents, class OtherLayoutPolicy, class OtherAccessorPolicy>
+  constexpr basic_mdspan(const basic_mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessorPolicy>& other);
 ```
 
 * *Requires:*
@@ -2189,14 +2187,13 @@ template<class OtherElementType, class OtherExtents, class OtherLayoutPolicy, cl
 * *Remarks:* This constructor will not participate in overload resolution unless all of the following conditions are met:
     + `OtherElementType(*)[]` is convertible to `ElementType(*)[]`, <!-- lifted directly from span wording -->
     + `OtherLayoutPolicy::template mapping<OtherExtents>` is convertible to `mapping`
-    + `OtherAccessor` is convertible to `Accessor`, and
 * *Throws:* Nothing.
 
 <br/>
 
 ```c++
-template<class OtherElementType, class OtherExtents, class OtherLayoutPolicy, class OtherAccessor>
-  constexpr basic_mdspan& operator=(const basic_mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessor>& other);
+template<class OtherElementType, class OtherExtents, class OtherLayoutPolicy, class OtherAccessorPolicy>
+  constexpr basic_mdspan& operator=(const basic_mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessorPolicy>& other);
 ```
 
 * *Requires:*
@@ -2210,7 +2207,6 @@ template<class OtherElementType, class OtherExtents, class OtherLayoutPolicy, cl
 * *Remarks:* This constructor will not participate in overload resolution unless all of the following conditions are met:
     + `OtherElementType(*)[]` is assignable to `ElementType(*)[]`, <!-- lifted directly from span wording -->
     + `OtherLayoutPolicy::template mapping<OtherExtents>` is assignable to `mapping`
-    + `OtherAccessor` is assignable to `Accessor`, and
 * *Throws:* Nothing.
 
 
@@ -2241,7 +2237,7 @@ template<class... IndexType>
 ```
 
 * *Requires:* 0 <= `array<index_type, sizeof...(indices)>{indices...}[r]` < `extent(r)` for all `r` in the range `[0, rank())`.
-* *Effects:* Equivalent to `return acc_[ map_(indices...)];`
+* *Effects:* Equivalent to `return accessor_type::deref(acc_,map_(indices...));`
 * *Remarks:* This operator does not participate in overload resolution unless
     + `is_convertible_v<IndexType, index_type> && ...`
     + `sizeof...(IndexType)==rank()`

--- a/P0009/P0009.bs
+++ b/P0009/P0009.bs
@@ -2411,7 +2411,7 @@ template<class... IndexType>
 static constexpr index_type required_span_size(IndexType... dynamic_extents) noexcept;
 ```
 
-* *Returns:* 'mapping_type(dynamic_extents...).required_span_size();`
+* *Returns:* `mapping_type(dynamic_extents...).required_span_size();`
 
 <br/>
 
@@ -2420,7 +2420,7 @@ template<class IndexType, size_t N>
 static constexpr index_type required_span_size(const array<IndexType, N>& dynamic_extents) noexcept;
 ```
 
-* *Returns:* 'mapping_type(dynamic_extents).required_span_size();`
+* *Returns:* `mapping_type(dynamic_extents).required_span_size();`
 
 <br/>
 

--- a/P0009/P0009.bs
+++ b/P0009/P0009.bs
@@ -1772,51 +1772,52 @@ Table �: Accessor policy requirements
   <th>Requirements/Notes</th>
 </tr>
 <tr>
-  <td>A::element_type</td>
+  <td>`A::element_type`</td>
   <td></td>
   <td>Type of elements accessed</td>
 </tr>
 <tr>
-  <td>A::accessor_type</td>
+  <td>`A::accessor_type`</td>
   <td></td>
   <td>Type through which the contiguous set of elements are accessed</td>
 </tr>
 <tr>
-  <td>A::reference</td>
+  <td>`A::reference`</td>
   <td></td>
   <td>Type through which an element is accessed</td>
 </tr>
 <tr>
-  <td>A::pointer</td>
+  <td>`A::pointer`</td>
   <td></td>
   <td>Pointer type to which the accessor type decays</td>
 </tr>
 <tr>
-  <td>A::offset_policy</td>
+  <td>`A::offset_policy`</td>
   <td></td>
   <td>Accessor policy of an offset of an accessor_type object.</td>
 </tr>
 <tr>
   <td>`A::decay(a)`</td>
-  <td>`A::pointer`
+  <td>`A::pointer`</td>
   <td>*Returns:* A pointer to the contiguous set of objects accessed by `a`.</td>
 </tr>
 <tr>
   <td>`A::deref(a,i)`</td>
-  <td>`A::reference</td>
+  <td>`A::reference`</td>
   <td>*Returns:* An object which provides access to the `i`*th* element in the contiguous set.</td>
 </tr>
 <tr>
   <td>`A::offset(a,i)`</td>
-  <td>`A::offset_policy::accessor_type</td>
+  <td>`A::offset_policy::accessor_type`</td>
   <td>*Returns:* An accessor for the contiguous span of elements offset by `i`.  *Requires:* `A::decay(p)+i == A::offset_policy::decay(A::offset(a,i))`.</td>
 </tr>
 <tr>
   <td>`A::accessor_type(p)`</td>
-	<td></td>
-	<td>Construct an accessor for a contiguous span of elements starting at `p`.</td>
+  <td></td>
+  <td>Construct an accessor for a contiguous span of elements starting at `p`.</td>
 </tr>
 </table>
+
 
 <!--
 
@@ -1844,14 +1845,11 @@ struct accessor_basic {
   using pointer       = ElementType*;
 
   static constexpr typename offset_policy::accessor_type
-    offset( accessor_type acc , size_t i ) noexcept
-      { return acc+i; }
+    offset( accessor_type acc , size_t i ) noexcept;
 
-  static constexpr reference deref( accessor_type acc , size_t i ) noexcept
-    { return acc[i]; }
+  static constexpr reference deref( accessor_type acc , size_t i ) noexcept;
 
-  static constexpr pointer decay( accessor_type acc ) noexcept
-    { return acc; }
+  static constexpr pointer decay( accessor_type acc ) noexcept;
 };
 
 }}}
@@ -1862,22 +1860,19 @@ static constexpr typename offset_policy::accessor_type
   offset( accessor_type acc , size_t i ) noexcept ;
 ```
 
-* *Returns:* `acc+i`
-</br>
+* *Returns:* `acc+i` <br/>
 
 ```c++
 static constexpr reference deref( accessor_type acc , size_t i ) noexcept ;
 ```
 
-* *Returns:* `acc[i]`
-</br>
+* *Returns:* `acc[i]` <br/>
 
 ```c++
 static constexpr pointer deref( accessor_type acc , size_t i ) noexcept ;
 ```
 
-* *Returns:* `acc`
-</br>
+* *Returns:* `acc` <br/>
 
 <!--
 888                        d8b                                      888

--- a/P0009/P0009.bs
+++ b/P0009/P0009.bs
@@ -731,14 +731,17 @@ namespace fundamentals_v3 {
   class layout_right;
   class layout_stride;
 
-  // [mdspan.accessor.basic], class template accessor_basic
-  class accessor_basic;
+  // [mdspan.accessor.traits]
+  template<class Accessor>
+  class accessor_reference;
+  template<class Accessor>
+  using accessor_reference_t = typename accessor_reference<Accessor>::type;
 
   // [mdspan.basic], class template mdspan
   template<class ElementType,
            class Extents,
            class LayoutPolicy = layout_right,
-           class Accessor = accessor_basic>
+           class Accessor = T*>
     class basic_mdspan;
 
   template<class T, ptrdiff_t... Extents>
@@ -1110,7 +1113,7 @@ struct layout_left {
       constexpr mapping& operator=(const mapping&lt;OtherExtents>& other);
 
     // [mdspan.layout.left.ops], layout_left::mapping operations
-    const Extents & extents() const noexcept;
+    Extents extents() const noexcept;
 
     constexpr typename Extents::index_type required_span_size() const noexcept;
 
@@ -1214,7 +1217,7 @@ constexpr mapping(const mapping<OtherExtents>& other);
 <br/>
 
 ```c++
-const Extents & extents() const noexcept;
+Extents extents() const noexcept;
 ```
 
 * *Returns:* `extents_`.
@@ -1338,7 +1341,7 @@ struct layout_right {
       constexpr mapping& operator=(const mapping&lt;OtherExtents>& other);
 
     // [mdspan.layout.right.ops], layout_right::mapping operations
-    const Extents & extents() const noexcept;
+    Extents extents() const noexcept;
 
     constexpr typename Extents::index_type required_span_size() const noexcept;
 
@@ -1441,7 +1444,7 @@ template<class OtherExtents>
 <br/>
 
 ```c++
-const Extents & extents() const noexcept;
+Extents extents() const noexcept;
 ```
 
 * *Returns:* `extents_`.
@@ -1574,7 +1577,7 @@ struct layout_stride {
       constexpr mapping& operator=(const mapping&lt;OtherExtents>& other);
 
     // [mdspan.layout.stride.ops], layout_stride::mapping operations
-    const Extents & extents() const noexcept;
+    Extents extents() const noexcept;
     const array&lt;typename Extents::index_type, Extents::rank()> & strides() const noexcept;
 
     constexpr typename Extents::index_type required_span_size() const noexcept;
@@ -1650,7 +1653,7 @@ template<class OtherExtents>
 <b>26.7.�.4.2 layout_stride::mapping operations [mdspan.layout.stride.ops]</b>
 
 ```c++
-const Extents & extents() const noexcept;
+Extents extents() const noexcept;
 ```
 * Returns: extents_.
 
@@ -1740,15 +1743,25 @@ template<class OtherExtents>
 
 <b>26.7.� Accessor [mdspan.accessor]</b>
 
+An *accessor* is an object through which a contiguous set of objects of type *T* 
+that the accessor does not own are accessed. 
+An accessor is similar to an *array of unknown bound of T* [dcl.array] 
+when it is used as a *function parameter* [dcl.fct].
+
+
 <br/>
 <b>26.7.�.1 Accessor requirements [mdspan.accessor.reqs]</b>
 
-An *accessor* is a class that defines `pointer` and `reference` types. *[Note:* The intended semantic is that the reference refers to a value at the given offset from the given pointer. *—end note]*
+An accessor supports subscripting operator [expr.sub], conversion to pointer [conv.array],
+and is constructable from a pointer to a contiguous set of objects of type `T`.
+The subscripting operator returns an object which provides access to the indexed element,
+this return type may be a type that is not `T&`.
 
 In Table �:
   * `A` denotes an accessor type.
+  * `a` denotes an object of type `A`
   * `T` denotes an object type and is not an array type.
-  * `p` denotes a value of type `A::pointer<T>`.
+  * `p` denotes an object of type `T*`.
   * `i` denotes an integer value.
 
 Table �: Accessor requirements
@@ -1759,19 +1772,19 @@ Table �: Accessor requirements
   <th>Requirements/Notes</th>
 </tr>
 <tr>
-  <td>`A::reference<T>`</td>
-  <td></td>
-  <td>*Requires:* `A::reference<T>` shall be convertable to `T` and, if `!is_const_v<T>`, assignable from `T`. *[Note:* This may be `T&` or a proxy that operates like `T&`. *--end note]*</td>
+  <td>`a[i]`</td>
+  <td>`accessor_reference_t<A>`
+  <td>*Returns:* An object which provides access to the `i`*th* element in the contiguous set.</td>
 </tr>
 <tr>
-  <td>`A::pointer<T>`</td>
-  <td></td>
-  <td>*Requires:* `A::pointer<T>` shall be `DefaultConstructible` and `CopyAssignable`. *[Note:* This may be `T*` or a proxy that operates like `T*`. *--end note]*</td>
+  <td>`p = a;`</td>
+  <td>`T*`</td>
+  <td>*Returns:* a pointer to the contiguous set of objects referenced by `a`.</td>
 </tr>
 <tr>
-  <td>`p[i]`</td>
-  <td>`A::reference<T>`</td>
-  <td>*Returns:* `A::reference<T>` corresponding to offset `i` from `p`.
+  <td>`A a(p)`</td>
+  <td></td>
+  <td>*Requires:* `p` is a pointer to a contiguous set of objects.</td>
 </tr>
 </table>
 
@@ -1785,22 +1798,18 @@ Table �: Accessor requirements
 -->
 
 <br/>
-<b>26.7.�.2 Class `accessor_basic` [mdspan.accessor.basic]</b>
-
-1. `accessor_basic` meets the requirements of accessor.
-2. `accessor_basic` gives an accessor that has semantics equivalent to dereferencing a pointer to an array of values.
-3. If `T` is not an object type or is an array type, the program is ill-formed.
+<b>26.7.�.2 Class `accessor_reference` [mdspan.accessor.traits]</b>
 
 ```c++
 namespace std {
 namespace experimental {
 namespace fundamentals_v3 {
 
-struct accessor_basic {
-  template<class T>
-  using pointer = T*;
-  template<class T>
-  using reference = T&;
+template<class T>
+struct accessor_reference ;
+template<class T>
+struct accessor_reference<T*> {
+  using type = T&;
 };
 
 }}}
@@ -1857,9 +1866,9 @@ public:
   using element_type = ElementType ;
   using value_type = remove_cv_t&lt;element_type>;
   using index_type = ptrdiff_t ;
-  using difference_type = ptrdiff_t ;
-  using pointer = typename accessor_type::template pointer&lt;element_type>;
-  using reference = typename accessor_type::template reference&lt;element_type>;
+  using difference_type = ptrdiff_t;
+  using pointer = ElementType*;
+  using reference = typename accessor_reference_t&lt;ElementType>;
 
   // [mdspan.basic.cons], basic_mdspan constructors, assignment, and destructor
   constexpr basic_mdspan() noexcept = default;
@@ -1899,7 +1908,7 @@ public:
   static constexpr int rank_dynamic() noexcept;
   static constexpr index_type static_extent(size_t) noexcept;
 
-  constexpr const Extents & extents() const noexcept;
+  constexpr Extents extents() const noexcept;
   constexpr index_type extent(size_t) const noexcept;
 
   // [mdspan.basic.codomain], basic_mdspan observers of the codomain
@@ -1910,7 +1919,7 @@ public:
   static constexpr bool is_always_contiguous() noexcept;
   static constexpr bool is_always_strided() noexcept;
 
-  constexpr const mapping_type & mapping() const noexcept;
+  constexpr mapping_type mapping() const noexcept;
   constexpr bool is_unique() const noexcept;
   constexpr bool is_contiguous() const noexcept;
   constexpr bool is_strided() const noexcept;
@@ -2305,7 +2314,7 @@ static constexpr bool is_always_strided() noexcept;
 <br/>
 
 ```c++
-constexpr const mapping_type & mapping() const noexcept;
+constexpr mapping_type mapping() const noexcept;
 ```
 
 * *Returns:* `map_`
@@ -2390,7 +2399,7 @@ namespace fundamentals_v3 {
   // [mdspan.subspan], subspan creation
   template<class ElementType, class Extents, class LayoutPolicy,
            class Accessor, class... SliceSpecifiers>
-    basic_mdspan<ElementType, E /* see-below */, layout_stride, Accessor>
+    basic_mdspan<ElementType, E /* see-below */, L /* see-below */, A /* see-below */ >
       subspan(const basic_mdspan<ElementType, Extents, LayoutPolicy, Accessor>& src, SliceSpecifiers ... slices) noexcept;
 
 }}}
@@ -2399,7 +2408,9 @@ namespace fundamentals_v3 {
 `subspan` creates a `basic_mdspan` that is a view on a (potentially trivial) subset of another `basic_mdspan`.
 The SliceSpecifier parameters indicate the subset that the return value references.
 Let slices[r] denote the rth value in the parameter pack slices.
-The second template parameter of the return type is E, a specialization of `extents`.
+The second template parameter of the return type, `E`, is a specialization of `extents`.
+The third template parameter of the return type, `L`, is a layout mapping policy [mdspan.layout].
+The fourth template paramter of the return type, `A`, is an accessor [mdspan.accessor].
 <br/>
 
 Let <em>C</em> be the number of parameters in `SliceSpecifiers` which are convertible to `ptrdiff_t` <br/>
@@ -2426,6 +2437,8 @@ Postcondition: <br/>
     * If <em>ranges[r]</em> is the nth value of `ranges` convertible to `alltype_t` or `pair<ptrdiff_t,ptrdiff_t>` and `slices[k]` is the `n`th value of `slices` convertible to `all type_t` or  `pair<ptrdiff_t,ptrdiff_t>` then `sub.extent(r)==last[k]-first[k]` and `sub.stride(r)==src.stride(k)` <br/> 
     * `sub.ptr_==src.ptr_+first[0]*src.stride(0)+`...`+first[Extents::rank()-1]*src.stride(Extents::rank()-1)` <br/>
     * Note: it is quality of implementation whether static extents are preserved if possible.  <br/>
+
+
 
 * Examples:
 

--- a/P0009/prototype/include/accessor_atomic_ref.hpp
+++ b/P0009/prototype/include/accessor_atomic_ref.hpp
@@ -1,0 +1,36 @@
+
+#include <type_traits>
+
+template<class T>
+class atomic_ref {};
+
+template<class T>
+struct accessor_atomic {
+
+  static_assert( std::is_trivially_copyable<T>::value );
+
+	using element_type = T;
+	using reference    = atomic_ref<T> ;
+	using pointer      = T*;
+	using offset       = accessor_atomic ;
+
+  constexpr accessor_atomic() noexcept = default ;
+  constexpr accessor_atomic( accessor_atomic && ) noexcept = default ;
+  constexpr accessor_atomic( const accessor_atomic & ) noexcept = default ;
+  accessor_atomic & operator =( accessor_atomic && ) noexcept = default ;
+  accessor_atomic & operator =( const accessor_atomic & ) noexcept = default ;
+
+  explicit constexpr accessor_atomic( pointer other ) noexcept
+	  : ptr(other)
+		{ assert( 0 == reinterpret_cast<uintptr_t>(ptr) % reference::required_alignment ); };
+
+  constexpr reference operator[]( size_t i ) const noexcept
+	  { return reference( ptr[i] ); }
+
+  constexpr offset operator+( size_t i ) const noexcept
+	  { return offset(ptr+i); }
+
+  constexpr operator pointer() const
+	  { assert(false /* cannot access raw data outside of atomic */); }
+};
+

--- a/P0009/prototype/include/mdspan
+++ b/P0009/prototype/include/mdspan
@@ -39,11 +39,9 @@ class layout_right ;
 class layout_left ;
 class layout_stride ;
 
-// [mdspan.accessor.reference]
+// [mdspan.accessor.traits]
 template<class Accessor>
-class accessor_reference;
-template<class Accessor>
-using accessor_reference_t = typename accessor_reference<Accessor>::type;
+class accessor_traits;
 
 // [mdspan.basic]
 template<class ElementType,
@@ -528,12 +526,24 @@ namespace experimental {
 namespace fundamentals_v3 {
 
 template<class Accessor>
-class accessor_reference ;
+struct accessor_traits ;
 
 template<class T>
-class accessor_reference<T*> {
-public:
-  using type = T&;
+struct accessor_traits<T*> {
+  using accessor     = T*;
+  using element_type = T;
+	using pointer      = T*;
+	using reference    = T&;
+	using offset       = T*;
+};
+
+template<class Accessor>
+struct accessor_traits {
+  using accessor     = Accessor ;
+  using element_type = typename accessor::element_type;
+	using pointer      = typename accessor::pointer;
+	using reference    = typename accessor::reference;
+	using offset       = typename accessor::offset;
 };
 
 }}} // std::experimental::fundamentals_v3
@@ -553,7 +563,10 @@ public:
 
   enum : size_t { align = N };
 
-	using reference = T&;
+  using element_type = T;
+	using reference    = T&;
+	using pointer      = T*;
+	using offset       = T*;
 
 	constexpr accessor_aligned() noexcept {};
 	constexpr accessor_aligned( const accessor_aligned & ) noexcept = default ;
@@ -569,23 +582,22 @@ public:
 		  assert( 0 == reinterpret_cast<uintptr_t>(ptr) % N );
 		}
 
-  // constexpr operator alignas(N) T* () const noexcept { return ptr };
+  // constexpr operator [[aligned(N)]] T* () const noexcept { return ptr };
 
   constexpr operator T*() const noexcept
 	  { return ptr; }
+
 	constexpr reference operator[]( size_t i ) const noexcept
 	  { return ptr[i]; }
 
+  // Offsetting looses the alignment attribute
+	constexpr offset operator+( size_t i ) const noexcept
+	  { return ptr+i; }
+
 private:
 
-  // alignas(N) T * const ptr = 0 ;
+  // [[aligned(N)]] T * const ptr = 0 ;
   T * const ptr = 0 ;
-};
-
-template<class T, size_t N>
-class accessor_reference< accessor_aligned<T,N> > {
-public:
-  using type = typename accessor_aligned<T,N>::reference ;
 };
 
 }}} // std::experimental::fundamentals_v3
@@ -607,17 +619,17 @@ public:
   using layout_type      = LayoutPolicy ;
   using mapping_type     = typename layout_type::template mapping<extents_type> ;
   using accessor_type    = Accessor ;
-  using element_type     = ElementType ;
+  using element_type     = typename accessor_traits<Accessor>::element_type ;
   using value_type       = typename std::remove_cv<element_type>::type ;
   using index_type       = ptrdiff_t ;
   using difference_type  = ptrdiff_t ;
-  using pointer          = ElementType*;
-  using reference        = accessor_reference_t<Accessor>;
+  using pointer          = typename accessor_traits<Accessor>::pointer;
+  using reference        = typename accessor_traits<Accessor>::reference;
 
   // [mdspan.basic.cons]
 
   HOST_DEVICE
-  constexpr basic_mdspan() noexcept : m_ptr(0), m_map() {}
+  constexpr basic_mdspan() noexcept : m_acc(0), m_map() {}
 
   HOST_DEVICE
   constexpr basic_mdspan(basic_mdspan&& other) noexcept = default;
@@ -640,7 +652,7 @@ public:
                        OtherExtents,
                        OtherLayoutPolicy,
                        OtherAccessor> & rhs ) noexcept
-    : m_ptr( rhs.m_ptr )
+    : m_acc( rhs.m_acc )
     , m_map( rhs.m_map )
     {}
 
@@ -653,15 +665,15 @@ public:
                        OtherExtents,
                        OtherLayoutPolicy,
                        OtherAccessor> & rhs ) noexcept
-    { m_ptr = rhs.m_ptr ; m_map = rhs.m_map ; return *this ; }
+    { m_acc = rhs.m_acc ; m_map = rhs.m_map ; return *this ; }
 
   template<class... IndexType >
   explicit constexpr basic_mdspan
     ( pointer ptr , IndexType ... DynamicExtents ) noexcept
-    : m_ptr(ptr), m_map( DynamicExtents... ) {}
+    : m_acc(ptr), m_map( DynamicExtents... ) {}
 
   constexpr basic_mdspan( pointer ptr , const mapping_type & m ) noexcept
-    : m_ptr(ptr), m_map( m ) {}
+    : m_acc(ptr), m_map( m ) {}
 
   // [mdspan.basic.mapping]
 
@@ -671,7 +683,7 @@ public:
   constexpr
   typename std::enable_if<sizeof...(IndexType)==extents_type::rank(),reference>::type
   operator()( IndexType... indices) const noexcept
-    { return m_ptr[ m_map( indices... ) ]; }
+    { return m_acc[ m_map( indices... ) ]; }
 
   // Enforce rank() == 1
   template<class IndexType >
@@ -679,7 +691,7 @@ public:
   constexpr
   typename std::enable_if<std::is_integral<IndexType>::value && 1==extents_type::rank(),reference>::type
   operator[]( IndexType i ) const noexcept
-    { return m_ptr[ m_map(i) ]; }
+    { return m_acc[ m_map(i) ]; }
 
   // [mdspan.basic.domobs]
 
@@ -703,10 +715,10 @@ public:
   // ------------------------------
   // constexpr span<element_type> span() const noexcept ;
 
-     constexpr pointer span_data() const noexcept { return m_ptr ; }
+     constexpr pointer span_data() const noexcept { return (pointer) m_acc ; }
 
      constexpr index_type span_size() const noexcept
-       { return m_ptr ? m_map.required_span_size() : 0 ; }
+       { return ((pointer)m_acc) ? m_map.required_span_size() : 0 ; }
   // ------------------------------
 
   // [mdspan.basic.obs]
@@ -738,7 +750,7 @@ public:
 
 private:
 
-  Accessor     m_ptr ;
+  Accessor     m_acc ;
   mapping_type m_map ;
 };
 

--- a/P0009/prototype/include/mdspan
+++ b/P0009/prototype/include/mdspan
@@ -41,11 +41,7 @@ class layout_stride ;
 
 // [mdspan.accessor.reference]
 template<class Accessor>
-class accessor_pointer;
-template<class Accessor>
 class accessor_reference;
-template<class Accessor>
-using accessor_pointer_t = typename accessor_pointer<Accessor>::type;
 template<class Accessor>
 using accessor_reference_t = typename accessor_reference<Accessor>::type;
 
@@ -532,15 +528,7 @@ namespace experimental {
 namespace fundamentals_v3 {
 
 template<class Accessor>
-class accessor_pointer ;
-template<class Accessor>
 class accessor_reference ;
-
-template<class T>
-class accessor_pointer<T*> {
-public:
-  using type = T*;
-};
 
 template<class T>
 class accessor_reference<T*> {
@@ -552,8 +540,6 @@ public:
 
 //--------------------------------------------------------------------------
 //--------------------------------------------------------------------------
-// accessor::pointer<T> is
-// an object pointer type [basic.compound]
 
 namespace std {
 namespace experimental {
@@ -567,8 +553,6 @@ public:
 
   enum : size_t { align = N };
 
-	// using pointer = alignas(N) T*;
-	using pointer = T*;
 	using reference = T&;
 
 	constexpr accessor_aligned() noexcept {};
@@ -578,7 +562,7 @@ public:
 	accessor_aligned operator = ( accessor_aligned && ) = delete ;
 	accessor_aligned operator = ( const accessor_aligned & ) = delete ;
 
-	explicit accessor_aligned( pointer other ) noexcept
+	explicit accessor_aligned( T * other ) noexcept
 		: ptr(other)
 		{
 		  // Verify pointer alignment:
@@ -587,14 +571,15 @@ public:
 
   // constexpr operator alignas(N) T* () const noexcept { return ptr };
 
-  constexpr operator pointer () const noexcept
+  constexpr operator T*() const noexcept
 	  { return ptr; }
 	constexpr reference operator[]( size_t i ) const noexcept
 	  { return ptr[i]; }
 
 private:
 
-  pointer const ptr = 0 ;
+  // alignas(N) T * const ptr = 0 ;
+  T * const ptr = 0 ;
 };
 
 template<class T, size_t N>
@@ -626,7 +611,7 @@ public:
   using value_type       = typename std::remove_cv<element_type>::type ;
   using index_type       = ptrdiff_t ;
   using difference_type  = ptrdiff_t ;
-  using pointer          = accessor_pointer_t<Accessor>;
+  using pointer          = ElementType*;
   using reference        = accessor_reference_t<Accessor>;
 
   // [mdspan.basic.cons]

--- a/P0009/prototype/include/mdspan
+++ b/P0009/prototype/include/mdspan
@@ -39,14 +39,21 @@ class layout_right ;
 class layout_left ;
 class layout_stride ;
 
-// [mdspan.accessor.basic]
-class accessor_basic;
+// [mdspan.accessor.reference]
+template<class Accessor>
+class accessor_pointer;
+template<class Accessor>
+class accessor_reference;
+template<class Accessor>
+using accessor_pointer_t = typename accessor_pointer<Accessor>::type;
+template<class Accessor>
+using accessor_reference_t = typename accessor_reference<Accessor>::type;
 
 // [mdspan.basic]
 template<class ElementType,
          class Extents,
          class LayoutPolicy = layout_right,
-         class Accessor = accessor_basic >
+         class Accessor = ElementType*>
 class basic_mdspan ;
 
 // [msspan.subspan]
@@ -524,10 +531,76 @@ namespace std {
 namespace experimental {
 namespace fundamentals_v3 {
 
-class accessor_basic {
+template<class Accessor>
+class accessor_pointer ;
+template<class Accessor>
+class accessor_reference ;
+
+template<class T>
+class accessor_pointer<T*> {
 public:
-  template<class T> using pointer_t = T * ;
-  template<class T> using reference_t = T & ;
+  using type = T*;
+};
+
+template<class T>
+class accessor_reference<T*> {
+public:
+  using type = T&;
+};
+
+}}} // std::experimental::fundamentals_v3
+
+//--------------------------------------------------------------------------
+//--------------------------------------------------------------------------
+// accessor::pointer<T> is
+// an object pointer type [basic.compound]
+
+namespace std {
+namespace experimental {
+namespace fundamentals_v3 {
+
+template<class T, size_t N>
+class accessor_aligned {
+public:
+  static_assert( ( 0 == ( N & ( N - 1 ))), "" );
+  static_assert( ( 0 == ( N % sizeof(T))), "" );
+
+  enum : size_t { align = N };
+
+	// using pointer = alignas(N) T*;
+	using pointer = T*;
+	using reference = T&;
+
+	constexpr accessor_aligned() noexcept {};
+	constexpr accessor_aligned( const accessor_aligned & ) noexcept = default ;
+
+	accessor_aligned( accessor_aligned && ) = delete ;
+	accessor_aligned operator = ( accessor_aligned && ) = delete ;
+	accessor_aligned operator = ( const accessor_aligned & ) = delete ;
+
+	explicit accessor_aligned( pointer other ) noexcept
+		: ptr(other)
+		{
+		  // Verify pointer alignment:
+		  assert( 0 == reinterpret_cast<uintptr_t>(ptr) % N );
+		}
+
+  // constexpr operator alignas(N) T* () const noexcept { return ptr };
+
+  constexpr operator pointer () const noexcept
+	  { return ptr; }
+	constexpr reference operator[]( size_t i ) const noexcept
+	  { return ptr[i]; }
+
+private:
+
+  pointer const ptr = 0 ;
+};
+
+template<class T, size_t N>
+class accessor_reference< accessor_aligned<T,N> > {
+public:
+  using type = typename accessor_aligned<T,N>::reference ;
 };
 
 }}} // std::experimental::fundamentals_v3
@@ -553,8 +626,8 @@ public:
   using value_type       = typename std::remove_cv<element_type>::type ;
   using index_type       = ptrdiff_t ;
   using difference_type  = ptrdiff_t ;
-  using pointer          = typename accessor_type::template pointer_t<element_type>;
-  using reference        = typename accessor_type::template reference_t<element_type>;
+  using pointer          = accessor_pointer_t<Accessor>;
+  using reference        = accessor_reference_t<Accessor>;
 
   // [mdspan.basic.cons]
 
@@ -680,12 +753,12 @@ public:
 
 private:
 
-  pointer      m_ptr ;
+  Accessor     m_ptr ;
   mapping_type m_map ;
 };
 
 template<class T, ptrdiff_t... Indices>
-using mdspan = basic_mdspan<T,extents<Indices...>,layout_right,accessor_basic> ;
+using mdspan = basic_mdspan<T,extents<Indices...>,layout_right,T*> ;
 
 }}} // std::experimental::fundamentals_v3
 

--- a/P0009/prototype/include/mdspan
+++ b/P0009/prototype/include/mdspan
@@ -528,20 +528,20 @@ namespace fundamentals_v3 {
 template<class ElementType>
 struct accessor_basic {
   using accessor_type = ElementType*;
-	using offset_policy = accessor_basic;
+  using offset_policy = accessor_basic;
   using element_type  = ElementType;
-	using reference     = ElementType&;
-	using pointer       = ElementType*;
+  using reference     = ElementType&;
+  using pointer       = ElementType*;
 
   static typename offset_policy::accessor_type
-	  offset( accessor_type acc , size_t i ) noexcept
-	    { return acc+i; }
+    offset( accessor_type acc , size_t i ) noexcept
+      { return acc+i; }
 
   static reference deref( accessor_type acc , size_t i ) noexcept
-	  { return acc[i]; }
+    { return acc[i]; }
 
   static pointer decay( accessor_type acc ) noexcept
-	  { return acc; }
+    { return acc; }
 };
 
 }}} // std::experimental::fundamentals_v3
@@ -562,34 +562,34 @@ public:
   enum : size_t { align = N };
 
   using element_type = T;
-	using reference    = T&;
-	using pointer      = T*;
-	using offset       = T*;
+  using reference    = T&;
+  using pointer      = T*;
+  using offset       = T*;
 
-	constexpr aligned_accessor() noexcept {};
-	constexpr aligned_accessor( const aligned_accessor & ) noexcept = default ;
+  constexpr aligned_accessor() noexcept {};
+  constexpr aligned_accessor( const aligned_accessor & ) noexcept = default ;
 
-	aligned_accessor( aligned_accessor && ) = delete ;
-	aligned_accessor operator = ( aligned_accessor && ) = delete ;
-	aligned_accessor operator = ( const aligned_accessor & ) = delete ;
+  aligned_accessor( aligned_accessor && ) = delete ;
+  aligned_accessor operator = ( aligned_accessor && ) = delete ;
+  aligned_accessor operator = ( const aligned_accessor & ) = delete ;
 
-	explicit aligned_accessor( T * other ) noexcept
-		: ptr(other)
-		{
-		  // Verify pointer alignment:
-		  assert( 0 == reinterpret_cast<uintptr_t>(ptr) % N );
-		}
+  explicit aligned_accessor( T * other ) noexcept
+  	: ptr(other)
+  	{
+  	  // Verify pointer alignment:
+  	  assert( 0 == reinterpret_cast<uintptr_t>(ptr) % N );
+  	}
 
   // constexpr operator [[aligned(N)]] T* () const noexcept { return ptr };
 
   constexpr operator T*() const noexcept
 	  { return ptr; }
 
-	constexpr reference operator[]( size_t i ) const noexcept
+  constexpr reference operator[]( size_t i ) const noexcept
 	  { return ptr[i]; }
 
   // Offsetting looses the alignment attribute
-	constexpr offset operator+( size_t i ) const noexcept
+  constexpr offset operator+( size_t i ) const noexcept
 	  { return ptr+i; }
 
 private:
@@ -601,10 +601,10 @@ private:
 template<class ElementType, size_t N>
 struct aligned_access_policy {
   using accessor_type  = aligned_accessor<ElementType,N>;
-	using offset_policy  = accessor_basic<ElementType>;
+  using offset_policy  = accessor_basic<ElementType>;
   using element_type   = typename accessor_type::element_type;
-	using reference      = typename accessor_type::reference;
-	using pointer        = typename accessor_type::pointer;
+  using reference      = typename accessor_type::reference;
+  using pointer        = typename accessor_type::pointer;
 
   static typename offset_policy::accessor_type
 	  offset( const accessor_type & acc , size_t i ) noexcept
@@ -640,7 +640,7 @@ public:
   using value_type       = typename std::remove_cv<element_type>::type ;
   using index_type       = ptrdiff_t ;
   using difference_type  = ptrdiff_t ;
-	using access           = typename accessor_type::accessor_type;
+  using access           = typename accessor_type::accessor_type;
   using pointer          = typename accessor_type::pointer;
   using reference        = typename accessor_type::reference;
 

--- a/P0009/prototype/include/mdspan
+++ b/P0009/prototype/include/mdspan
@@ -170,9 +170,9 @@ public:
       { return helper::product(i,j); }
 
     template<ptrdiff_t... OtherStaticExtents>
-	  HOST_DEVICE constexpr bool
+    HOST_DEVICE constexpr bool
     equal( const extents<OtherStaticExtents...>& other ) const noexcept
-		  { return rank() == other.rank() && helper::equal( other ); }
+      { return rank() == other.rank() && helper::equal( other ); }
 };
 
 //----------------------------------------------------------------------------
@@ -182,6 +182,73 @@ HOST_DEVICE
 constexpr bool operator==(const extents<LHS...>& lhs,
                           const extents<RHS...>& rhs) noexcept
 { return lhs.equal(rhs); }
+
+}}} // std::experimental::fundamentals_v3
+
+//--------------------------------------------------------------------------
+//--------------------------------------------------------------------------
+
+namespace std {
+namespace experimental {
+namespace fundamentals_v3 {
+
+struct layout_none {
+
+  template<class Extents>
+  class mapping {
+  private:
+
+    static_assert( Extents::rank() <= 1 , "" );
+
+    Extents m_extents ;
+
+  public:
+
+    using index_type = ptrdiff_t ;
+
+    HOST_DEVICE
+    constexpr mapping() noexcept = default ;
+
+    HOST_DEVICE
+    constexpr mapping( mapping && ) noexcept = default ;
+
+    HOST_DEVICE
+    constexpr mapping( const mapping & ) noexcept = default ;
+
+    HOST_DEVICE
+    mapping & operator = ( mapping && ) noexcept = default ;
+
+    HOST_DEVICE
+    mapping & operator = ( const mapping & ) noexcept = default ;
+
+    HOST_DEVICE
+    constexpr mapping( const Extents & ext ) noexcept
+      : m_extents( ext ) {}
+
+    constexpr const Extents & extents() const noexcept { return m_extents ; }
+
+    template<class... Indices>
+    constexpr mapping( Indices... DynamicExtents ) noexcept
+      : m_extents( DynamicExtents... ) {}
+
+    constexpr index_type required_span_size() const noexcept
+      { return m_extents.extent(0); }
+
+    constexpr index_type operator()() const noexcept { return 0 ; }
+    constexpr index_type operator()( index_type i ) const noexcept { return i ; }
+
+    static constexpr bool is_always_unique     = true ;
+    static constexpr bool is_always_contiguous = true ;
+    static constexpr bool is_always_strided    = true ;
+
+    constexpr bool is_unique()     const noexcept { return true ; }
+    constexpr bool is_contiguous() const noexcept { return true ; }
+    constexpr bool is_strided()    const noexcept { return true ; }
+
+    static constexpr index_type stride(size_t) noexcept { return 1 ; }
+  }; // struct mapping
+
+}; // struct layout_none
 
 }}} // std::experimental::fundamentals_v3
 
@@ -527,21 +594,21 @@ namespace fundamentals_v3 {
 
 template<class ElementType>
 struct accessor_basic {
-  using accessor_type = ElementType*;
-  using offset_policy = accessor_basic;
   using element_type  = ElementType;
-  using reference     = ElementType&;
   using pointer       = ElementType*;
+  using handle_type   = ElementType*;
+  using offset_policy = accessor_basic;
+  using reference     = ElementType&;
 
-  static typename offset_policy::accessor_type
-    offset( accessor_type acc , size_t i ) noexcept
-      { return acc+i; }
+  static typename offset_policy::handle_type
+    offset( handle_type h , size_t i ) noexcept
+      { return h+i; }
 
-  static reference deref( accessor_type acc , size_t i ) noexcept
-    { return acc[i]; }
+  static reference deref( handle_type h , size_t i ) noexcept
+    { return h[i]; }
 
-  static pointer decay( accessor_type acc ) noexcept
-    { return acc; }
+  static pointer decay( handle_type h ) noexcept
+    { return h; }
 };
 
 }}} // std::experimental::fundamentals_v3
@@ -574,23 +641,23 @@ public:
   aligned_accessor operator = ( const aligned_accessor & ) = delete ;
 
   explicit aligned_accessor( T * other ) noexcept
-  	: ptr(other)
-  	{
-  	  // Verify pointer alignment:
-  	  assert( 0 == reinterpret_cast<uintptr_t>(ptr) % N );
-  	}
+    : ptr(other)
+    {
+      // Verify pointer alignment:
+      assert( 0 == reinterpret_cast<uintptr_t>(ptr) % N );
+    }
 
   // constexpr operator [[aligned(N)]] T* () const noexcept { return ptr };
 
   constexpr operator T*() const noexcept
-	  { return ptr; }
+    { return ptr; }
 
   constexpr reference operator[]( size_t i ) const noexcept
-	  { return ptr[i]; }
+    { return ptr[i]; }
 
   // Offsetting looses the alignment attribute
   constexpr offset operator+( size_t i ) const noexcept
-	  { return ptr+i; }
+    { return ptr+i; }
 
 private:
 
@@ -600,21 +667,21 @@ private:
 
 template<class ElementType, size_t N>
 struct aligned_access_policy {
-  using accessor_type  = aligned_accessor<ElementType,N>;
-  using offset_policy  = accessor_basic<ElementType>;
-  using element_type   = typename accessor_type::element_type;
-  using reference      = typename accessor_type::reference;
-  using pointer        = typename accessor_type::pointer;
+  using element_type  = ElementType;
+  using pointer       = ElementType*;
+  using handle_type   = aligned_accessor<ElementType,N>;
+  using reference     = typename handle_type::reference;
+  using offset_policy = accessor_basic<ElementType>;
 
-  static typename offset_policy::accessor_type
-	  offset( const accessor_type & acc , size_t i ) noexcept
-	    { return acc+i; }
+  static typename offset_policy::handle_type
+    offset( const handle_type & h , size_t i ) noexcept
+      { return h+i; }
 
-  static reference deref( const accessor_type & acc , size_t i ) noexcept
-	  { return acc[i]; }
+  static reference deref( const handle_type & h , size_t i ) noexcept
+    { return h[i]; }
 
-  static pointer decay( const accessor_type & acc ) noexcept
-	  { return (pointer)acc; }
+  static pointer decay( const handle_type & h ) noexcept
+    { return (pointer)h; }
 };
 
 }}} // std::experimental::fundamentals_v3
@@ -625,6 +692,9 @@ struct aligned_access_policy {
 namespace std {
 namespace experimental {
 namespace fundamentals_v3 {
+
+template<class T, ptrdiff_t N = dynamic_extent >
+using span = basic_mdspan<T,extents<N>,layout_none,accessor_basic<T> >;
 
 template<class ElementType, class Extents, class LayoutPolicy, class AccessorPolicy>
 class basic_mdspan {
@@ -640,7 +710,7 @@ public:
   using value_type       = typename std::remove_cv<element_type>::type ;
   using index_type       = ptrdiff_t ;
   using difference_type  = ptrdiff_t ;
-  using access           = typename accessor_type::accessor_type;
+  using handle_type      = typename accessor_type::handle_type;
   using pointer          = typename accessor_type::pointer;
   using reference        = typename accessor_type::reference;
 
@@ -687,10 +757,10 @@ public:
 
   template<class... IndexType >
   explicit constexpr basic_mdspan
-    ( pointer ptr , IndexType ... DynamicExtents ) noexcept
+    ( handle_type ptr , IndexType ... DynamicExtents ) noexcept
     : m_acc(ptr), m_map( DynamicExtents... ) {}
 
-  constexpr basic_mdspan( pointer ptr , const mapping_type & m ) noexcept
+  constexpr basic_mdspan( handle_type ptr , const mapping_type & m ) noexcept
     : m_acc(ptr), m_map( m ) {}
 
   // [mdspan.basic.mapping]
@@ -731,12 +801,10 @@ public:
   // [mdspan.basic.codomain]
 
   // ------------------------------
-  // constexpr span<element_type> span() const noexcept ;
 
-     constexpr pointer span_data() const noexcept { return (pointer) m_acc ; }
+  constexpr fundamentals_v3::span<element_type> span() const noexcept
+	  { return fundamentals_v3::span((pointer)m_acc,m_map.extents().extent(0)); }
 
-     constexpr index_type span_size() const noexcept
-       { return ((pointer)m_acc) ? m_map.required_span_size() : 0 ; }
   // ------------------------------
 
   // [mdspan.basic.obs]
@@ -768,9 +836,10 @@ public:
 
 private:
 
-  access       m_acc ;
+  handle_type  m_acc ;
   mapping_type m_map ;
 };
+
 
 template<class T, ptrdiff_t... Indices>
 using mdspan = basic_mdspan<T,extents<Indices...>,layout_right,accessor_basic<T> > ;

--- a/P0009/prototype/include/mdspan
+++ b/P0009/prototype/include/mdspan
@@ -1,0 +1,748 @@
+
+#ifndef STD_EXPERIMENTAL_FUNDAMENTALS_V3_MDSPAN_HEADER
+#define STD_EXPERIMENTAL_FUNDAMENTALS_V3_MDSPAN_HEADER
+
+#define HOST_DEVICE /* __host__ __device__ */
+
+#include <cassert>
+#include <type_traits>
+#include <utility>
+#include <array>
+#include <initializer_list>
+
+//--------------------------------------------------------------------------
+//--------------------------------------------------------------------------
+
+namespace std {
+namespace experimental {
+namespace fundamentals_v3 {
+
+inline constexpr ptrdiff_t dynamic_extent = -1 ;
+
+// [mdspan.extents]
+template< ptrdiff_t ... StaticExtents >
+class extents;
+
+// [mdspan.extents.compare]
+template<ptrdiff_t... LHS, ptrdiff_t... RHS>
+HOST_DEVICE
+constexpr bool operator==(const extents<LHS...>& lhs,
+                          const extents<RHS...>& rhs) noexcept;
+
+template<ptrdiff_t... LHS, ptrdiff_t... RHS>
+HOST_DEVICE
+constexpr bool operator!=(const extents<LHS...>& lhs,
+                          const extents<RHS...>& rhs) noexcept;
+
+// [mdspan.layout]
+class layout_right ;
+class layout_left ;
+class layout_stride ;
+
+// [mdspan.accessor.basic]
+class accessor_basic;
+
+// [mdspan.basic]
+template<class ElementType,
+         class Extents,
+         class LayoutPolicy = layout_right,
+         class Accessor = accessor_basic >
+class basic_mdspan ;
+
+// [msspan.subspan]
+
+namespace detail {
+template<class ElementType,
+         class Extents,
+         class LayoutPolicy,
+         class Accessor,
+         class ... SliceSpecifiers>
+class subspan_deduction;
+}
+
+template<class ElementType,
+         class Extents,
+         class LayoutPolicy,
+         class Accessor,
+         class ... SliceSpecifiers>
+HOST_DEVICE
+  typename detail::subspan_deduction<ElementType,
+                                     Extents,
+                                     LayoutPolicy,
+                                     Accessor,
+                                     SliceSpecifiers...>::type
+subspan(const basic_mdspan<ElementType,Extents,LayoutPolicy,Accessor> &,
+        SliceSpecifiers...) noexcept ;
+
+class all_type { public: constexpr explicit all_type() = default; };
+
+inline constexpr all_type all ;
+
+}}} // std::experimental::fundamentals_v3
+
+//--------------------------------------------------------------------------
+//--------------------------------------------------------------------------
+
+#include <mdspan_helper.hpp>
+
+namespace std {
+namespace experimental {
+namespace fundamentals_v3 {
+
+template< ptrdiff_t ... StaticExtents >
+class extents : private detail::extents_helper<0,StaticExtents...>
+{
+private:
+
+  template< ptrdiff_t... > friend class extents ;
+
+  using helper  = detail::extents_helper<0,StaticExtents...> ;
+
+public:
+
+  using index_type = ptrdiff_t ;
+
+  HOST_DEVICE
+  constexpr extents() noexcept : helper() {}
+
+  HOST_DEVICE
+  constexpr extents( extents && ) noexcept = default ;
+
+  HOST_DEVICE
+  constexpr extents( const extents & ) noexcept = default ;
+
+  template< class ... IndexType >
+  constexpr explicit extents( ptrdiff_t dn,
+                              IndexType ... DynamicExtents ) noexcept
+    : helper( dn , DynamicExtents... ) 
+    { static_assert( 1+sizeof...(DynamicExtents) == helper::RankDynamic ); }
+
+  template<ptrdiff_t... OtherStaticExtents>
+  extents( const extents<OtherStaticExtents...>& other )
+    : helper( (const detail::extents_helper<0,OtherStaticExtents...> &) other ) {}
+
+  HOST_DEVICE
+  extents & operator = ( extents && ) noexcept = default;
+
+  HOST_DEVICE
+  extents & operator = ( const extents & ) noexcept = default;
+
+  template<ptrdiff_t... OtherStaticExtents>
+  extents & operator = ( const extents<OtherStaticExtents...>& other )
+    { helper::operator=( (const detail::extents_helper<0,OtherStaticExtents...> &) other ); return *this ; }
+
+  HOST_DEVICE
+  ~extents() = default ;
+
+  // [mdspan.extents.obs]
+
+  HOST_DEVICE
+  static constexpr size_t rank() noexcept
+    { return sizeof...(StaticExtents); }
+
+  HOST_DEVICE
+  static constexpr size_t rank_dynamic() noexcept 
+    { return helper::RankDynamic ; }
+
+  HOST_DEVICE
+  static constexpr index_type static_extent(size_t k) noexcept
+    { return helper::static_extent(k); }
+
+  HOST_DEVICE
+  constexpr index_type extent(size_t k) const noexcept
+    { return helper::extent(k); }
+
+  // implementation details
+
+  template<size_t K>
+  HOST_DEVICE
+  constexpr index_type extent() const noexcept
+    { return helper::template extent<K>(); }
+
+  HOST_DEVICE constexpr index_type extent() const noexcept
+    { return helper::N ; }
+
+  HOST_DEVICE constexpr const typename helper::next_t & next() const noexcept
+    { return (const typename helper::next_t &) (*this); };
+
+  HOST_DEVICE constexpr index_type product(size_t i, size_t j) const noexcept
+    { return helper::product(i,j); }
+};
+
+//----------------------------------------------------------------------------
+
+template<ptrdiff_t... LHS, ptrdiff_t... RHS>
+HOST_DEVICE
+constexpr bool operator==(const extents<LHS...>& lhs,
+                          const extents<RHS...>& rhs) noexcept
+{
+  bool result = lhs.rank() == rhs.rank();
+  for ( size_t i = 0 ; i < lhs.rank() && ( result = lhs.extent(i) == rhs.extent(i) ); ++i );
+  return result ;
+}
+
+}}} // std::experimental::fundamentals_v3
+
+//--------------------------------------------------------------------------
+//--------------------------------------------------------------------------
+
+namespace std {
+namespace experimental {
+namespace fundamentals_v3 {
+
+struct layout_right {
+
+  template<class Extents>
+  class mapping {
+  private:
+
+    Extents m_extents ;
+
+  public:
+
+    using index_type = ptrdiff_t ;
+
+    HOST_DEVICE
+    constexpr mapping() noexcept = default ;
+
+    HOST_DEVICE
+    constexpr mapping( mapping && ) noexcept = default ;
+
+    HOST_DEVICE
+    constexpr mapping( const mapping & ) noexcept = default ;
+
+    HOST_DEVICE
+    mapping & operator = ( mapping && ) noexcept = default ;
+
+    HOST_DEVICE
+    mapping & operator = ( const mapping & ) noexcept = default ;
+
+    HOST_DEVICE
+    constexpr mapping( const Extents & ext ) noexcept
+      : m_extents( ext ) {}
+
+    constexpr const Extents & extents() const noexcept { return m_extents ; }
+
+    template<class... Indices>
+    constexpr mapping( Indices... DynamicExtents ) noexcept
+      : m_extents( DynamicExtents... ) {}
+
+  private:
+
+    // ( ( ( ( i0 ) * N1 + i1 ) * N2 + i2 ) * N3 + i3 ) ...
+
+    template<class Ext, class ... Indices >
+    static constexpr index_type
+    offset( const Ext & ext,
+            index_type sum,
+            index_type i) noexcept
+      { return sum * ext.extent() + i ; }
+
+    template<class Ext, class ... Indices >
+    static constexpr index_type
+    offset( const Ext & ext,
+            index_type sum,
+            index_type i,
+            Indices... indices ) noexcept
+      {
+        return mapping::offset( ext.next(), sum * ext.extent() + i, indices...);
+      }
+
+  public:
+
+    constexpr index_type required_span_size() const noexcept
+      { return m_extents.product(0,m_extents.rank()); }
+
+    template<class ... Indices >
+    constexpr
+    typename std::enable_if<sizeof...(Indices) == Extents::rank(),index_type>::type
+    operator()( Indices ... indices ) const noexcept
+      { return mapping::offset( m_extents, 0, indices... ); }
+
+/*
+    template<class Index0, class Index1, class Index2 >
+    typename std::enable_if< std::is_integral<Index0>::value &&
+                             std::is_integral<Index1>::value &&
+                             std::is_integral<Index2>::value &&
+                             3 == Extents::rank() , index_type >::type
+    operator()( Index0 i0 , Index1 i1 , Index2 i2 ) const noexcept
+      { return ( ( ( i0 ) * m_extents.template extent<1>() + i1 )
+                          * m_extents.template extent<2>() + i2 ); }
+*/
+
+    static constexpr bool is_always_unique     = true ;
+    static constexpr bool is_always_contiguous = true ;
+    static constexpr bool is_always_strided    = true ;
+
+    constexpr bool is_unique()     const noexcept { return true ; }
+    constexpr bool is_contiguous() const noexcept { return true ; }
+    constexpr bool is_strided()    const noexcept { return true ; }
+
+    constexpr index_type stride(size_t r) const noexcept
+      { return m_extents.product(r+1,m_extents.rank()); }
+
+  }; // struct mapping
+
+}; // struct layout_right
+
+}}} // std::experimental::fundamentals_v3
+
+//----------------------------------------------------------------------------
+
+namespace std {
+namespace experimental {
+namespace fundamentals_v3 {
+
+struct layout_left {
+
+  template<class Extents>
+  class mapping {
+  private:
+
+    Extents m_extents ;
+
+  public:
+
+    using index_type = ptrdiff_t ;
+
+    HOST_DEVICE
+    constexpr mapping() noexcept = default ;
+
+    HOST_DEVICE
+    constexpr mapping( mapping && ) noexcept = default ;
+
+    HOST_DEVICE
+    constexpr mapping( const mapping & ) noexcept = default ;
+
+    HOST_DEVICE
+    mapping & operator = ( mapping && ) noexcept = default ;
+
+    HOST_DEVICE
+    mapping & operator = ( const mapping & ) noexcept = default ;
+
+    HOST_DEVICE
+    constexpr mapping( const Extents & ext ) noexcept
+      : m_extents( ext ) {}
+
+    constexpr const Extents & extents() const noexcept { return m_extents ; }
+
+    template<class... Indices>
+    constexpr mapping( Indices... DynamicExtents ) noexcept
+      : m_extents( DynamicExtents... ) {}
+
+  private:
+
+    // ( i0 + N0 * ( i1 + N1 * ( i2 + N2 * ( ... ) ) ) )
+
+    template<class Ext >
+    HOST_DEVICE
+    static constexpr index_type
+    offset( const Ext & ) noexcept
+      { return 0 ; }
+
+    template<class Ext , class ... IndexType >
+    HOST_DEVICE
+    static constexpr index_type
+    offset( const Ext & ext, index_type i, IndexType... indices ) noexcept
+      { return i + ext.extent() * mapping::offset( ext.next(), indices... ); }
+
+  public:
+
+    constexpr index_type required_span_size() const noexcept
+      { return m_extents.product(0,m_extents.rank()); }
+
+    template<class ... Indices >
+    constexpr
+    typename std::enable_if<sizeof...(Indices) == Extents::rank(),index_type>::type
+    operator()( Indices ... indices ) const noexcept
+      { return mapping::offset( m_extents, indices... ); }
+
+/*
+    template<class Index0, class Index1, class Index2 >
+    typename std::enable_if< std::is_integral<Index0>::value &&
+                             std::is_integral<Index1>::value &&
+                             std::is_integral<Index2>::value &&
+                             3 == Extents::rank() , index_type >::type
+    operator()( Index0 i0 , Index1 i1 , Index2 i2 ) const noexcept
+      { return i0 + m_extents.template extent<0>() * (
+               i1 + m_extents.template extent<1>() * ( i2 ) ); }
+*/
+
+    static constexpr bool is_always_unique     = true ;
+    static constexpr bool is_always_contiguous = true ;
+    static constexpr bool is_always_strided    = true ;
+
+    constexpr bool is_unique()     const noexcept { return true ; }
+    constexpr bool is_contiguous() const noexcept { return true ; }
+    constexpr bool is_strided()    const noexcept { return true ; }
+
+    constexpr index_type stride(size_t r) const noexcept
+      { return m_extents.product(0,r); }
+
+  }; // struct mapping
+
+}; // struct layout_left
+
+}}} // std::experimental::fundamentals_v3
+
+//----------------------------------------------------------------------------
+//----------------------------------------------------------------------------
+
+namespace std {
+namespace experimental {
+namespace fundamentals_v3 {
+
+struct layout_stride {
+
+  template<class Extents>
+  class mapping {
+  private:
+
+    using stride_t = std::array<ptrdiff_t,Extents::rank()> ;
+
+    Extents   m_extents ;
+    stride_t  m_stride ;
+    int       m_contig ;
+    int       m_unique ;
+
+  public:
+
+    using index_type = ptrdiff_t ;
+
+    HOST_DEVICE
+    constexpr mapping() noexcept = default ;
+
+    HOST_DEVICE
+    constexpr mapping( mapping && ) noexcept = default ;
+
+    HOST_DEVICE
+    constexpr mapping( const mapping & ) noexcept = default ;
+
+    HOST_DEVICE
+    mapping & operator = ( mapping && ) noexcept = default ;
+
+    HOST_DEVICE
+    mapping & operator = ( const mapping & ) noexcept = default ;
+
+    HOST_DEVICE
+    mapping( const Extents & ext, const stride_t & str ) noexcept
+      : m_extents(ext), m_stride(str), m_contig(1), m_unique(1)
+      {
+        int p[ Extents::rank() ? Extents::rank() : 1 ];
+
+        // Fill permutation such that
+        //   m_stride[ p[i] ] <= m_stride[ p[i+1] ]
+        //
+        for ( size_t i = 0 ; i < Extents::rank() ; ++i ) {
+
+          int j = i ;
+
+          while ( j && m_stride[i] < m_stride[ p[j-1] ] )
+           { p[j] = p[j-1] ; --j ; }
+
+          p[j] = i ;
+        }
+
+        for ( size_t i = 1 ; i < Extents::rank() ; ++i ) {
+          const int j = p[i-1];
+          const int k = p[i];
+          const index_type prev = m_stride[j] * m_extents.extent(j);
+          if ( m_stride[k] != prev ) { m_contig = 0 ; }
+          if ( m_stride[k] <  prev ) { m_unique = 0 ; }
+        }
+      }
+
+    constexpr const Extents & extents() const noexcept { return m_extents ; }
+
+  private:
+
+    // i0 * N0 + i1 * N1 + i2 * N2 + ...
+
+    template<size_t>
+    HOST_DEVICE
+    constexpr index_type
+    offset() const noexcept
+      { return 0 ; }
+
+    template<size_t K, class... IndexType >
+    HOST_DEVICE
+    constexpr index_type
+    offset( index_type i, IndexType... indices ) const noexcept
+      { return i * m_stride[K] + mapping::template offset<K+1>(indices...); }
+
+  public:
+
+    HOST_DEVICE
+    index_type required_span_size() const noexcept
+      {
+        index_type max = 0 ;
+        for ( size_t i = 0 ; i < Extents::rank() ; ++i )
+          max += m_stride[i] * ( m_extents.extent(i) - 1 );
+        return max ;
+      }
+
+    template<class ... Indices >
+    constexpr
+    typename std::enable_if<sizeof...(Indices) == Extents::rank(),index_type>::type
+    operator()( Indices ... indices ) const noexcept
+      { return mapping::offset( indices... ); }
+
+/*
+    template<class Index0, class Index1, class Index2 >
+    typename std::enable_if< std::is_integral<Index0>::value &&
+                             std::is_integral<Index1>::value &&
+                             std::is_integral<Index2>::value &&
+                             3 == Extents::rank() , index_type >::type
+    operator()( Index0 i0 , Index1 i1 , Index2 i2 ) const noexcept
+      { return i0 * m_stride_t[0] +
+               i1 * m_stride_t[1] +
+               i2 * m_stride_t[2] ; }
+*/
+
+    static constexpr bool is_always_unique     = false ;
+    static constexpr bool is_always_contiguous = false ;
+    static constexpr bool is_always_strided    = true ;
+
+    constexpr bool is_unique()     const noexcept { return m_unique ; }
+    constexpr bool is_contiguous() const noexcept { return m_contig ; }
+    constexpr bool is_strided()    const noexcept { return true ; }
+
+    constexpr index_type stride(size_t r) const noexcept
+      { return m_stride[r]; }
+
+  }; // struct mapping
+
+}; // struct layout_stride
+
+}}} // std::experimental::fundamentals_v3
+
+//--------------------------------------------------------------------------
+//--------------------------------------------------------------------------
+
+namespace std {
+namespace experimental {
+namespace fundamentals_v3 {
+
+class accessor_basic {
+public:
+  template<class T> using pointer_t = T * ;
+  template<class T> using reference_t = T & ;
+};
+
+}}} // std::experimental::fundamentals_v3
+
+//--------------------------------------------------------------------------
+//--------------------------------------------------------------------------
+
+namespace std {
+namespace experimental {
+namespace fundamentals_v3 {
+
+template<class ElementType, class Extents, class LayoutPolicy, class Accessor>
+class basic_mdspan {
+public:
+
+  // Domain and codomain types
+
+  using extents_type     = Extents ;
+  using layout_type      = LayoutPolicy ;
+  using mapping_type     = typename layout_type::template mapping<extents_type> ;
+  using accessor_type    = Accessor ;
+  using element_type     = ElementType ;
+  using value_type       = typename std::remove_cv<element_type>::type ;
+  using index_type       = ptrdiff_t ;
+  using difference_type  = ptrdiff_t ;
+  using pointer          = typename accessor_type::template pointer_t<element_type>;
+  using reference        = typename accessor_type::template reference_t<element_type>;
+
+  // [mdspan.basic.cons]
+
+  HOST_DEVICE
+  constexpr basic_mdspan() noexcept : m_ptr(0), m_map() {}
+
+  HOST_DEVICE
+  constexpr basic_mdspan(basic_mdspan&& other) noexcept = default;
+
+  HOST_DEVICE
+  constexpr basic_mdspan(const basic_mdspan & other) noexcept = default;
+
+  HOST_DEVICE
+  basic_mdspan& operator=(const basic_mdspan & other) noexcept = default;
+
+  HOST_DEVICE
+  basic_mdspan& operator=(basic_mdspan&& other) noexcept = default;
+
+  template<class OtherElementType,
+           class OtherExtents,
+           class OtherLayoutPolicy,
+           class OtherAccessor>
+  constexpr basic_mdspan(
+    const basic_mdspan<OtherElementType,
+                       OtherExtents,
+                       OtherLayoutPolicy,
+                       OtherAccessor> & rhs ) noexcept
+    : m_ptr( rhs.m_ptr )
+    , m_map( rhs.m_map )
+    {}
+
+  template<class OtherElementType,
+           class OtherExtents,
+           class OtherLayoutPolicy,
+           class OtherAccessor>
+  basic_mdspan & operator = (
+    const basic_mdspan<OtherElementType,
+                       OtherExtents,
+                       OtherLayoutPolicy,
+                       OtherAccessor> & rhs ) noexcept
+    { m_ptr = rhs.m_ptr ; m_map = rhs.m_map ; return *this ; }
+
+  template<class... IndexType >
+  explicit constexpr basic_mdspan
+    ( pointer ptr , IndexType ... DynamicExtents ) noexcept
+    : m_ptr(ptr), m_map( DynamicExtents... ) {}
+
+  constexpr basic_mdspan( pointer ptr , const mapping_type & m ) noexcept
+    : m_ptr(ptr), m_map( m ) {}
+
+  // [mdspan.basic.mapping]
+
+  // Enforce rank() <= sizeof...(IndexType)
+  template<class... IndexType >
+  HOST_DEVICE
+  constexpr
+  typename std::enable_if<sizeof...(IndexType)==extents_type::rank(),reference>::type
+  operator()( IndexType... indices) const noexcept
+    { return m_ptr[ m_map( indices... ) ]; }
+
+  // Enforce rank() == 1
+  template<class IndexType >
+  HOST_DEVICE
+  constexpr
+  typename std::enable_if<std::is_integral<IndexType>::value && 1==extents_type::rank(),reference>::type
+  operator[]( IndexType i ) const noexcept
+    { return m_ptr[ m_map(i) ]; }
+
+  // [mdspan.basic.domobs]
+
+  static constexpr int rank() noexcept
+    { return extents_type::rank(); }
+
+  static constexpr int rank_dynamic() noexcept
+    { return extents_type::rank_dynamic(); }
+
+  constexpr index_type static_extent( size_t k ) const noexcept
+    { return m_map.extents().static_extent( k ); }
+
+  constexpr index_type extent( int k ) const noexcept
+    { return m_map.extents().extent( k ); }
+
+  constexpr const extents_type & extents() const noexcept
+    { return m_map.extents(); }
+
+  // [mdspan.basic.codomain]
+
+  // ------------------------------
+  // constexpr span<element_type> span() const noexcept ;
+
+     constexpr pointer span_data() const noexcept { return m_ptr ; }
+
+     constexpr index_type span_size() const noexcept
+       { return m_ptr ? m_map.required_span_size() : 0 ; }
+  // ------------------------------
+
+  // [mdspan.basic.obs]
+
+  static constexpr bool is_always_unique = mapping_type::is_always_unique ;
+  static constexpr bool is_always_regular = mapping_type::is_always_regular ;
+  static constexpr bool is_always_contiguous = mapping_type::is_always_contiguous ;
+
+  HOST_DEVICE
+  constexpr bool is_unique() const noexcept  { return m_map.is_unique(); }
+  HOST_DEVICE
+  constexpr bool is_regular() const noexcept { return m_map.is_regular(); }
+  HOST_DEVICE
+  constexpr bool is_contiguous() const noexcept {return m_map.is_contiguous();}
+
+  HOST_DEVICE
+  constexpr index_type stride( size_t r ) const noexcept
+    { return m_map.stride(r); }
+
+  template<class... IndexType>
+  HOST_DEVICE
+  static constexpr
+  typename std::enable_if<sizeof...(IndexType)==extents_type::rank_dynamic(),index_type>::type
+  required_span_size(IndexType... DynamicExtents) noexcept
+    { return mapping_type(DynamicExtents...).required_span_size(); }
+
+  HOST_DEVICE
+  constexpr const mapping_type & mapping() const noexcept { return m_map ; }
+
+private:
+
+  pointer      m_ptr ;
+  mapping_type m_map ;
+};
+
+template<class T, ptrdiff_t... Indices>
+using mdspan = basic_mdspan<T,extents<Indices...>,layout_right,accessor_basic> ;
+
+}}} // std::experimental::fundamentals_v3
+
+//--------------------------------------------------------------------------
+
+#if 0
+
+namespace std {
+namespace experimental {
+namespace fundamentals_v3 {
+
+template< class MDSPAN , typename ... SliceSpecs >
+mdspan< typename MDSPAN::element_type
+      , typename detail::sub_extents_deduction
+          < typename MDSPAN::properties::extents
+          , SliceSpecs...
+          >::type
+      , layout_stride
+      >
+subspan( MDSPAN const & a , SliceSpecs const & ... slice_specs )
+{
+  typedef typename MDSPAN::properties::extents
+    extents_input ;
+
+  typedef detail::sub_extents_deduction< extents_input , SliceSpecs...  >
+    deduction ;
+
+  typedef typename deduction::type
+    extents_output ;
+
+  typedef
+    mdspan< typename MDSPAN::element_type
+          , extents_output
+          , layout_stride
+          > return_type ;
+
+  constexpr int output_rank = extents_output::rank();
+
+  ptrdiff_t offset = a.offset( detail::slices_begin( slice_specs )... );
+
+  ptrdiff_t dyn[ output_rank ? output_rank : 1 ];
+  ptrdiff_t str[ output_rank ? output_rank : 1 ];
+
+  deduction::get( dyn , str , a , slice_specs... );
+
+  typedef typename
+    detail::mdspan_mapping< extents_output , layout_stride >::type
+      mapping ;
+  
+  return return_type( a.data() + offset , mapping( dyn , str ) );
+}
+
+}}} // std::experimental::fundamentals_v3
+
+#endif /* #if 0 */
+
+//--------------------------------------------------------------------------
+//--------------------------------------------------------------------------
+
+#endif // #ifndef STD_EXPERIMENTAL_MDSPAN_HEADER
+

--- a/P0009/prototype/include/mdspan
+++ b/P0009/prototype/include/mdspan
@@ -39,15 +39,15 @@ class layout_right ;
 class layout_left ;
 class layout_stride ;
 
-// [mdspan.accessor.traits]
-template<class Accessor>
-class accessor_traits;
+// [mdspan.accessor.basic]
+template<class ElementType>
+class accessor_basic;
 
 // [mdspan.basic]
 template<class ElementType,
          class Extents,
          class LayoutPolicy = layout_right,
-         class Accessor = ElementType*>
+         class AccessorPolicy = accessor_basic<ElementType> >
 class basic_mdspan ;
 
 // [msspan.subspan]
@@ -56,7 +56,7 @@ namespace detail {
 template<class ElementType,
          class Extents,
          class LayoutPolicy,
-         class Accessor,
+         class AccessorPolicy,
          class ... SliceSpecifiers>
 class subspan_deduction;
 }
@@ -64,15 +64,15 @@ class subspan_deduction;
 template<class ElementType,
          class Extents,
          class LayoutPolicy,
-         class Accessor,
+         class AccessorPolicy,
          class ... SliceSpecifiers>
 HOST_DEVICE
   typename detail::subspan_deduction<ElementType,
                                      Extents,
                                      LayoutPolicy,
-                                     Accessor,
+                                     AccessorPolicy,
                                      SliceSpecifiers...>::type
-subspan(const basic_mdspan<ElementType,Extents,LayoutPolicy,Accessor> &,
+subspan(const basic_mdspan<ElementType,Extents,LayoutPolicy,AccessorPolicy> &,
         SliceSpecifiers...) noexcept ;
 
 class all_type { public: constexpr explicit all_type() = default; };
@@ -525,25 +525,23 @@ namespace std {
 namespace experimental {
 namespace fundamentals_v3 {
 
-template<class Accessor>
-struct accessor_traits ;
+template<class ElementType>
+struct accessor_basic {
+  using accessor_type = ElementType*;
+	using offset_policy = accessor_basic;
+  using element_type  = ElementType;
+	using reference     = ElementType&;
+	using pointer       = ElementType*;
 
-template<class T>
-struct accessor_traits<T*> {
-  using accessor     = T*;
-  using element_type = T;
-	using pointer      = T*;
-	using reference    = T&;
-	using offset       = T*;
-};
+  static typename offset_policy::accessor_type
+	  offset( accessor_type acc , size_t i ) noexcept
+	    { return acc+i; }
 
-template<class Accessor>
-struct accessor_traits {
-  using accessor     = Accessor ;
-  using element_type = typename accessor::element_type;
-	using pointer      = typename accessor::pointer;
-	using reference    = typename accessor::reference;
-	using offset       = typename accessor::offset;
+  static reference deref( accessor_type acc , size_t i ) noexcept
+	  { return acc[i]; }
+
+  static pointer decay( accessor_type acc ) noexcept
+	  { return acc; }
 };
 
 }}} // std::experimental::fundamentals_v3
@@ -556,7 +554,7 @@ namespace experimental {
 namespace fundamentals_v3 {
 
 template<class T, size_t N>
-class accessor_aligned {
+class aligned_accessor {
 public:
   static_assert( ( 0 == ( N & ( N - 1 ))), "" );
   static_assert( ( 0 == ( N % sizeof(T))), "" );
@@ -568,14 +566,14 @@ public:
 	using pointer      = T*;
 	using offset       = T*;
 
-	constexpr accessor_aligned() noexcept {};
-	constexpr accessor_aligned( const accessor_aligned & ) noexcept = default ;
+	constexpr aligned_accessor() noexcept {};
+	constexpr aligned_accessor( const aligned_accessor & ) noexcept = default ;
 
-	accessor_aligned( accessor_aligned && ) = delete ;
-	accessor_aligned operator = ( accessor_aligned && ) = delete ;
-	accessor_aligned operator = ( const accessor_aligned & ) = delete ;
+	aligned_accessor( aligned_accessor && ) = delete ;
+	aligned_accessor operator = ( aligned_accessor && ) = delete ;
+	aligned_accessor operator = ( const aligned_accessor & ) = delete ;
 
-	explicit accessor_aligned( T * other ) noexcept
+	explicit aligned_accessor( T * other ) noexcept
 		: ptr(other)
 		{
 		  // Verify pointer alignment:
@@ -600,6 +598,25 @@ private:
   T * const ptr = 0 ;
 };
 
+template<class ElementType, size_t N>
+struct aligned_access_policy {
+  using accessor_type  = aligned_accessor<ElementType,N>;
+	using offset_policy  = accessor_basic<ElementType>;
+  using element_type   = typename accessor_type::element_type;
+	using reference      = typename accessor_type::reference;
+	using pointer        = typename accessor_type::pointer;
+
+  static typename offset_policy::accessor_type
+	  offset( const accessor_type & acc , size_t i ) noexcept
+	    { return acc+i; }
+
+  static reference deref( const accessor_type & acc , size_t i ) noexcept
+	  { return acc[i]; }
+
+  static pointer decay( const accessor_type & acc ) noexcept
+	  { return (pointer)acc; }
+};
+
 }}} // std::experimental::fundamentals_v3
 
 //--------------------------------------------------------------------------
@@ -609,7 +626,7 @@ namespace std {
 namespace experimental {
 namespace fundamentals_v3 {
 
-template<class ElementType, class Extents, class LayoutPolicy, class Accessor>
+template<class ElementType, class Extents, class LayoutPolicy, class AccessorPolicy>
 class basic_mdspan {
 public:
 
@@ -617,14 +634,15 @@ public:
 
   using extents_type     = Extents ;
   using layout_type      = LayoutPolicy ;
+  using accessor_type    = AccessorPolicy ;
   using mapping_type     = typename layout_type::template mapping<extents_type> ;
-  using accessor_type    = Accessor ;
-  using element_type     = typename accessor_traits<Accessor>::element_type ;
+  using element_type     = typename accessor_type::element_type ;
   using value_type       = typename std::remove_cv<element_type>::type ;
   using index_type       = ptrdiff_t ;
   using difference_type  = ptrdiff_t ;
-  using pointer          = typename accessor_traits<Accessor>::pointer;
-  using reference        = typename accessor_traits<Accessor>::reference;
+	using access           = typename accessor_type::accessor_type;
+  using pointer          = typename accessor_type::pointer;
+  using reference        = typename accessor_type::reference;
 
   // [mdspan.basic.cons]
 
@@ -750,12 +768,12 @@ public:
 
 private:
 
-  Accessor     m_acc ;
+  access       m_acc ;
   mapping_type m_map ;
 };
 
 template<class T, ptrdiff_t... Indices>
-using mdspan = basic_mdspan<T,extents<Indices...>,layout_right,T*> ;
+using mdspan = basic_mdspan<T,extents<Indices...>,layout_right,accessor_basic<T> > ;
 
 }}} // std::experimental::fundamentals_v3
 

--- a/P0009/prototype/include/mdspan
+++ b/P0009/prototype/include/mdspan
@@ -17,7 +17,7 @@ namespace std {
 namespace experimental {
 namespace fundamentals_v3 {
 
-inline constexpr ptrdiff_t dynamic_extent = -1 ;
+enum : ptrdiff_t { dynamic_extent = -1 };
 
 // [mdspan.extents]
 template< ptrdiff_t ... StaticExtents >
@@ -76,7 +76,7 @@ subspan(const basic_mdspan<ElementType,Extents,LayoutPolicy,Accessor> &,
 
 class all_type { public: constexpr explicit all_type() = default; };
 
-inline constexpr all_type all ;
+/* inline */ constexpr all_type all ;
 
 }}} // std::experimental::fundamentals_v3
 
@@ -115,7 +115,7 @@ public:
   constexpr explicit extents( ptrdiff_t dn,
                               IndexType ... DynamicExtents ) noexcept
     : helper( dn , DynamicExtents... ) 
-    { static_assert( 1+sizeof...(DynamicExtents) == helper::RankDynamic ); }
+    { static_assert( 1+sizeof...(DynamicExtents) == helper::RankDynamic , "" ); }
 
   template<ptrdiff_t... OtherStaticExtents>
   extents( const extents<OtherStaticExtents...>& other )
@@ -154,19 +154,24 @@ public:
 
   // implementation details
 
-  template<size_t K>
-  HOST_DEVICE
-  constexpr index_type extent() const noexcept
-    { return helper::template extent<K>(); }
+    template<size_t K>
+    HOST_DEVICE
+    constexpr index_type extent() const noexcept
+      { return helper::template extent<K>(); }
 
-  HOST_DEVICE constexpr index_type extent() const noexcept
-    { return helper::N ; }
+    HOST_DEVICE constexpr index_type extent() const noexcept
+      { return helper::N ; }
 
-  HOST_DEVICE constexpr const typename helper::next_t & next() const noexcept
-    { return (const typename helper::next_t &) (*this); };
+    HOST_DEVICE constexpr const typename helper::next_t & next() const noexcept
+      { return (const typename helper::next_t &) (*this); };
 
-  HOST_DEVICE constexpr index_type product(size_t i, size_t j) const noexcept
-    { return helper::product(i,j); }
+    HOST_DEVICE constexpr index_type product(size_t i, size_t j) const noexcept
+      { return helper::product(i,j); }
+
+    template<ptrdiff_t... OtherStaticExtents>
+	  HOST_DEVICE constexpr bool
+    equal( const extents<OtherStaticExtents...>& other ) const noexcept
+		  { return rank() == other.rank() && helper::equal( other ); }
 };
 
 //----------------------------------------------------------------------------
@@ -175,11 +180,7 @@ template<ptrdiff_t... LHS, ptrdiff_t... RHS>
 HOST_DEVICE
 constexpr bool operator==(const extents<LHS...>& lhs,
                           const extents<RHS...>& rhs) noexcept
-{
-  bool result = lhs.rank() == rhs.rank();
-  for ( size_t i = 0 ; i < lhs.rank() && ( result = lhs.extent(i) == rhs.extent(i) ); ++i );
-  return result ;
-}
+{ return lhs.equal(rhs); }
 
 }}} // std::experimental::fundamentals_v3
 

--- a/P0009/prototype/include/mdspan
+++ b/P0009/prototype/include/mdspan
@@ -803,7 +803,7 @@ public:
   // ------------------------------
 
   constexpr fundamentals_v3::span<element_type> span() const noexcept
-	  { return fundamentals_v3::span((pointer)m_acc,m_map.extents().extent(0)); }
+	  { return fundamentals_v3::span<element_type>((pointer)m_acc,m_map.extents().extent(0)); }
 
   // ------------------------------
 

--- a/P0009/prototype/include/mdspan_helper.hpp
+++ b/P0009/prototype/include/mdspan_helper.hpp
@@ -58,6 +58,9 @@ public:
 
 	HOST_DEVICE
 	constexpr index_type product(size_t,size_t) const noexcept { return N ; }
+
+	HOST_DEVICE
+	bool equal( const extents_helper & ) const noexcept { return true ; }
 };
 
 // Iteration 'R' of StaticExtents... expansion
@@ -116,7 +119,7 @@ public:
 	  const extents_helper<R,OtherStaticExtents...> & other ) noexcept
 		: val_t( other.N )
 		, next_t( (const typename extents_helper<R,OtherStaticExtents...>::next_t &) other )
-		{ assert( N == other.N ); }
+		{}
 
   template<ptrdiff_t... OtherStaticExtents>
 	HOST_DEVICE
@@ -152,6 +155,11 @@ public:
 	HOST_DEVICE
 	constexpr index_type product(size_t i, size_t j) const noexcept
 	  { return ( i <= R && R < j ? N : 1 ) * next_t::product(i,j); }
+
+  template<ptrdiff_t... OtherStaticExtents>
+	HOST_DEVICE
+	bool equal( const extents_helper<R,OtherStaticExtents...> & other ) const noexcept
+		{ return ( N == other.N ) && ( next().equal( other.next() ) ); }
 };
 
 }}}}
@@ -196,7 +204,7 @@ template<class ElementType,
          class ... SliceSpecifiers>
 struct subspan_deduction {
 
-  static_assert( sizeof...(SliceSpecifiers) == Extents::rank() );
+  static_assert( sizeof...(SliceSpecifiers) == Extents::rank() , "" );
 
 	static constexpr size_t sum() noexcept { return 0 ; }
 

--- a/P0009/prototype/include/mdspan_helper.hpp
+++ b/P0009/prototype/include/mdspan_helper.hpp
@@ -1,0 +1,221 @@
+
+namespace std {
+namespace experimental {
+namespace fundamentals_v3 {
+namespace detail {
+
+template< size_t R , ptrdiff_t StaticExtent >
+struct extent_value
+{
+  enum : ptrdiff_t { N = StaticExtent };
+
+	HOST_DEVICE
+	constexpr extent_value() noexcept {}
+
+	HOST_DEVICE
+	constexpr explicit extent_value( ptrdiff_t ) noexcept {}
+};
+
+template<size_t R >
+struct extent_value<R,dynamic_extent> {
+  ptrdiff_t N ;
+
+	HOST_DEVICE
+	constexpr extent_value() noexcept : N(0) {}
+
+	HOST_DEVICE
+	constexpr explicit extent_value( ptrdiff_t dn ) noexcept : N(dn) {}
+};
+
+template< size_t R , ptrdiff_t ... StaticExtents >
+class extents_helper ;
+
+// End of StaticExtents... expansion
+template< size_t R >
+class extents_helper<R> {
+public:
+  using index_type = ptrdiff_t ;
+  enum : size_t { RankDynamic = 0 };
+  enum : ptrdiff_t { N = 1 };
+
+	HOST_DEVICE
+  static constexpr index_type static_extent( size_t ) noexcept
+	  { return N ; }
+
+	HOST_DEVICE
+  static constexpr index_type extent( size_t ) noexcept
+	  { return N ; }
+
+  template<size_t>
+	HOST_DEVICE
+	constexpr index_type extent() const noexcept { return N ; }
+
+	HOST_DEVICE
+	constexpr index_type extent() const noexcept { return N ; }
+
+	HOST_DEVICE
+  constexpr const extents_helper & next() const noexcept { return *this ; }
+
+	HOST_DEVICE
+	constexpr index_type product(size_t,size_t) const noexcept { return N ; }
+};
+
+// Iteration 'R' of StaticExtents... expansion
+template< size_t R , ptrdiff_t SN , ptrdiff_t ... TailSN >
+class extents_helper<R,SN,TailSN...> 
+  : public extent_value<R,SN>,
+    public extents_helper<R+1,TailSN...> {
+public:
+  using index_type = ptrdiff_t ;
+	using val_t  = extent_value<R,SN>;
+  using next_t = extents_helper<R+1,TailSN...>;
+
+  using val_t::N ;
+
+  enum : size_t { is_dynamic = SN == dynamic_extent ? 1 : 0 };
+  enum : size_t { RankDynamic = next_t::RankDynamic + is_dynamic };
+
+  HOST_DEVICE
+	constexpr extents_helper() noexcept = default ;
+
+  HOST_DEVICE
+	constexpr extents_helper( extents_helper && ) noexcept = default ;
+
+  HOST_DEVICE
+	constexpr extents_helper( const extents_helper & ) noexcept = default ;
+
+  HOST_DEVICE
+  extents_helper & operator = ( extents_helper && ) noexcept = default ;
+
+  HOST_DEVICE
+  extents_helper & operator = ( const extents_helper & ) noexcept = default ;
+
+  // Constructor to peel dynamic extent
+  template<class... TailDN >
+  HOST_DEVICE
+	constexpr extents_helper( std::true_type , index_type dn, TailDN... tail )
+	  : val_t(dn), next_t( tail...)
+		{}
+
+  // Constructor to skip dynamic extent
+  template<class...Indices>
+  HOST_DEVICE
+	constexpr extents_helper( std::false_type , Indices... indices )
+	  : val_t(), next_t( indices...)
+		{}
+
+  // Constructor with dynamic extents
+  template<class... Indices>
+  HOST_DEVICE
+	constexpr extents_helper( ptrdiff_t dn , Indices... indices )
+	  : extents_helper(std::integral_constant<bool,is_dynamic>(), dn, indices... ) {}
+
+  template<ptrdiff_t... OtherStaticExtents>
+	HOST_DEVICE
+	constexpr extents_helper(
+	  const extents_helper<R,OtherStaticExtents...> & other ) noexcept
+		: val_t( other.N )
+		, next_t( (const typename extents_helper<R,OtherStaticExtents...>::next_t &) other )
+		{ assert( N == other.N ); }
+
+  template<ptrdiff_t... OtherStaticExtents>
+	HOST_DEVICE
+	extents_helper & operator = (
+	  const extents_helper<R,OtherStaticExtents...> & other ) noexcept
+		{
+		  val_t::operator=( val_t(other.N) );
+			next_t::operator=( (const typename extents_helper<R,OtherStaticExtents...>::next_t &) other );
+		  assert( N == other.N );
+			return *this ;
+		}
+
+	HOST_DEVICE
+  static constexpr index_type static_extent( size_t k ) noexcept
+	  { return k == 0 ? SN : next_t::static_extent(k-1); }
+
+	HOST_DEVICE
+  constexpr index_type extent( size_t k ) const noexcept
+		{ return k == 0 ? N : next_t::extent(k-1); }
+
+  template<size_t K>
+	HOST_DEVICE
+	constexpr index_type extent() const noexcept
+	  { return K == R ? N : next_t::template extent<K>(); }
+
+	HOST_DEVICE
+	constexpr index_type extent() const noexcept { return N ; }
+
+	HOST_DEVICE
+	constexpr const next_t & next() const noexcept
+	  { return (const next_t &)(*this); }
+
+	HOST_DEVICE
+	constexpr index_type product(size_t i, size_t j) const noexcept
+	  { return ( i <= R && R < j ? N : 1 ) * next_t::product(i,j); }
+};
+
+}}}}
+
+//----------------------------------------------------------------------------
+//----------------------------------------------------------------------------
+
+namespace std {
+namespace experimental {
+namespace fundamentals_v3 {
+namespace detail {
+
+template<size_t R>
+struct extents_dynamic ;
+
+template<>
+struct extents_dynamic<1> {
+  using type = extents<dynamic_extent> ;
+};
+template<>
+struct extents_dynamic<2> {
+  using type = extents<dynamic_extent,dynamic_extent> ;
+};
+template<>
+struct extents_dynamic<3> {
+  using type = extents<dynamic_extent,dynamic_extent,dynamic_extent> ;
+};
+
+template<class Slice, class Enable = void> struct is_slice_range ;
+
+template<class T>
+struct is_slice_range< T, typename std::enable_if< std::is_integral<T>::value >::type > : public std::false_type {};
+
+// assuming size == 2
+template<class T>
+struct is_slice_range< std::initializer_list<T>, typename std::enable_if< std::is_integral<T>::value >::type > : public std::true_type {};
+
+template<class ElementType,
+         class Extents,
+         class LayoutPolicy,
+         class Accessor,
+         class ... SliceSpecifiers>
+struct subspan_deduction {
+
+  static_assert( sizeof...(SliceSpecifiers) == Extents::rank() );
+
+	static constexpr size_t sum() noexcept { return 0 ; }
+
+	template<class... Flag>
+	static constexpr size_t sum( size_t i , Flag... flag ) noexcept
+	  { return i + sum( flag... ); }
+
+  enum : size_t { Rank = sum( is_slice_range<SliceSpecifiers>::value... ) };
+
+  using layout = typename
+	  std::conditional< std::is_same<LayoutPolicy,layout_left>::value ||
+	                    std::is_same<LayoutPolicy,layout_right>::value ||
+	                    std::is_same<LayoutPolicy,layout_stride>::value ,
+										  layout_stride , void >::type ;
+
+	using type = basic_mdspan<ElementType, typename extents_dynamic<Rank>::type, layout, Accessor > ;
+};
+
+
+
+}}}}
+

--- a/P0009/prototype/test/test_mdspan.cpp
+++ b/P0009/prototype/test/test_mdspan.cpp
@@ -123,10 +123,10 @@ void test_accessor()
 {
   using namespace std::experimental::fundamentals_v3 ;
 
-  static_assert( std::is_same<int&,typename accessor_traits<int*>::reference >::value , "" );
+  static_assert( std::is_same<int&,typename accessor_basic<int>::reference >::value , "" );
 
-  using iacc = accessor_aligned<int,8>;
-  using iref = typename accessor_traits<iacc>::reference;
+  using iacc = typename aligned_access_policy<int,8>::accessor_type;
+  using iref = typename aligned_access_policy<int,8>::reference;
 
 	alignas(8) int x = 42 ;
 

--- a/P0009/prototype/test/test_mdspan.cpp
+++ b/P0009/prototype/test/test_mdspan.cpp
@@ -123,10 +123,10 @@ void test_accessor()
 {
   using namespace std::experimental::fundamentals_v3 ;
 
-  static_assert( std::is_same<int&,accessor_reference_t<int*> >::value , "" );
+  static_assert( std::is_same<int&,typename accessor_traits<int*>::reference >::value , "" );
 
   using iacc = accessor_aligned<int,8>;
-  using iref = accessor_reference_t<iacc>;
+  using iref = typename accessor_traits<iacc>::reference;
 
 	alignas(8) int x = 42 ;
 

--- a/P0009/prototype/test/test_mdspan.cpp
+++ b/P0009/prototype/test/test_mdspan.cpp
@@ -123,11 +123,15 @@ void test_accessor()
 {
   using namespace std::experimental::fundamentals_v3 ;
 
-  using iptr = accessor_basic::pointer_t<int> ;
-  using iref = accessor_basic::reference_t<int> ;
+  static_assert( std::is_same<int*,accessor_pointer_t<int*> >::value , "" );
+  static_assert( std::is_same<int&,accessor_reference_t<int*> >::value , "" );
 
-	int x = 42 ;
-	iptr px = & x ;
+  using iacc = accessor_aligned<int,8>;
+  using iref = accessor_reference_t<iacc>;
+
+	alignas(8) int x = 42 ;
+
+	iacc px( & x );
 	iref rx = x ;
 
 	assert( px[0] == 42 );

--- a/P0009/prototype/test/test_mdspan.cpp
+++ b/P0009/prototype/test/test_mdspan.cpp
@@ -1,0 +1,192 @@
+
+#include <iostream>
+#include <mdspan>
+
+void test_extents()
+{
+  using namespace std::experimental::fundamentals_v3 ;
+
+  {
+    constexpr extents<2,4,8> exA ;
+
+    static_assert( exA.rank() == 3 );
+    static_assert( exA.rank_dynamic() == 0 );
+	  static_assert( exA.static_extent(0) == 2 , "" );
+	  static_assert( exA.static_extent(1) == 4 , "" );
+	  static_assert( exA.static_extent(2) == 8 , "" );
+	  static_assert( exA.extent(0) == 2 , "" );
+	  static_assert( exA.extent(1) == 4 , "" );
+	  static_assert( exA.extent(2) == 8 , "" );
+	}
+
+  {
+    constexpr extents<2,dynamic_extent,dynamic_extent> exB(4,8);
+
+    static_assert( exB.rank() == 3 );
+    static_assert( exB.rank_dynamic() == 2 );
+	  static_assert( exB.static_extent(0) == 2 , "" );
+	  static_assert( exB.static_extent(1) == dynamic_extent , "" );
+	  static_assert( exB.static_extent(2) == dynamic_extent , "" );
+	  static_assert( exB.extent(0) == 2 , "" );
+	  static_assert( exB.extent(1) == 4 , "" );
+	  static_assert( exB.extent(2) == 8 , "" );
+	}
+
+  {
+    constexpr extents<2,dynamic_extent,dynamic_extent> exC ;
+
+    static_assert( exC.rank() == 3 );
+    static_assert( exC.rank_dynamic() == 2 );
+	  static_assert( exC.static_extent(0) == 2 , "" );
+	  static_assert( exC.static_extent(1) == dynamic_extent , "" );
+	  static_assert( exC.static_extent(2) == dynamic_extent , "" );
+	  static_assert( exC.extent(0) == 2 , "" );
+	  static_assert( exC.extent(1) == 0 , "" );
+	  static_assert( exC.extent(2) == 0 , "" );
+	}
+
+  {
+    constexpr extents<2,4,8> exA ;
+    const extents<2,dynamic_extent,dynamic_extent> exB(exA);
+
+    std::cout << "{ " << exB.extent(0) 
+              << " , " << exB.extent(1) 
+              << " , " << exB.extent(2) 
+              << " ; " << exB.extent(3) 
+              << " , " << exB.extent(3) 
+              << " , " << exB.extent(4) 
+							<< " }" << std::endl ;
+
+    static_assert( exB.rank() == 3 );
+    static_assert( exB.rank_dynamic() == 2 );
+	  static_assert( exB.static_extent(0) == 2 , "" );
+	  static_assert( exB.static_extent(1) == dynamic_extent , "" );
+	  static_assert( exB.static_extent(2) == dynamic_extent , "" );
+	  assert( exB.extent(0) == 2 );
+	  assert( exB.extent(1) == 4 );
+	  assert( exB.extent(2) == 8 );
+	}
+}
+
+void test_layout()
+{
+  using namespace std::experimental::fundamentals_v3 ;
+
+  {
+	  using ext = extents<2,dynamic_extent,dynamic_extent>;
+		using lmap = typename layout_right::template mapping< ext > ;
+
+		constexpr ext exB(4,8);
+		constexpr lmap lb( exB );
+
+    static_assert( lb.extents() == exB );
+    static_assert( lb.is_always_unique );
+    static_assert( lb.is_always_contiguous );
+    static_assert( lb.is_always_strided );
+		static_assert( lb.required_span_size() == exB.extent(0) * exB.extent(1) * exB.extent(2) );
+
+		static_assert( lb.stride(0) == exB.extent(1) * exB.extent(2) );
+		static_assert( lb.stride(1) == exB.extent(2) );
+		static_assert( lb.stride(2) == 1 );
+    
+		static_assert( lb(0,0,0) == 0 );
+		static_assert( lb(0,0,1) == lb.stride(2) );
+		static_assert( lb(0,1,0) == lb.stride(1) );
+		static_assert( lb(1,0,0) == lb.stride(0) );
+	}
+
+  {
+	  using ext = extents<2,dynamic_extent,dynamic_extent>;
+		using lmap = typename layout_left::template mapping< ext > ;
+
+		constexpr ext exB(4,8);
+		constexpr lmap lb( exB );
+
+    static_assert( lb.extents() == exB );
+    static_assert( lb.is_always_unique );
+    static_assert( lb.is_always_contiguous );
+    static_assert( lb.is_always_strided );
+		static_assert( lb.required_span_size() == exB.extent(0) * exB.extent(1) * exB.extent(2) );
+
+		static_assert( lb.stride(0) == 1 );
+		static_assert( lb.stride(1) == exB.extent(0) );
+		static_assert( lb.stride(2) == exB.extent(0) * exB.extent(1) );
+    
+		static_assert( lb(0,0,0) == 0 );
+		static_assert( lb(1,0,0) == lb.stride(0) );
+		static_assert( lb(0,1,0) == lb.stride(1) );
+		static_assert( lb(0,0,1) == lb.stride(2) );
+	}
+}
+
+void test_accessor()
+{
+  using namespace std::experimental::fundamentals_v3 ;
+
+  using iptr = accessor_basic::pointer_t<int> ;
+  using iref = accessor_basic::reference_t<int> ;
+
+	int x = 42 ;
+	iptr px = & x ;
+	iref rx = x ;
+
+	assert( px[0] == 42 );
+	assert( rx == 42 );
+}
+
+void test_mdspan()
+{
+  using namespace std::experimental::fundamentals_v3 ;
+
+  {
+    using imd_t = mdspan<int,2,dynamic_extent,dynamic_extent> ;
+
+    enum : size_t { LEN = imd_t::required_span_size(4,8) };
+ 
+    int buffer[ LEN ] = {0};
+
+	  imd_t imd( buffer , 4 , 8 );
+
+    int val = 0 ;
+    for ( int k = 0 ; k < imd.extent(2) ; ++k )
+    for ( int j = 0 ; j < imd.extent(1) ; ++j )
+    for ( int i = 0 ; i < imd.extent(0) ; ++i )
+	    imd(i,j,k) = val++ ;
+
+	  std::cout << std::endl << "right{" ;
+	  for ( size_t i = 0 ; i < LEN ; ++i )
+	    std::cout << " " << buffer[i];
+	  std::cout << " }" << std::endl ;
+	}
+
+  {
+    using imd_t = basic_mdspan<int,extents<2,dynamic_extent,dynamic_extent>,layout_left> ;
+
+    enum : size_t { LEN = imd_t::required_span_size(4,8) };
+ 
+    int buffer[ LEN ] = {0};
+
+	  imd_t imd( buffer , 4 , 8 );
+
+    int val = 0 ;
+    for ( int k = 0 ; k < imd.extent(2) ; ++k )
+    for ( int j = 0 ; j < imd.extent(1) ; ++j )
+    for ( int i = 0 ; i < imd.extent(0) ; ++i )
+	    imd(i,j,k) = val++ ;
+
+	  std::cout << std::endl << "left{" ;
+	  for ( size_t i = 0 ; i < LEN ; ++i )
+	    std::cout << " " << buffer[i];
+	  std::cout << " }" << std::endl ;
+	}
+}
+
+int main()
+{
+  test_extents();
+  test_layout();
+	test_accessor();
+	test_mdspan();
+	return 0 ;
+}
+

--- a/P0009/prototype/test/test_mdspan.cpp
+++ b/P0009/prototype/test/test_mdspan.cpp
@@ -123,7 +123,6 @@ void test_accessor()
 {
   using namespace std::experimental::fundamentals_v3 ;
 
-  static_assert( std::is_same<int*,accessor_pointer_t<int*> >::value , "" );
   static_assert( std::is_same<int&,accessor_reference_t<int*> >::value , "" );
 
   using iacc = accessor_aligned<int,8>;

--- a/P0009/prototype/test/test_mdspan.cpp
+++ b/P0009/prototype/test/test_mdspan.cpp
@@ -9,8 +9,8 @@ void test_extents()
   {
     constexpr extents<2,4,8> exA ;
 
-    static_assert( exA.rank() == 3 );
-    static_assert( exA.rank_dynamic() == 0 );
+    static_assert( exA.rank() == 3 , "" );
+    static_assert( exA.rank_dynamic() == 0 , "" );
 	  static_assert( exA.static_extent(0) == 2 , "" );
 	  static_assert( exA.static_extent(1) == 4 , "" );
 	  static_assert( exA.static_extent(2) == 8 , "" );
@@ -22,8 +22,8 @@ void test_extents()
   {
     constexpr extents<2,dynamic_extent,dynamic_extent> exB(4,8);
 
-    static_assert( exB.rank() == 3 );
-    static_assert( exB.rank_dynamic() == 2 );
+    static_assert( exB.rank() == 3 , "" );
+    static_assert( exB.rank_dynamic() == 2 , "" );
 	  static_assert( exB.static_extent(0) == 2 , "" );
 	  static_assert( exB.static_extent(1) == dynamic_extent , "" );
 	  static_assert( exB.static_extent(2) == dynamic_extent , "" );
@@ -35,8 +35,8 @@ void test_extents()
   {
     constexpr extents<2,dynamic_extent,dynamic_extent> exC ;
 
-    static_assert( exC.rank() == 3 );
-    static_assert( exC.rank_dynamic() == 2 );
+    static_assert( exC.rank() == 3 , "" );
+    static_assert( exC.rank_dynamic() == 2 , "" );
 	  static_assert( exC.static_extent(0) == 2 , "" );
 	  static_assert( exC.static_extent(1) == dynamic_extent , "" );
 	  static_assert( exC.static_extent(2) == dynamic_extent , "" );
@@ -57,8 +57,8 @@ void test_extents()
               << " , " << exB.extent(4) 
 							<< " }" << std::endl ;
 
-    static_assert( exB.rank() == 3 );
-    static_assert( exB.rank_dynamic() == 2 );
+    static_assert( exB.rank() == 3 , "" );
+    static_assert( exB.rank_dynamic() == 2 , "" );
 	  static_assert( exB.static_extent(0) == 2 , "" );
 	  static_assert( exB.static_extent(1) == dynamic_extent , "" );
 	  static_assert( exB.static_extent(2) == dynamic_extent , "" );
@@ -79,20 +79,20 @@ void test_layout()
 		constexpr ext exB(4,8);
 		constexpr lmap lb( exB );
 
-    static_assert( lb.extents() == exB );
-    static_assert( lb.is_always_unique );
-    static_assert( lb.is_always_contiguous );
-    static_assert( lb.is_always_strided );
-		static_assert( lb.required_span_size() == exB.extent(0) * exB.extent(1) * exB.extent(2) );
+    assert( lb.extents() == exB );
+    static_assert( lb.is_always_unique , "" );
+    static_assert( lb.is_always_contiguous , "" );
+    static_assert( lb.is_always_strided , "" );
+		static_assert( lb.required_span_size() == exB.extent(0) * exB.extent(1) * exB.extent(2) , "" );
 
-		static_assert( lb.stride(0) == exB.extent(1) * exB.extent(2) );
-		static_assert( lb.stride(1) == exB.extent(2) );
-		static_assert( lb.stride(2) == 1 );
+		static_assert( lb.stride(0) == exB.extent(1) * exB.extent(2) , "" );
+		static_assert( lb.stride(1) == exB.extent(2) , "" );
+		static_assert( lb.stride(2) == 1 , "" );
     
-		static_assert( lb(0,0,0) == 0 );
-		static_assert( lb(0,0,1) == lb.stride(2) );
-		static_assert( lb(0,1,0) == lb.stride(1) );
-		static_assert( lb(1,0,0) == lb.stride(0) );
+		static_assert( lb(0,0,0) == 0 , "" );
+		static_assert( lb(0,0,1) == lb.stride(2) , "" );
+		static_assert( lb(0,1,0) == lb.stride(1) , "" );
+		static_assert( lb(1,0,0) == lb.stride(0) , "" );
 	}
 
   {
@@ -102,20 +102,20 @@ void test_layout()
 		constexpr ext exB(4,8);
 		constexpr lmap lb( exB );
 
-    static_assert( lb.extents() == exB );
-    static_assert( lb.is_always_unique );
-    static_assert( lb.is_always_contiguous );
-    static_assert( lb.is_always_strided );
-		static_assert( lb.required_span_size() == exB.extent(0) * exB.extent(1) * exB.extent(2) );
+    assert( lb.extents() == exB );
+    static_assert( lb.is_always_unique , "" );
+    static_assert( lb.is_always_contiguous , "" );
+    static_assert( lb.is_always_strided , "" );
+		static_assert( lb.required_span_size() == exB.extent(0) * exB.extent(1) * exB.extent(2) , "" );
 
-		static_assert( lb.stride(0) == 1 );
-		static_assert( lb.stride(1) == exB.extent(0) );
-		static_assert( lb.stride(2) == exB.extent(0) * exB.extent(1) );
+		static_assert( lb.stride(0) == 1 , "" );
+		static_assert( lb.stride(1) == exB.extent(0) , "" );
+		static_assert( lb.stride(2) == exB.extent(0) * exB.extent(1) , "" );
     
-		static_assert( lb(0,0,0) == 0 );
-		static_assert( lb(1,0,0) == lb.stride(0) );
-		static_assert( lb(0,1,0) == lb.stride(1) );
-		static_assert( lb(0,0,1) == lb.stride(2) );
+		static_assert( lb(0,0,0) == 0 , "" );
+		static_assert( lb(1,0,0) == lb.stride(0) , "" );
+		static_assert( lb(0,1,0) == lb.stride(1) , "" );
+		static_assert( lb(0,0,1) == lb.stride(2) , "" );
 	}
 }
 

--- a/P0009/prototype/test/test_mdspan.cpp
+++ b/P0009/prototype/test/test_mdspan.cpp
@@ -125,7 +125,7 @@ void test_accessor()
 
   static_assert( std::is_same<int&,typename accessor_basic<int>::reference >::value , "" );
 
-  using iacc = typename aligned_access_policy<int,8>::accessor_type;
+  using iacc = typename aligned_access_policy<int,8>::handle_type;
   using iref = typename aligned_access_policy<int,8>::reference;
 
 	alignas(8) int x = 42 ;


### PR DESCRIPTION
Introduce beginnings of prototype / reference implementation based upon updating prior prototypes to new wording.  
Adjust wording based upon prototyping experience.
Non-trivial change to the `Accessor` to allow a non-template `Accessor` class to denote access properties independent of the element type.