### PR TITLE
Make a template parameter uniform by using int everywhere

### DIFF
--- a/P0009/reference-implementation/include/extents.hpp
+++ b/P0009/reference-implementation/include/extents.hpp
@@ -68,7 +68,7 @@ namespace detail {
     }
   };
 
-  template< size_t R, ptrdiff_t ... StaticExtents >
+  template< int R, ptrdiff_t ... StaticExtents >
   struct extents_analyse<R,dynamic_extent,StaticExtents...> {
     typedef extents_analyse<R-1,StaticExtents...> next_extents_analyse;
 


### PR DESCRIPTION
This fix this error with g++-8:

.../cpp-proposals-pub/P0009/reference-implementation/include/extents.hpp:72:10: error: template argument ‘(int)R’ involves template parameter(s)
   struct extents_analyse<R,dynamic_extent,StaticExtents...> {
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~