### PR TITLE
P0009r8: Math-ify mdspan.subspan; clean up accessor policy; fix #71

### DIFF
--- a/P0009/P0009.bs
+++ b/P0009/P0009.bs
@@ -2459,19 +2459,31 @@ and is implementation defined.
 The `SliceSpecifier` parameters indicate the subset that the return value references.
 <br/>
 
-Define `slices_tuple` as `auto slices_tuple = forward_as_tuple(slices...);`. <br/>
-Define `first[r]` as follows: <br/>
-    * If `slices_tuple.get<r>()` is convertible to `ptrdiff_t`, then `first[r]` equals `slices_tuple.get<r>()`. <br/>
-    * Otherwise, if `slices_tuple.get<r>()` is convertible to `pair<ptrdiff_t,ptrdiff_t>`,
-      then `first[r]` equals `pair<ptrdiff_t,ptrdiff_t>(slices_tuple.get<r>()).first`. <br/>
-    * Otherwise, if `slices_tuple.get<r>()` is convertible to `all_type`, then `first[r]` equals `0`. <br/>
-Define `last[r]` as follows: <br/>
-    * If `slices_tuple.get<r>()` is convertible to `ptrdiff_t`,
-      then `last[r]` equals `slices_tuple.get<r>()+1`. <br/>
-    * Otherwise, if `slices_tuple.get<r>()` is convertible to `pair<ptrdiff_t,ptrdiff_t>`,
-      then `last[r]` equals `pair<ptrdiff_t,ptrdiff_t>(slices_tuple.get<r>()).second`. <br/>
-    * Otherwise, if `slices_tuple.get<r>()` is convertible to `all_type`,
-      then `last[r]` equals `src.extent(r)`. <br/>
+<pre highlight="c++">
+  auto slices_tuple = forward_as_tuple(slices...);
+  array<ptrdiff_t, sizeof...(slices)> first;
+  array<ptrdiff_t, sizeof...(slices)> last;
+  for(size_t r=0; r&lt;sizeof...(slices); r++) {
+    if constexpr (is_convertible_v<decltype(slices_tuple.get<r>()), ptrdiff_t>) {
+      first[r] = slices_tuple.get<r>();
+      last[r] = first[r] + 1;
+    }
+    else if constexpr (is_convertible_v<decltype(slices_tuple.get<r>()), pair<ptrdiff_t,ptrdiff_t>>) {
+      const pair<ptrdiff_t, ptrdiff_t> slices_r = slices_tuple.get<r>();
+      first[r] = slices_r.first;
+      last[r] = slices_r.second;      
+    }
+    else if constexpr (is_convertible_v<slices_tuple.get<r>(), all_type>) {
+      first[r] = 0;
+      last[r] = src.extent(r);
+    }
+    else {
+      // <i>emit an implementation-defined diagnostic</i>
+      static_assert(false);
+    }
+  }
+</pre>
+
 Define `R[K]` as follows: <br/>
 <pre highlight="c++">
   size_t k = 0;

--- a/P0009/P0009.bs
+++ b/P0009/P0009.bs
@@ -1108,12 +1108,12 @@ Table � — Layout mapping policy and layout mapping requirements
 <tr>
   <td>`m.is_strided()`</td>
   <td>`bool`</td>
-  <td>*Returns:* `true` if there exists an integer <math>s<sub>r</sub></math>
+  <td>*Returns:* `true` if there exists an integer <math>&sigma;<sub>r</sub></math>
        such that, for all `j...` and `i...` in `e`,
        if all members of `j...` and `i...` are equal
        except for exactly one r-th member where
        <math>j<sub>r</sub></math> equals <math>i<sub>r</sub></math> + 1, 
-       then `m(j...) - m(i...)` equals <math>s<sub>r</sub></math>.</td>
+       then `m(j...) - m(i...)` equals <math>&sigma;<sub>r</sub></math>.</td>
   <td></td>
 </tr>
 <tr>
@@ -1137,8 +1137,8 @@ Table � — Layout mapping policy and layout mapping requirements
 <tr>
   <td>`m.stride(r)`</td>
   <td>`E::index_type`</td>
-  <td>*Returns:* <math>s<sub>r</sub></math>, as defined for `m.is_strided()` above.
-      We say that <math>s<sub>r</sub></math> is the *stride* of ordinate `r`. </td>
+  <td>*Returns:* <math>&sigma;<sub>r</sub></math>, as defined for `m.is_strided()` above.
+      We say that <math>&sigma;<sub>r</sub></math> is the *stride* of ordinate `r`. </td>
   <td>*Requires:* `m.is_strided()` is `true`. </td>
 </tr>
 </table>

--- a/P0009/P0009.bs
+++ b/P0009/P0009.bs
@@ -1903,7 +1903,7 @@ Table �: Accessor policy requirements
 <tr>
   <td>`A::offset_policy`</td>
   <td></td>
-  <td>Accessor policy which can access a pointer that has been return by `a.offset(p,i)`.</td>
+  <td>Accessor policy which can access a pointer that has been returned by `a.offset(p,i)`.</td>
 </tr>
 <tr>
   <td>`a.decay(p)`</td>
@@ -1913,12 +1913,12 @@ Table �: Accessor policy requirements
 <tr>
   <td>`a.access(p,i)`</td>
   <td>`A::reference`</td>
-  <td>*Returns:* An object which provides access to the `i`*th* element in the contiguous set.</td>
+  <td>*Returns:* An object which provides access to the `i`-th element in the contiguous set.</td>
 </tr>
 <tr>
   <td>`a.offset(p,i)`</td>
   <td>`A::offset_policy::pointer`</td>
-  <td>*Returns:* A pointer for the contiguous span of elements offset by `i`.  *Requires:* `A::decay(p)+i == A::offset_policy::decay(A::offset(p,i))`.</td>
+  <td>*Returns:* A pointer to the contiguous span of elements offset by `i`.  *Requires:* `A::decay(p)+i` equals `A::offset_policy::decay(A::offset(p,i))`.</td>
 </tr>
 </table>
 
@@ -2583,15 +2583,46 @@ The `SliceSpecifier` template argument(s)
 and the corresponding value(s) of the arguments of `subspan` after `src`
 determine the subset of `src` that the return value views.
 
-Define the exposition-only `array`s `first`, `last`, and `R` as 
+Define the exposition-only function `mdspan_subspan_fill_first_and_last` as follows:
 
 <pre highlight="c++">
-template&lt;class ... SliceSpecifier>
-void first_last_and_R (array&lt;ptrdiff_t, sizeof...(SliceSpecifier)>& first,
-                       array&lt;ptrdiff_t, sizeof...(SliceSpecifier)>& last,
-                       array&lt;ptrdiff_t, sizeof...(SliceSpecifier)>& R,
-		       SliceSpecifier... slices)
+template&lt;class... SliceSpecifier, size_t r>
+constexpr void mdspan_subspan_fill_first_and_last(
+  array&lt;ptrdiff_t, sizeof...(SliceSpecifier)>& first,
+  array&lt;ptrdiff_t, sizeof...(SliceSpecifier)>& last,
+  SliceSpecifier... slices)
 {
+  auto slices_tuple = forward_as_tuple(slices...);
+  using cur_type = decltype(slices_tuple.get&lt;r>());
+
+  if constexpr (is_convertible_v&lt;cur_type, ptrdiff_t>) {
+    first[r] = slices_tuple.get&lt;r>();
+    last[r] = first[r] + 1;
+  }
+  else if constexpr (is_convertible_v&lt;cur_type, pair&lt;ptrdiff_t, ptrdiff_t>>) {
+    const pair&lt;ptrdiff_t, ptrdiff_t> slices_r = slices_tuple.get&lt;r>();
+    first[r] = slices_r.first;
+    last[r] = slices_r.second;
+  }
+  else if constexpr (is_convertible_v&lt;cur_type, all_type>) {
+    first[r] = 0;
+    last[r] = src.extent(r);
+  }
+}
+</pre>
+
+Define the exposition-only struct `mdspan_subspan_first_and_last` as follows:
+
+Let `first` and `last` be exposition-only 
+`array<ptrdiff_t, sizeof...(SliceSpecifier)`.
+Define `first` and `last` as in the following code:
+
+Let `R` be an exposition-only
+`array<ptrdiff_t, mdspan_subspan_rank_v<SliceSpecifier...>>`.
+Define `R` as in the following code:
+
+
+<pre highlight="c++">
   constexpr size_t result_rank = mdspan_subspan_rank_v(slices...);
   constexpr size_t num_args = sizeof...(SliceSpecifier);
   
@@ -2620,7 +2651,17 @@ void first_last_and_R (array&lt;ptrdiff_t, sizeof...(SliceSpecifier)>& first,
 
 </pre>
 
+*[Note:* The code above is not a suggested implementation. *— end note]*
+
+
 Let `sub` be the return value of `subspan(src, slices...)`.
+Let &rho; equal `sub.rank()`.
+Denote the value of the <math>k</math>-th member of `slices...`
+by <math>s<sub>k</sub></math>.
+If `i...` is a pack of integers other than `slices...`,
+then denote the value of the
+<math>k</math>-th member of `i...` by <math>i<sub>k</sub></math>.
+We say that the integer r "is not in `R`" when, for 0 <= k < &rho;, r &ne; `R[k]`.
 
 * *Requires:*
     * `sizeof(slices...)` equals `src.rank()`.
@@ -2631,18 +2672,27 @@ Let `sub` be the return value of `subspan(src, slices...)`.
       `is_convertible_v<T, ptrdiff_t> || is_convertible_v<T, pair<ptrdiff_t, ptrdiff_t>> || is_convertible_v<T, all_type>` is `true`.
 * *Ensures:*
     * `mdspan_subspan<ElementType, Extents, LayoutPolicy, AccessorPolicy, SliceSpecifiers...>::extents_t::rank()` equals `result_rank`.
-    * Let `I...` be a multi-index such that `I[k] < sub.extents(k)` and
-      `J...` be a multi-index where `J[R[k]]=first[R[k]]+I[k]` or `J[r]=first[r]` for `r` not in `R`.
-      Then, `sub(I...)` and `src(J...)` refer to the same element.
+    * Let the pack `i...` denote a multi-index in the domain of `sub`
+      such that i<sub>k</sub></math> < `sub.extents(k)` for 0 <= `k` < &rho;.
+      Let the pack `j...` denote a multi-index in the domain of `src` where
+      <math>j<sub>`R[k]`</sub></math> equals `first[R[k]]` + <math>i<sub>k</sub></math>
+      for 0 <= `k` < <math>&rho;</math>, 
+      and <math>j<sub>r</sub></math> equals `first[r]`
+      for all `r` such that 0 <= `r` < `src.rank()` and `r` is not in `R`.
+      Then, `sub(i...)` and `src(j...)` refer to the same element.
     * `sub.extent(k)` equals `last[R[k]] - first[R[k]]`.
     * If `src.is_strided()`, then `sub.is_strided()` is `true` and
       `sub.stride(k)` equals `src.stride(R[k])`.
-    * If `src.static_extent(R[k])` does not equal `dynamic_extent` and
+    * Let `slices_tuple` equal `forward_as_tuple(slices...)`.
+      For all 0 <= k < &rho;, 
+      if `src.static_extent(R[k])` does not equal `dynamic_extent` and
       `is_convertible_v<decltype(slices_tuple.get<R[k]>()), all_type>` is `true`,
       then `sub.static_extent(k)` equals `src.static_extent(R[k])`.
+      *[Note:* `R[k]` is a `constexpr` integer. *— end note]*
+
 <br/>
 
-* Examples:
+*[Note:* Example of `subspan` use:
 
 ```c++
 // Create a mapping
@@ -2675,7 +2725,7 @@ for(int i0=0; i0<a_sub.extent(0); i0++) {
 10501 10502 10503 10504 10505
 */
 ```
-
+*- end note]*
 
 
 

--- a/P0009/P0009.bs
+++ b/P0009/P0009.bs
@@ -1845,32 +1845,33 @@ template<class OtherExtents>
 <b>26.7.� Accessor Policy [mdspan.accessor]</b>
 
 An *accessor policy* defines types and operations by which
-a contiguous set of objects of type *ElementType* are accessed. 
+a contiguous set of objects of a particular type are accessed. 
 
 <br/>
 <b>26.7.�.1 Accessor policy requirements [mdspan.accessor.reqs]</b>
 
-An accessor policy defines
-a type through which a single element is accessed,
-a type through which the contiguous set of elements is accessed, 
-and the following operations:
-  * Access to elements in a subscripting-like **[expr.sub]** way,
-  * Conversion to a pointer **[conv.array]**, and
-  * Offsetting a pointer.
+An accessor policy defines:
 
-The access operation returns an object that gives access to the indexed element.
-The type of this object need not necessarily be `T&`.
-The offset operation returns an object that gives access to the contiguous subset of elements beginning at the offset value; 
-the returned object need not necessarily have the same type as the object giving access to the original contiguous set of elements.
+    * a handle to a single element of type `element_type`;
+    * a handle to a contiguous set of elements of type `element_type`, 
+      accessible only through the policy's `access` function;
+    * conversion of a handle to a contiguous set of elements, 
+      to a pointer **[conv.array]**; and
+    * getting a handle to the contiguous subset of elements 
+      beginning at an integer offset value.
+
+*[Note:* The type of `reference` need not be `element_type&`. 
+  The type of `pointer` need not be `element_type*`. *— end note]* 
+
 The constructor of the object representing the contiguous set of objects
 may impose additional restrictions on the contiguous set of objects, 
-such as restricting `T` to be trivially copyable or 
-requiring a larger alignment than `alignment_of_v<T>`.
+such as restricting `element_type` to be trivially copyable or 
+requiring a larger alignment than `alignment_of_v<element_type>`.
 
 In Table �:
   * `A` denotes an accessor policy.
   * `a` denotes an object of type `A`.
-  * `p` denotes an object of type `typename A::pointer`.
+  * `p` denotes an object of type `A::pointer`.
   * `i` denotes a `ptrdiff_t` value.
 
 Table �: Accessor policy requirements
@@ -1878,12 +1879,12 @@ Table �: Accessor policy requirements
 <tr>
   <th>Expression</th>
   <th>Return Type</th>
-  <th>Requirements/Notes</th>
+  <th>Notes/Returns/Requires</th>
 </tr>
 <tr>
   <td>`A::element_type`</td>
   <td></td>
-  <td>Type of elements accessed</td>
+  <td>Type of each element in the contiguous set of elements.</td>
 </tr>
 <tr>
   <td>`A::pointer`</td>
@@ -1895,12 +1896,14 @@ Table �: Accessor policy requirements
 <tr>
   <td>`A::reference`</td>
   <td></td>
-  <td>Type through which an element is accessed</td>
+  <td>Type through which an element is accessed. </td>
 </tr>
 <tr>
   <td>`A::offset_policy`</td>
   <td></td>
-  <td>Accessor policy which can access a pointer that has been returned by `a.offset(p,i)`.</td>
+  <td>Accessor policy for accessing a pointer returned by `a.offset(p,i)`. 
+      *Requires:* `A::offset_policy` meets the requirements of an accessor policy in Table �.
+  </td>
 </tr>
 <tr>
   <td>`a.decay(p)`</td>
@@ -1910,7 +1913,7 @@ Table �: Accessor policy requirements
 <tr>
   <td>`a.access(p,i)`</td>
   <td>`A::reference`</td>
-  <td>*Returns:* An object which provides access to the `i`-th element in the contiguous set.</td>
+  <td>*Returns:* An object which provides access to the `i`-th element in the contiguous set of elements. </td>
 </tr>
 <tr>
   <td>`a.offset(p,i)`</td>

--- a/P0009/P0009.bs
+++ b/P0009/P0009.bs
@@ -842,7 +842,7 @@ public:
   template&lt;ptrdiff_t... OtherExtents>
   constexpr extents& operator=(const extents&lt;OtherExtents...>& other);
 
-  // [mdspan.extents.obs], Observers of the domain multi-index space
+  // [mdspan.extents.obs], Observers of the domain multidimensional index space
   static constexpr size_t rank() noexcept;
   static constexpr size_t rank_dynamic() noexcept;
   static constexpr index_type static_extent(size_t) noexcept;
@@ -900,49 +900,50 @@ constexpr extents(const extents<OtherExtents...>& other);
 
 <br/>
 
-<!-- TODO BELOW HERE -->
-
 ```c++
 template<class... IndexType>
 constexpr extents(IndexType... dynamic_extents) noexcept;
 ```
 
-<!-- TODO look at how parameter pack expansions are specified in, e.g., integer_sequence -->
-
-* *Requires:* `((dynamic_extents>=0) && ...)`
-* *Effects:* Aggregate-initializes `dynamic_extents_` to `{dynamic_extents...}`
-* *Postconditions:* `extent(`*DynamicRank[i]*`)` is equal to the *i*th entry in the parameter pack `dynamic_extents`
-* *Remarks:* This constructor shall not participate in overload resolution unless:
-    + `(is_convertible_v<IndexType, index_type> && ...)`
-    + and `sizeof...(dynamic_extents)==rank_dynamic()`
+* *Requires:* `((dynamic_extents>=0) && ...)` is `true`.
+* *Constraints:* `(is_convertible_v<IndexType, index_type> && ...) && sizeof...(dynamic_extents)==rank_dynamic()` is `true`.
+* *Effects:* Aggregate-initializes `dynamic_extents_` to `{dynamic_extents...}`.
+* *Ensures:* `extent(`*DynamicRank[i]*`)` is equal to the *i*th entry in the parameter pack `dynamic_extents`.
 
 ```c++
 template<class IndexType, size_t rank_dynamic>
 constexpr extents(const array<IndexType, rank_dynamic> & dynamic_extents) noexcept;
 ```
 
-* *Requires:* `dynamic_extents[i]>=0` for all `i` where 0 <= `i` < `rank_dynamic()`
-* *Effects:* Initializes `dynamic_extents_` with `dynamic_extents`
-* *Postconditions:* `extent(`*DynamicRank[i]*`)` is equal to `dynamic_extents[i]`
-* *Remarks:* This constructor shall not participate in overload resolution unless:
-    + `is_convertible_v<IndexType, index_type>`
+* *Requires:* Let <math>D</math> equal `rank_dynamic()`.
+             <math>&forall; `i` &isin; [0, D)</math>, 
+             `dynamic_extents[i] >= 0` is `true`.
+* *Constraints:* `is_convertible_v<IndexType, index_type>` is `true`.
+* *Effects:* Initializes `dynamic_extents_` with `dynamic_extents`.
+* *Ensures:* `extent(`*DynamicRank[i]*`)` equals `dynamic_extents[i]`.
 
 ```c++
 template<ptrdiff_t... OtherExtents>
 constexpr extents& operator=(const extents<OtherExtents...>& other);
 ```
 
-* *Requires:* For each `r` in the range `[0, rank())`, `static_extent(r) != dynamic_extent || static_extent(r) == other.extent(r)` is `true`.
-* *Effects:* For each `r` in the range `[0, rank())`, if `static_extent(r)` equals `dynamic_extent`, assigns `dynamic_extents_[`*DynamicRank[*`r`*]*`]` to `other.extent(r)`.
-* *Throws:* Nothing.
-* *Postconditions:* `*this==other`
+* *Requires:* Let <math>R</math> equal `rank()`.
+              <math>&forall; `r` &isin; [0, R)</math>, 
+              `static_extent(r) != dynamic_extent || static_extent(r) == other.extent(r)` is `true`.
+* *Constraints:* `sizeof...(Extents)==sizeof...(OtherExtents)` is `true`.
+* *Effects:* Let <math>R</math> equal `rank()`.
+              <math>&forall; `r` &isin; [0, R)</math>,
+             if `static_extent(r)` equals `dynamic_extent`, 
+             assigns `dynamic_extents_[`*DynamicRank[*`r`*]*`]` to `other.extent(r)`.
+* *Ensures:* `*this==other`.
 * *Returns:* `*this`.
-* *Remarks:* This constructor shall not participate in overload resolution unless `sizeof...(Extents)==sizeof...(OtherExtents)`.
+* *Throws:* Nothing.
 
+<!-- TODO FIX EASY STUFF BELOW HERE -->
 <br/>
 
 <br/>
-<b>26.7.�.3 Observers of the domain multi-index space [mdspan.extents.obs]</b>
+<b>26.7.�.3 Observers of the domain multidimensional index space [mdspan.extents.obs]</b>
 
 <br/>
 ```c++
@@ -1020,9 +1021,9 @@ template<ptrdiff_t... LHS, ptrdiff_t... RHS>
 4. In Table �:
     * `MP` denotes a layout mapping policy.
     * `E` denotes a specialization of `extents`.
-    * `e` denotes an object of type `E` defining a domain multi-index space.
+    * `e` denotes an object of type `E` defining a domain multidimensional index space.
     * `r` is a value of an integral type such that 0 <= `r` < `e.rank()`.
-    * `i...` and `j...` are packs of an integer type denoting values in the multi-index space `e`, the `r`*th member of packs `i...` and `j...` are denoted by `i[r]` and `j[r]`, and `sizeof...(i)==E::rank()`, 0 <= `i[r]` < `e.extent(r)`, `sizeof...(j)==E::rank()`, and 0 <= `j[r]` < `e.extent(r)`.
+    * `i...` and `j...` are packs of an integer type denoting values in the multidimensional index space `e`, the `r`*th member of packs `i...` and `j...` are denoted by `i[r]` and `j[r]`, and `sizeof...(i)==E::rank()`, 0 <= `i[r]` < `e.extent(r)`, `sizeof...(j)==E::rank()`, and 0 <= `j[r]` < `e.extent(r)`.
     * `M` denotes a layout mapping class.
     * `m` denotes an object of type `M` that maps a multi-index `i...` to an integral value.
 
@@ -1990,7 +1991,7 @@ public:
     constexpr reference operator()(const array&lt;IndexType, N>& indices) const noexcept;
   accessor_type accessor() const;
 
-  // [mdspan.basic.domobs], basic_mdspan observers of the domain multi-index space
+  // [mdspan.basic.domobs], basic_mdspan observers of the domain multidimensional index space
   static constexpr int rank() noexcept;
   static constexpr int rank_dynamic() noexcept;
   static constexpr index_type static_extent(size_t) noexcept;
@@ -2263,7 +2264,7 @@ accessor_type accessor() const;
 
 -->
 <br/>
-<b>26.7.�.3 `basic_mdspan` observers of the domain multi-index space [mdspan.basic.domobs]</b>
+<b>26.7.�.3 `basic_mdspan` observers of the domain multidimensional index space [mdspan.basic.domobs]</b>
 
 ```c++
 static constexpr int rank() noexcept;

--- a/P0009/P0009.bs
+++ b/P0009/P0009.bs
@@ -2002,6 +2002,7 @@ public:
 
   // [mdspan.basic.codomain], basic_mdspan observers of the codomain
   constexpr span&lt;element_type> span() const noexcept;
+  constexpr pointer data() const noexcept;
 
   // [mdspan.basic.obs], basic_mdspan observers of the mapping
   static constexpr bool is_always_unique() noexcept;
@@ -2335,6 +2336,11 @@ constexpr span<element_type> span() const noexcept;
 
 * *Returns:* `std::span<element_type>(acc_.decay(ptr_),required_span_size())`.
 
+```c++
+constexpr pointer data() const noexcept;
+```
+
+* *Returns:* `ptr_`.
 
 <!--
 

--- a/P0009/P0009.bs
+++ b/P0009/P0009.bs
@@ -768,9 +768,6 @@ namespace fundamentals_v3 {
     constexpr bool operator!=(const extents&lt;LHS...>& lhs, const extents&lt;RHS...>& rhs) noexcept;
 
   // [mdspan.subspan], subspan creation
-  template&lt;class ... Args>
-  constexpr size_t mdspan_subspan_rank_v = <i>see below</i>;<i> // exposition only</i>
-
   template&lt;class ElementType, class Extents, class LayoutPolicy,
            class AccessorPolicy, class... SliceSpecifiers>
   struct mdspan_subspan { // <i>exposition only</i>
@@ -2512,10 +2509,6 @@ namespace experimental {
 namespace fundamentals_v3 {
 
   // [mdspan.subspan], subspan creation
-  template&lt;class ... Args>
-  constexpr size_t mdspan_subspan_rank_v =
-    <i>see below</i>;<i> // exposition only</i>
-
   template&lt;class ElementType, class Extents, class LayoutPolicy,
            class AccessorPolicy, class... SliceSpecifiers>
   struct mdspan_subspan { // <i>exposition only</i>
@@ -2542,30 +2535,30 @@ namespace fundamentals_v3 {
 }}}
 </pre>
 
-The exposition-only metafunction `mdspan_subspan_rank_v`,
-specifies the rank of the `basic_mdspan` returned by `subspan`.
-Define `mdspan_subspan_rank_v` as follows:
+The `subspan` function creates a `basic_mdspan` that is a view
+of a (potentially trivial) subset of another `basic_mdspan`.
+The `SliceSpecifier` template argument(s)
+and the corresponding value(s) of the arguments of `subspan` after `src`
+determine the subset of `src` that the return value views.
 
-<pre highlight="c++">
-  template&lt;class ... Args>
-  struct mdspan_subspan_rank;
+Let `sub` be the return value of `subspan(src, slices...)`.
+Denote the value of the <math>k</math>-th member of `slices...`
+by <math>s<sub>k</sub></math>.
+Denote the type of the <math>k</math>-th member of `slices...`
+by <math>S<sub>k</sub></math>.
 
-  template&lt;class First, class ... Rest>
-  struct mdspan_subspan_rank&lt;First, Rest...> {
-    constexpr size_t value =
-      ((is_convertible_v&lt;First, pair&lt;ptrdiff_t, ptrdiff_t>> ||
-        is_convertible_v&lt;First, all_type>) ? 1 : 0) +
-      mdspan_subspan_rank&lt;Rest...>::value;
-  };
-  
-  template&lt;>
-  struct mdspan_subspan_rank&lt;> {
-    constexpr size_t value = 0;
-  };
+Let &rho; be `sub.rank()`.
+&rho; equals the number of `k`
+such that `is_convertible_v<`<math>S<sub>k</sub></math>`, pair<ptrdiff_t, ptrdiff_t>> || is_convertible_v<`<math>S<sub>k</sub></math>`, all_type>` is `true`.
 
-  template&lt;class ... Args>
-  constexpr size_t mdspan_subspan_rank_v = mdspan_subspan_rank&lt;Args...>::value;
-</pre>
+Define `rank_map` as the length &rho; `std::integer_sequence` of `ptrdiff_t`
+consisting of the unique values of `k`, in increasing order, such that
+`is_convertible_v<`<math>S<sub>k</sub></math>`, pair<ptrdiff_t, ptrdiff_t>> || is_convertible_v<`<math>S<sub>k</sub></math>`, all_type>` is `true`.
+Define the exposition-only `constexpr` function `get_seq<k>(seq)`,
+where `k` is an integer,
+as the function returning the `k`-th entry of the `std::integer_sequence` `seq`.
+We say that the integer r "is not in `rank_map`" when,
+for 0 <= `k` < &rho;, r does not equal `get_seq<k>(rank_map)`.
 
 In the exposition-only `struct mdspan_subspan`,
 
@@ -2577,117 +2570,42 @@ In the exposition-only `struct mdspan_subspan`,
       and is implementation defined; and
     * The `type` type alias specifies the type returned by `subspan`.
 
-The `subspan` function creates a `basic_mdspan` that is a view
-of a (potentially trivial) subset of another `basic_mdspan`.
-The `SliceSpecifier` template argument(s)
-and the corresponding value(s) of the arguments of `subspan` after `src`
-determine the subset of `src` that the return value views.
+*[Note:* High-quality implementations will avoid `layout_stride` whenever possible,
+if the input layout is `layout_left` or `layout_right`. *— end note]* 
 
-<!-- TODO add `mdspan_subspan_compute_bounds` to synopsis (2x above) -->
+Let `first` and `last` be exposition-only `array<ptrdiff_t, sizeof...(SliceSpecifier)>`,
+where `SliceSpecifier...` is the same parameter pack as `subspan`'s.
+For 0 <= `r` < `sizeof...(SliceSpecifier)`,
+define the values of `first[r]` and `last[r]` as follows,
+where `src` and `slices...` are the arguments of `subspan`.
 
-Define the exposition-only function `mdspan_subspan_compute_bounds` as follows:
-
-<pre highlight="c++">
-template&lt;class ElementType, class Extents, class LayoutPolicy,
-	 class AccessorPolicy, size_t N, size_t r,
-	 class... SliceSpecifiers>
-struct mdspan_subspan_compute_bounds_impl {};
-
-template&lt;class ElementType, class Extents, class LayoutPolicy,
-	 class AccessorPolicy, size_t N, size_t r>
-struct mdspan_subspan_compute_bounds_impl&lt;ElementType, Extents, LayoutPolicy,
-                                          AccessorPolicy, N, r>
-{
-  using array_type = array&lt;ptrdiff_t, N>;
-  using mdspan_type = basic_mdspan&lt;ElementType, Extents, LayoutPolicy,
-				   AccessorPolicy>;
-  static void run (array_type& first, array_type& last, const mdspan_type&) {}
-};
-
-template&lt;class ElementType, class Extents, class LayoutPolicy,
-	 class AccessorPolicy, size_t N, size_t r,
-	 class HeadSliceSpecifier, class... TailSliceSpecifiers>
-struct mdspan_subspan_compute_bounds_impl&lt;ElementType, Extents, LayoutPolicy,
-                                          AccessorPolicy, N, r, HeadSliceSpecifier,
-                                          TailSliceSpecifiers...>
-{
-  using array_type = array&lt;ptrdiff_t, N>;
-  using mdspan_type = basic_mdspan&lt;ElementType, Extents, LayoutPolicy,
-				   AccessorPolicy>;
-  static void run (array_type& first, array_type& last, const mdspan_type& src,
-		   HeadSliceSpecifier head, TailSliceSpecifiers... tail)
-  {
-    if constexpr (is_convertible_v&lt;HeadSliceSpecifier, ptrdiff_t>) {
-      first[r] = head;
-      last[r] = first[r] + 1;
-    }
-    else if constexpr (is_convertible_v&lt;HeadSliceSpecifier,
-		                        pair&lt;ptrdiff_t, ptrdiff_t>>) {
-      const pair&lt;ptrdiff_t, ptrdiff_t> cur_bounds = head;
-      first[r] = cur_bounds.first;
-      last[r] = cur_bounds.second;
-    }
-    else if constexpr (is_convertible_v&lt;HeadSliceSpecifier, all_type>) {
-      first[r] = 0;
-      last[r] = src.extent(r);
-    }
-
-    using recurse_type =
-      mdspan_subspan_compute_bounds_impl&lt;ElementType, Extents, LayoutPolicy,
-					 AccessorPolicy, N, r+1,
-					 TailSliceSpecifiers...>;
-    recurse_type::run (first, last, src, tail...);
-  }
-};
-
-template&lt;class ElementType, class Extents, class LayoutPolicy,
-	 class AccessorPolicy, class... SliceSpecifier>
-void mdspan_subspan_compute_bounds (array&lt;ptrdiff_t, sizeof...(SliceSpecifier)>& first,
-				    array&lt;ptrdiff_t, sizeof...(SliceSpecifier)>& last,
-				    const basic_mdspan&lt;ElementType, Extents, LayoutPolicy, AccessorPolicy>& src,
-				    SliceSpecifier... slices)
-{
-  constexpr size_t N = sizeof...(SliceSpecifier);
-  constexpr size_t r = 0;
-  using impl_type =
-    mdspan_subspan_compute_bounds_impl&lt;ElementType, Extents, LayoutPolicy,
-				       AccessorPolicy, N, r, SliceSpecifier...>;
-  impl_type::run (first, last, src, slices...);
-}
-</pre>
-
-Let `first` and `last` be exposition-only `array<ptrdiff_t, sizeof...(SliceSpecifier)>`, computed as if in the code that follows, where `src` and `slices...` are the arguments given to `subspan`:
-<pre highlight="c++">
-array&lt;ptrdiff_t, sizeof...(SliceSpecifier)>> first;
-array&lt;ptrdiff_t, sizeof...(SliceSpecifier)>> last;
-mdspan_subspan_compute_bounds (first, last, src, slices...);
-</pre>
+    * If `is_convertible_v<`<math>S<sub>`r`</sub></math>`, ptrdiff_t>`, 
+      then `first[r]` equals <math>s<sub>`r`</sub></math>, and
+      `last[r]` equals `first[r]` + 1;
+    * Else, if `is_convertible_v<`<math>S<sub>`r`</sub></math>`, pair<ptrdiff_t, ptrdiff_t>>`,
+      then `first[r]` equals `p.first`, and `last[r]` equals `p.second`,
+      where `p` is the result of converting <math>s<sub>`r`</sub></math>
+      to `pair<ptrdiff_t, ptrdiff_t>`;
+    * Else, if `is_convertible_v<`<math>S<sub>`r`</sub></math>`, all_type>`,
+      then `first[r] = 0`, and `last[r]` equals `src.extent(r)`.
 
 If `i...` is a pack of integers other than `slices...`,
 then denote the value of the
 <math>k</math>-th member of `i...` by <math>i<sub>k</sub></math>.
 
-Let &rho; equal `sub.rank()`.
-
-Denote the value of the <math>k</math>-th member of `slices...`
-by <math>s<sub>k</sub></math>.
-
-Define `rank_map` as the length &rho; `std::integer_sequence` of `ptrdiff_t` consisting of all k such that `is_convertible_v<`<math>s<sub>k</sub></math>`, pair<ptrdiff_t, ptrdiff_t>> || is_convertible_v<`<math>s<sub>k</sub></math>`, all_type>` is `true`.
-
-Define the exposition-only `constexpr` function `get_seq<k>(seq)` as the function returning the `k`-th entry of the `std::integer_sequence` `seq`.
-
-We say that the integer r "is not in `rank_map`" when,
-for 0 <= `k` < &rho;, r does not equal `get_seq<k>(rank_map)`.
-
-Let `sub` be the return value of `subspan(src, slices...)`.
-
 * *Requires:*
     * `sizeof(slices...)` equals `src.rank()`.
-    * For all `r` in 0, 1, ..., `sizeof...(slices)-1`,
+    * For 0 <= `r` < `sizeof...(slices)`,
       `0 <= first[r] && first[r] < last[r] && last[r] <= src.extent(r)` is `true`.
 * *Constraints:*
-    * For all types `T` in the parameter pack `SliceSpecifiers...`,
-      `is_convertible_v<T, ptrdiff_t> || is_convertible_v<T, pair<ptrdiff_t, ptrdiff_t>> || is_convertible_v<T, all_type>` is `true`.
+    * `LayoutPolicy` is `layout_left`, `layout_right`, `layout_stride`,
+       or any type in a possibly empty set of implementation-defined types,
+       each of which meets the requirements of a layout mapping policy
+       **[mdspan.layout.reqs]**.
+       *[Note:* Valid and useful layout mapping policies exist,
+       for which taking an arbitrary `subspan` does not make sense. *— end note]* 
+    * For 0 <= `k` < `sizeof...(slices)`,
+      `is_convertible_v<`<math>S<sub>k</sub></math>`, ptrdiff_t> || is_convertible_v<`<math>S<sub>k</sub></math>`, pair<ptrdiff_t, ptrdiff_t>> || is_convertible_v<`<math>S<sub>k</sub></math>`, all_type>` is `true`.
 * *Ensures:*
     * `mdspan_subspan<ElementType, Extents, LayoutPolicy, AccessorPolicy, SliceSpecifiers...>::extents_t::rank()` equals &rho;.
     * Let the pack `i...` denote a multi-index in the domain of `sub`
@@ -2699,17 +2617,16 @@ Let `sub` be the return value of `subspan(src, slices...)`.
       and <math>j<sub>r</sub></math> equals `first[r]`
       for all `r` such that 0 <= `r` < `src.rank()` and `r` is not in `rank_map`.
       Then, `sub(i...)` and `src(j...)` refer to the same element.
-    * `sub.extent(k)` equals
+    * For 0 <= `k` < &rho;, `sub.extent(k)` equals
       `last[get_seq<k>(rank_map)] - first[get_seq<k>(rank_map)]`.
-    * If `src.is_strided()`, then `sub.is_strided()` is `true` and
+    * If `src.is_strided()`, then `sub.is_strided()` is `true`,
+      and for 0 <= `k` < &rho;,
       `sub.stride(k)` equals `src.stride(get_seq<k>(rank_map))`.
-    * Let `slices_tuple` equal `forward_as_tuple(slices...)`.
-      For all 0 <= `k` < &rho;, 
-      if `src.static_extent(get_seq<k>(rank_map))` does not equal
-      `dynamic_extent` and
-      `is_convertible_v<decltype(slices_tuple.get<get_seq<k>(rank_map)>()), all_type>` is `true`,
-      then `sub.static_extent(k)` equals
-      `src.static_extent(get_seq<k>(rank_map))`.
+    * For 0 <= `k` < &rho;,
+      let `rmk` equal `get_seq<k>(rank_map)`; then,
+      if `src.static_extent(rmk)` does not equal `dynamic_extent` and
+      `is_convertible_v<`<math>S<sub>`rmk`</sub></math>`, all_type>` is `true`,
+      then `sub.static_extent(k)` equals `src.static_extent(rmk)`.
 
 <br/>
 

--- a/P0009/P0009.bs
+++ b/P0009/P0009.bs
@@ -935,7 +935,7 @@ constexpr extents& operator=(const extents<OtherExtents...>& other);
               <math>&forall; `r` &isin; [0, R)</math>,
              if `static_extent(r)` equals `dynamic_extent`, 
              assigns `dynamic_extents_[`*DynamicRank[*`r`*]*`]` to `other.extent(r)`.
-* *Ensures:* `*this==other`.
+* *Ensures:* `*this==other` is `true`.
 * *Returns:* `*this`.
 * *Throws:* Nothing.
 
@@ -1282,21 +1282,20 @@ template<class... Indices>
   typename Extents::index_type operator()(Indices... i) const;
 ```
 
-Let `i[k]` denote the `k`*th* member of `i...`.
+* *Constraints:* 
+    * `sizeof...(Indices)==extents().rank()` is `true`, and
+    * `is_convertible_v<Indices, typename Extents::index_type> && ...` is `true`.
+* *Returns:* The sum of <math>i<sub>k</sub></math> * `stride(k)` for 0 <= k < `extents.rank()`, where <math>i<sub>k</sub></math> denotes the k-th member of `i...`, and the sum of zero terms is zero.
 
-* *Constraints:* `sizeof...(Indices)==extents().rank() && (is_convertible_v<Indices, typename Extents::index_type> && ...)` is `true`.
-* *Returns:* Equivalent to `offset` in
-
+<!--
+* *Returns:* Equivalent to `offset` in the following:
 ```
 Extents::index_type offset = 0 ;
 for(size_t k=0; k<extents.rank(); ++k) 
-  offset += i[k]*stride(k);
+  offset += i_k * stride(k);
 ```
+-->
 
-
-
-```
-```
 
 <br/>
 ```c++
@@ -1508,16 +1507,21 @@ template<class... Indices>
   typename Extents::index_type operator()(Indices... i) const noexcept;
 ```
 
+* *Constraints:* 
+    * `sizeof...(Indices)==extents().rank()` is `true`, and
+    * `is_convertible_v<Indices, typename Extents::index_type> && ...` is `true`.
+* *Returns:* The sum of <math>i<sub>k</sub></math> * `stride(k)` for 0 <= k < `Extents::rank()`, where <math>i<sub>k</sub></math> denotes the k-th member of `i...`, and the sum of zero terms is zero.
+
+<!--
 Let `i[k]` denote the `k`*th* member of `i...`.
 
-* *Constraints:* `sizeof...(Indices)==extents().rank() && (is_convertible_v<Indices, typename Extents::index_type> && ...)` is `true`.
 * *Returns:* Equivalent to `offset` in
-
 ```
 index_type offset = 0;
 for(size_t k=0; k<Extents::rank(); ++k) 
   offset += i[k]*stride(k);
 ```
+-->
 
 <br/>
 
@@ -1670,10 +1674,12 @@ constexpr mapping(mapping&& other) noexcept;
 constexpr mapping(Extents e, array<typename Extents::index_type, Extents::rank()> s) noexcept;
 ```
 * *Requires:*
-   + `s[i]>0` for 0 < `i` <= `Extents::rank()`
-   + There exists a permutation `o(i)` of the numbers `0`, ..., `Extents::rank()-1` 
-     with 0 <= `i` < `Extents::rank()` such that
-     `s(o(i))>=s(o(i-1))*e.extent(o(i-1))` for 1 <= `i` < `Extents::rank()`. <!-- FIXME CODE TO MATH -->
+    * `s[i]>0` is `true` for 0 < `i` <= `Extents::rank()`.
+    * If `Extents::rank()` is nonzero, then there exists a permutation `o(i)` 
+      of the integers `0`, ..., `Extents::rank()-1` 
+      with 0 <= `i` < `Extents::rank()` such that
+      `s(o(i))>=s(o(i-1))*e.extent(o(i-1))` is `true` 
+      for 1 <= `i` < `Extents::rank()`. <!-- FIXME CODE TO MATH -->
 * *Effects:* Initializes `extents_` with `e` and `strides_` with `s`.
 * *Ensures:* `extents()==e && strides()==s` is `true`.
 * *Throws:* Nothing.
@@ -1711,8 +1717,8 @@ template <class... Indices>
   typename Extents::index_type operator()(Indices... i) const noexcept;
 ```
 * *Constraints:*
-  * `sizeof...(Indices)==Extents::rank()` is `true`, and
-  * `is_convertible_v<Indices, typename Extents::index_type> && ...` is `true`.
+    * `sizeof...(Indices)==Extents::rank()` is `true`, and
+    * `is_convertible_v<Indices, typename Extents::index_type> && ...` is `true`.
 * *Returns:* If `i...` is `i0, i1, i2`, ..., `ik` (where `k==Extents::rank() - 1` is `true`) and `s` is `strides()`, returns `i0*s[1]+i1*s[2]+`...`+ik*s[k]`. <!-- FIXME CODE TO MATH -->
 
 
@@ -1733,7 +1739,7 @@ static constexpr bool is_always_contiguous() noexcept;
 ```c++
 constexpr bool is_contiguous() const noexcept;
 ```
-* *Returns:* `true` if there is a permutation `o(i)` of the numbers `0`, ..., `Extents::rank()-1` with 0 <= `i` < `Extents::rank()` such that `min(stride(o(i))==1` is `true` and `stride(o(i))==stride(o(i-1))*extents().extent(o(i-1))` with 1 <= `i` < `Extents::rank()`.  Otherwise, returns `false`. <!-- FIXME CODE TO MATH -->
+* *Returns:* `true` if there is a permutation `o(i)` of the numbers `0`, ..., `Extents::rank()-1` with 0 <= `i` < `Extents::rank()` such that `min(stride(o(i))==1` is `true` and `stride(o(i))==stride(o(i-1))*extents().extent(o(i-1))` with 1 <= `i` < `Extents::rank()`.  Otherwise, returns `false`. <!-- FIXME CODE TO MATH --> <!-- FIXME what if zero length? -->
 
 ```c++
 typename Extents::index_type stride(size_t r) const noexcept;
@@ -2503,26 +2509,7 @@ The `SliceSpecifier` parameters indicate the subset that the return value refere
 <br/>
 
 <pre highlight="c++">
-  template&lt;class ... Args>
-  struct mdspan_subspan_rank;
-
-  template&lt;class First, class ... Rest>
-  struct mdspan_subspan_rank&lt;First, Rest...> {
-    constexpr size_t value =
-      (is_convertible_v<First, pair&lt;ptrdiff_t, ptrdiff_t>> ||
-       is_convertible_v<First, all_type> ? 1 : 0) +
-      mdspan_subspan_rank<Rest...>::value;
-  };
-  
-  template&lt;>
-  struct mdspan_subspan_rank&lt;> {
-    constexpr size_t value = 0;
-  };
-
-  template&lt;class ... Args>
-  constexpr size_t mdspan_subspan_rank_v = mdspan_subspan_rank<Args...>::value;
-
-  constexpr size_t result_rank = slices_result_rank(slices...);
+  constexpr size_t result_rank = mdspan_subspan_rank_v(slices...);
 
   auto slices_tuple = forward_as_tuple(slices...);
   array&lt;ptrdiff_t, sizeof...(slices)> first;
@@ -2548,10 +2535,6 @@ The `SliceSpecifier` parameters indicate the subset that the return value refere
       last[r] = src.extent(r);
       R[current_R_position++] = r;      
     }
-    else {
-      // <i>emit an implementation-defined diagnostic</i>
-      static_assert(false);
-    }
   }
 
 </pre>
@@ -2560,22 +2543,20 @@ Let `sub` be the return value of `subspan(src, slices...)`,
 and let `E` be `mdspan_subspan<ElementType, Extents, LayoutPolicy, AccessorPolicy, SliceSpecifiers...>::extents_t`.
 <br/>
 
-Requires: <br/>
-    * `sizeof(slices...)` equals `src.rank()`. <br/>
+* *Requires:*
+    * `sizeof(slices...)` equals `src.rank()`.
     * For all `r` in `0`, `1`, ..., `sizeof...(slices)-1`,
       `0 <= first[r] && first[r] < last[r] && last[r] <= src.extent(r)` is `true`.
-
-Mandates: <br/>
+* *Constraints:*
     * For all types `T` in the parameter pack `SliceSpecifiers...`,
-      `is_convertible_v<T, ptrdiff_t> || is_convertible_v<T, pair<ptrdiff_t, ptrdiff_t>> || is_convertible_v<T, all_type>` is `true`. <br/>
-
-Ensures: <br/>
-    * `E::rank()` equals `result_rank`. <br/>
+      `is_convertible_v<T, ptrdiff_t> || is_convertible_v<T, pair<ptrdiff_t, ptrdiff_t>> || is_convertible_v<T, all_type>` is `true`.
+* *Ensures:*
+    * `E::rank()` equals `result_rank`.
     * Let `I...` be a multi-index such that `I[k] < sub.extents(k)` and
       `J...` be a multi-index where `J[R[k]]=first[R[k]]+I[k]` or `J[r]=first[r]` for `r` not in `R`.
       Then, `sub(I...)` and `src(J...)` refer to the same element.
     * `sub.extent(k)` equals `last[R[k]] - first[R[k]]`.
-    * If `src.is_strided()`, then `sub.is_strided()` and `sub.stride(k)` equals `src.stride(R[k])`. <br/>
+    * If `src.is_strided()`, then `sub.is_strided()` and `sub.stride(k)` equals `src.stride(R[k])`.
     * If `src.static_extent(R[k])` does not equal `dynamic_extent` and
       `is_convertible_v<decltype(slices_tuple.get<R[k]>()), all_type>` is `true`,
       then `sub.static_extent(k)` equals `src.static_extent(R[k])`.

--- a/P0009/P0009.bs
+++ b/P0009/P0009.bs
@@ -647,10 +647,10 @@ as of \[N4750](http://wg21.link/n4750).
 The � character is used to denote a placeholder section number, table number,
 or paragraph number which the editor shall determine.
 
-Add the header `<mdspan>` to table 16 in **[headers]**.  
+Add the header `<mdspan>` to the "C++ library headers" table in **[headers]**.  
 
-Add the header `<mdspan>` to Table 76 in 26.1 **[containers.general]** below
-the listing for `<span>`.
+Add the header `<mdspan>` to the "Containers library summary" table in
+**[containers.general]** below the listing for `<span>`.
 
 <!--
 
@@ -671,35 +671,37 @@ Wording
 =======
 
 <blockquote>
-Text in blockquotes is not proposed wording
+Text in blockquotes is not proposed wording.
 
 The � character is used to denote a placeholder section number which the editor
 shall determine.
 </blockquote>
 
 <blockquote>
-Copy **[views]** *subclause (currently 26.7 in n4750)* which contains
-the wording for `span` and `dynamic_extent` which is needed for `basic_mdspan` 
+Copy the entire **[views]** subclause from the current draft, since it is
+needed for `basic_mdspan`.
 </blockquote>
 
 ---
 
 <br/>
-*Add the following paragraphs to* **[views.general]*:
+*Add the following paragraphs to* **[views.general]**:
 
 �. The header `<mdspan>` defines the view `basic_mdspan`, the type alias `mdspan`, 
-and other facilities for interacting with these views.  
-The `basic_mdspan` class template maps a multi-index within a multi-index *domain*
-to a reference an element in the *codomain* `span`.
+and other facilities for interacting with these views.
+The `basic_mdspan` object maps a multi-index within its domain
+to a reference of an element in the codomain.
+The *domain* of a `basic_mdspan` object is a multidimensional index space.
+The *codomain* of a `basic_mdspan` object is a `span` of elements.
 
-�. The `subspan` function generates a `basic_mdspan` with a domain
+�. The `subspan` function generates a `basic_mdspan` with a *domain*
 contained within the input `basic_mdspan` domain and codomain contained
 within the input `basic_mdspan` codomain.
 
 ---
 
 <br/>
-*Add the following subclauses to the end of the* **[views]** *subclause (currently 26.7 in n4750)*:
+*Add the following subclauses to the end of the* **[views]** *subclause in the current draft*:
 
 <!--
  .d8888b.                                               d8b
@@ -718,13 +720,12 @@ Y88b  d88P Y88b 888 888  888 Y88..88P 888 d88P      X88 888      X88
 <br/>
 <b>26.7.� Header `<mdspan>` synopsis [mdspan.syn]</b>
 
-
-```c++
+<pre highlight="c++">
 namespace std {
 namespace experimental {
 namespace fundamentals_v3 {
   // [mdspan.extents], class template extents
-  template<ptrdiff_t... StaticExtents>
+  template&lt;ptrdiff_t... StaticExtents>
     class extents;
 
   // [mdspan.layout], Layout mapping policies
@@ -733,36 +734,53 @@ namespace fundamentals_v3 {
   class layout_stride;
 
   // [mdspan.accessor.basic]
-  template<class ElementType>
+  template&lt;class ElementType>
   class accessor_basic;
 
   // [mdspan.basic], class template mdspan
-  template<class ElementType,
+  template&lt;class ElementType,
            class Extents,
            class LayoutPolicy = layout_right,
-           class AccessorPolicy = accessor_basic<ElementType> >
+           class AccessorPolicy = accessor_basic&lt;ElementType> >
     class basic_mdspan;
 
-  template<class T, ptrdiff_t... Extents>
-    using mdspan = basic_mdspan<T, extents<Extents...>>;
+  template&lt;class T, ptrdiff_t... Extents>
+    using mdspan = basic_mdspan&lt;T, extents&lt;Extents...>>;
 
   // [mdspan.extents.compare], extents comparison operators
-  template<ptrdiff_t... LHS, ptrdiff_t... RHS>
-    constexpr bool operator==(const extents<LHS...>& lhs, const extents<RHS...>& rhs) noexcept;
-  template<ptrdiff_t... LHS, ptrdiff_t... RHS>
-    constexpr bool operator!=(const extents<LHS...>& lhs, const extents<RHS...>& rhs) noexcept;
+  template&lt;ptrdiff_t... LHS, ptrdiff_t... RHS>
+    constexpr bool operator==(const extents&lt;LHS...>& lhs, const extents&lt;RHS...>& rhs) noexcept;
+  template&lt;ptrdiff_t... LHS, ptrdiff_t... RHS>
+    constexpr bool operator!=(const extents&lt;LHS...>& lhs, const extents&lt;RHS...>& rhs) noexcept;
 
   // [mdspan.subspan], subspan creation
-  template<class ElementType, class Extents, class LayoutPolicy,
+  template&lt;class ElementType, class Extents, class LayoutPolicy,
            class AccessorPolicy, class... SliceSpecifiers>
-    basic_mdspan<ElementType, /* see-below */>
-      subspan(const basic_mdspan<ElementType, Extents, LayoutPolicy, AccessorPolicy>&, SliceSpecifiers...) noexcept;
+  struct mdspan_subspan { // <i>exposition only</i>
+    using extents_t = <i>see below</i>;
+    using layout_t = <i>see below</i>;
+    using type = basic_mdspan&lt;ElementType, extents_t, layout_t,
+                              typename AccessorPolicy::offset_policy>;
+  };
+
+  template&lt;class ElementType, class Extents, class LayoutPolicy,
+           class AccessorPolicy, class... SliceSpecifiers>
+  using mdspan_subspan_t = // <i>exposition only</i>
+    typename mdspan_subspan&lt;ElementType, Extents, LayoutPolicy,
+                            AccessorPolicy, SliceSpecifiers...>::type;
+
+  template&lt;class ElementType, class Extents, class LayoutPolicy,
+           class AccessorPolicy, class... SliceSpecifiers>
+    mdspan_subspan_t&lt;ElementType, Extents, LayoutPolicy,
+                     AccessorPolicy, SliceSpecifiers...>
+      subspan(const basic_mdspan&lt;ElementType, Extents, LayoutPolicy,
+                                 AccessorPolicy>& src, SliceSpecifiers ... slices) noexcept;
 
   // tag supporting subspan
   struct all_type { explicit all_type() = default; };
   inline constexpr all_type all = all_type{};
 }}}
-```
+</pre>
 
 <!--
                   888                     888
@@ -978,9 +996,9 @@ template<ptrdiff_t... LHS, ptrdiff_t... RHS>
 
 1. A *layout mapping policy* is a class that contains a *layout mapping*, a nested class template.
 
-2. A *layout mapping policy* shall meet the requirements in table �.
+2. A *layout mapping policy* shall meet the requirements in Table �.
 
-3. A *layout mapping* shall meet the requirements of `DefaultConstructible`, `CopyAssignable`, `EqualityComparable`, and the requirements in table �.
+3. A *layout mapping* shall meet the requirements of `DefaultConstructible`, `CopyAssignable`, `EqualityComparable`, and the requirements in Table �.
 
 4. In Table �:
     * `MP` denotes a layout mapping policy.
@@ -2398,56 +2416,88 @@ subspan
 <br/>
 <b>26.7.� subspan [mdspan.subspan]</b>
 
-```c++
+<pre highlight="c++">
 namespace std {
 namespace experimental {
 namespace fundamentals_v3 {
 
   // [mdspan.subspan], subspan creation
-  template<class ElementType, class Extents, class LayoutPolicy,
+  template&lt;class ElementType, class Extents, class LayoutPolicy,
            class AccessorPolicy, class... SliceSpecifiers>
-    basic_mdspan<ElementType, E /* see-below */, L /* see-below */, typename AccessorPolicy::offset_policy >
-      subspan(const basic_mdspan<ElementType, Extents, LayoutPolicy, AccessorPolicy>& src, SliceSpecifiers ... slices) noexcept;
+  struct mdspan_subspan { // <i>exposition only</i>
+    using extents_t = <i>see below</i>;
+    using layout_t = <i>see below</i>;
+    using type = basic_mdspan&lt;ElementType, extents_t, layout_t,
+                              typename AccessorPolicy::offset_policy>;
+  };
+
+  template&lt;class ElementType, class Extents, class LayoutPolicy,
+           class AccessorPolicy, class... SliceSpecifiers>
+  using mdspan_subspan_t = // <i>exposition only</i>
+    typename mdspan_subspan&lt;ElementType, Extents, LayoutPolicy,
+                            AccessorPolicy, SliceSpecifiers...>::type;
+
+  template&lt;class ElementType, class Extents, class LayoutPolicy,
+           class AccessorPolicy, class... SliceSpecifiers>
+    mdspan_subspan_t&lt;ElementType, Extents, LayoutPolicy,
+                     AccessorPolicy, SliceSpecifiers...>
+      subspan(const basic_mdspan&lt;ElementType, Extents, LayoutPolicy,
+                                 AccessorPolicy>& src, SliceSpecifiers ... slices) noexcept;
 
 }}}
-```
+</pre>
 
+<!-- basic_mdspan&lt;ElementType, E /* see-below */, L /* see-below */, typename AccessorPolicy::offset_policy > -->
 
-`subspan` creates a `basic_mdspan` that is a view on a (potentially trivial) subset of another `basic_mdspan`.
-The SliceSpecifier parameters indicate the subset that the return value references.
-The second template parameter of the return type, `E`, is a specialization of `extents`.
-The third template parameter of the return type, `L`, meets the requirements of layout mapping policy and is implementation defined [mdspan.layout].
+The exposition-only `struct mdspan_subspan` defines the type returned by `subspan`.
+The `extents_t` type alias is a specialization of `extents` **[mdspan.extents]**
+determined by the pre- and postconditions of `subspan` specified below.
+The `layout_t` type alias meets the requirements of a layout mapping policy [mdspan.layout.reqs]
+and is implementation defined.
+
+`subspan` creates a `basic_mdspan` that is a view of a (potentially trivial) subset of another `basic_mdspan`.
+The `SliceSpecifier` parameters indicate the subset that the return value references.
 <br/>
 
-Let `slices[r]` denote the `r`<em>th</em> value in the parameter pack `slices...`.<br/>
-Let `first[r]` denote the `r`<em>th</em> lower bound of `slices[r]`. <br/>
-    * If `slices[r]` is convertible to `ptrdiff_t` `first[r]==slices[r]` <br/>
-    * If `slices[r]` is convertible to `pair<ptrdiff_t,ptrdiff_t>` `first[r]==pair<ptrdiff_t,ptrdiff_t>(slices[r]).first()` <br/>
-    * If `slices[r]` is convertible to `all_type` `first[r]==0` <br/>
-Let `last[r]` denote the rth upper bound of `slices[r]`. <br/>
-    * If `slices[r]` is convertible to `ptrdiff_t` `last[r]==slices[r]+1` <br/>
-    * If `slices[r]` is convertible to `pair<ptrdiff_t,ptrdiff_t>` `last[r]==pair<ptrdiff_t,ptrdiff_t>(slices[r]).second()` <br/>
-    * If `slices[r]` is convertible to `all_type` `last[r]==src.extent(r)` <br/>
-Let an array `R[K]` be <br/>
+Define `slices_tuple` as `auto slices_tuple = forward_as_tuple(slices...);`. <br/>
+Define `first[r]` as follows: <br/>
+    * If `slices_tuple.get<r>()` is convertible to `ptrdiff_t`, then `first[r]` equals `slices_tuple.get<r>()`. <br/>
+    * Otherwise, if `slices_tuple.get<r>()` is convertible to `pair<ptrdiff_t,ptrdiff_t>`,
+      then `first[r]` equals `pair<ptrdiff_t,ptrdiff_t>(slices_tuple.get<r>()).first`. <br/>
+    * Otherwise, if `slices_tuple.get<r>()` is convertible to `all_type`, then `first[r]` equals `0`. <br/>
+Define `last[r]` as follows: <br/>
+    * If `slices_tuple.get<r>()` is convertible to `ptrdiff_t`,
+      then `last[r]` equals `slices_tuple.get<r>()+1`. <br/>
+    * Otherwise, if `slices_tuple.get<r>()` is convertible to `pair<ptrdiff_t,ptrdiff_t>`,
+      then `last[r]` equals `pair<ptrdiff_t,ptrdiff_t>(slices_tuple.get<r>()).second`. <br/>
+    * Otherwise, if `slices_tuple.get<r>()` is convertible to `all_type`,
+      then `last[r]` equals `src.extent(r)`. <br/>
+Define `R[K]` as follows: <br/>
 <pre highlight="c++">
   size_t k = 0;
   for(size_t r=0; r&lt;sizeof...(slices); r++)
-    if ( slices[r] <i>convertable to</i> pair&lt;ptrdiff_t,ptrdiff_t> <i>or</i> all_type ) R[k++] = r;
+    if ( slices_tuple.get<r>() <i>convertible to</i> pair&lt;ptrdiff_t,ptrdiff_t> <i>or</i> all_type ) R[k++] = r;
   size_t K = k;
 </pre>
-Let `sub` be the return value of `subspan` <br/>
+Let `sub` be the return value of `subspan`,
+and let `E` be `mdspan_subspan<ElementType, Extents, LayoutPolicy, AccessorPolicy, SliceSpecifiers...>::extents_t`.
+<br/>
 
 Requires: <br/>
     * `sizeof(slices...)==src.rank()` <br/>
-    * `slices[r]` is convertible to `ptrdiff_t`, `pair<ptrdiff_t,ptrdiff_t>` or `all_type` <br/>
+    * `slices_tuple.get<r>()` is convertible to `ptrdiff_t`, `pair<ptrdiff_t,ptrdiff_t>` or `all_type` <br/>
     * 0 <= `first[r]` < `last[r]` <= `src.extent(r)` <br/>
 
 Postcondition: <br/>
     * `E::rank()==K` <br/>
-    * Let `I...` be a multi-index such that `I[k] < sub.extents(k)` and `J...` be a multi-index where `J[R[k]]=first[R[k]]+I[k]` or `J[r]=first[r]` for `r` not in `R`, then `sub(I...)` and `src(J...)` refer to the same element.
-    * `sub.extent(k)==last[R[k]]-first[R[k]]`.
-    * If `src.is_strided()` then `sub.is_strided()` and `sub.stride(k)==src.stride(R[k])` <br/>
-    * If `src.static_extent(R[k]) != dynamic_extent` and `slices[R[k]]` is convertable to `all_type` then `sub.static_extent(k) == src.static_extent(R[k])`.
+    * Let `I...` be a multi-index such that `I[k] < sub.extents(k)` and
+      `J...` be a multi-index where `J[R[k]]=first[R[k]]+I[k]` or `J[r]=first[r]` for `r` not in `R`.
+      Then, `sub(I...)` and `src(J...)` refer to the same element.
+    * `sub.extent(k)` equals `last[R[k]] - first[R[k]]`.
+    * If `src.is_strided()`, then `sub.is_strided()` and `sub.stride(k)` equals `src.stride(R[k])`. <br/>
+    * If `src.static_extent(R[k])` does not equal `dynamic_extent` and
+      `slices_tuple.get<R[k]>()` is convertible to `all_type`, 
+      then `sub.static_extent(k)` equals `src.static_extent(R[k])`.
 <br/>
 
 * Examples:

--- a/P0009/P0009.bs
+++ b/P0009/P0009.bs
@@ -1041,7 +1041,7 @@ template<ptrdiff_t... LHS, ptrdiff_t... RHS>
 4. In Table �:
     * `MP` denotes a layout mapping policy.
     * `E` denotes a specialization of `extents`.
-    * `e` denotes an object of type `E` defining a domain multidimensional index space.
+    * `e` denotes an object of type `E` defining a multidimensional index space.
     * `r` is a value of an integral type such that 0 <= `r` < `e.rank()`.
     * If `k...` is a pack of an integer type, we say that "`k...` is in `e`" 
       if `k...` denotes a multi-index in `e`.
@@ -1089,7 +1089,8 @@ Table � — Layout mapping policy and layout mapping requirements
 <tr>
   <td>`m.required_span_size()`</td>
   <td>`E::index_type`</td>
-  <td>*Returns:* 1 plus the maximum value of `m(i...)`.</td>
+  <td>*Returns:* If the multidimensional index space that `e` defines is empty, then zero,
+      else 1 plus the maximum value of `m(i...)` for all `i...` in `e`.</td>
   <td></td>
 </tr>
 <tr>

--- a/P0009/P0009.bs
+++ b/P0009/P0009.bs
@@ -607,24 +607,30 @@ Description
 ===========
 
 The proposed polymorphic multidimensional array reference (`mdspan`)
-defines types and functions for mapping indices from the **domain**, a
-**multidimensional index space**, to the **codomain**, elements of a
-contiguous span of objects. A multidimensional index space is defined as
-the Cartesian product of integer extents, `[0..N0) * [0..N1) * [0..N2) `....
+defines types and functions for mapping multidimensional indices
+in its **domain**, a
+multidimensional index space, to the `mdspan`'s **codomain**,
+elements of a contiguous span of objects.
+A **multidimensional index space** of **rank** <math>r</math>
+is the Cartesian product 
+<math>[0, N<sub>0</sub>) &#10799; [0, N<sub>1</sub>) &#10799; ... &#10799; [0, N<sub>r-1</sub>)</math>
+of half-open integer intervals.
+A **multidimensional index** or **multi-index**
+is a member of a multidimensional index space.
 An `mdspan` has two policies: the **layout mapping**
 and the **accessor**. The layout mapping specifies the formula, and
 properties of the formula, for mapping a multi-index from the domain to
 an element in the codomain. The accessor is an extension point that
-allows modification of how elements are accessed. For example, the
-Accessors paper (P0367) proposed a rich set of potential access
-properties.
+allows modification of how elements are accessed. For example,
+\[P0367](http://wg21.link/p0367)
+proposed a rich set of potential access properties.
 
-**A multidimensional array is not an array-of-array-of-array-of-array...**
+**A multidimensional array is not an array-of-array-of-array-of...**
 
 The multidimensional array abstraction has been fundamental to numerical
 computations for over five decades. However, the C/C++ language provides
 only a one-dimensional array abstraction which can be composed into
-array-of-array-of-array... types. While such types have some similarity
+array-of-array-of-array-of... types. While such types have some similarity
 to multidimensional arrays, they do not provide adequate multidimensional
 array functionality of this proposal. Two critical functionality
 differences are (1) multiple dynamic extents and (2) polymorphic mapping
@@ -632,11 +638,11 @@ of multi-indices to element objects.
 
 **Optimized Implementation of Layout Mapping**
 
-The layout mapping of a multi-index is intended to be an O(1) `constexpr`
-operation that is trivially inlined and optimized. Note that Fortran
-compilers' optimizations include loop invariant code motion, including
-partial evaluation of multi-index layout mappings when indices are
-loop-invariant.
+We intend the layout mapping of a multi-index to be a constant-time
+`constexpr` operation that is trivially inlined and optimized.
+Compiler vendors may apply optimizations such as loop-invariant code
+motion, including partial evaluation of multi-index layout mappings
+when indices are loop invariant.
 
 Editing Notes
 =============
@@ -687,17 +693,24 @@ needed for `basic_mdspan`.
 <br/>
 *Add the following paragraphs to* **[views.general]**:
 
-�. The header `<mdspan>` defines the view `basic_mdspan`, the type alias `mdspan`, 
+�. The header `<mdspan>` defines the view `basic_mdspan`,
+the type alias `mdspan`, 
 and other facilities for interacting with these views.
-The `basic_mdspan` object maps a multidimensional index within its domain
+The `basic_mdspan` object maps a multidimensional index
+within its domain
 to a reference of an element in the codomain.
 The *domain* of a `basic_mdspan` object is a multidimensional index space.
-A *multidimensional index space* is a Cartesian product <math>[0, N<sub>0</sub>) &#10799; [0, N<sub>1</sub>) &#10799; ...</math> of half-open integer intervals.
+A *multidimensional index space* of *rank* <math>r</math>
+is the Cartesian product 
+<math>[0, N<sub>0</sub>) &#10799; [0, N<sub>1</sub>) &#10799; ... &#10799; [0, N<sub>r-1</sub>)</math>
+of half-open integer intervals.
+A **multidimensional index** or **multi-index**
+is a member of a multidimensional index space.
 The *codomain* of a `basic_mdspan` object is a `span` of elements.
 
-�. The `subspan` function generates a `basic_mdspan` with a *domain*
-contained within the input `basic_mdspan` domain and codomain contained
-within the input `basic_mdspan` codomain.
+�. The `subspan` function generates a `basic_mdspan`
+with a *domain* contained within the input `basic_mdspan` domain,
+and a codomain contained within the input `basic_mdspan` codomain.
 
 ---
 
@@ -905,8 +918,10 @@ template<class... IndexType>
 constexpr extents(IndexType... dynamic_extents) noexcept;
 ```
 
-* *Requires:* `((dynamic_extents>=0) && ...)` is `true`.
-* *Constraints:* `(is_convertible_v<IndexType, index_type> && ...) && sizeof...(dynamic_extents)==rank_dynamic()` is `true`.
+* *Requires:* `(dynamic_extents>=0) && ...` is `true`.
+* *Constraints:* 
+    * `is_convertible_v<IndexType, index_type> && ...` is `true`, and
+    * `sizeof...(dynamic_extents)==rank_dynamic()` is `true`.
 * *Effects:* Aggregate-initializes `dynamic_extents_` to `{dynamic_extents...}`.
 * *Ensures:* `extent(`*DynamicRank[i]*`)` is equal to the *i*th entry in the parameter pack `dynamic_extents`.
 
@@ -939,9 +954,6 @@ constexpr extents& operator=(const extents<OtherExtents...>& other);
 * *Returns:* `*this`.
 * *Throws:* Nothing.
 
-<!-- TODO FIX EASY STUFF BELOW HERE -->
-<br/>
-
 <br/>
 <b>26.7.�.3 Observers of the domain multidimensional index space [mdspan.extents.obs]</b>
 
@@ -956,21 +968,29 @@ static constexpr size_t rank() const noexcept;
 ```c++
 static constexpr size_t rank_dynamic() const noexcept;
 ```
-* *Returns:* `((Extents==dynamic_extent)+...)`. *[Note:* This is the number of dynamic extents. *—end note]*
+* *Returns:* 
+    * If `sizeof...(Extents)==0` is `true`, then zero;
+    * Otherwise, `((Extents==dynamic_extent)+...)`. 
+
+*[Note:* This is the number of dynamic extents. *—end note]*
 
 <br/>
 ```c++
 static constexpr index_type static_extent(size_t r) const noexcept;
 ```
 
-* *Returns:* The `r`th entry in the `Extents` parameter pack if 0 <= `r` < `rank()`, or 1 otherwise.
+* *Returns:* 
+    * If 0 <= `r` < `rank()`, then the `r`th entry 
+      in the `Extents` parameter pack;
+    * Otherwise, 1.
 
 <br/>
 ```c++
 constexpr index_type extent(size_t r) const noexcept;
 ```
 * *Returns:* 
-    * If `static_extent(r)==dynamic_extent`, then `dynamic_extents_[`*DynamicRank[*`r`*]*`]`.
+    * If `static_extent(r)==dynamic_extent`, then
+      `dynamic_extents_[`*DynamicRank[*`r`*]*`]`;
     * Otherwise, `static_extent(r)`.
 
 <br/>
@@ -982,7 +1002,10 @@ template<ptrdiff_t... LHS, ptrdiff_t... RHS>
   constexpr bool operator==(const extents<LHS...>& lhs, const extents<RHS...>& rhs) noexcept;
 ```
 
-* *Returns:* `true` if `lhs.rank()==rhs.rank()` and `lhs.extents(r)==rhs.extents(r)` for all `r` in the range `[0, lhs.rank())`, or `false` otherwise.
+* *Returns:* 
+    * If `lhs.rank()==rhs.rank() && lhs.extents(r)==rhs.extents(r)` is `true`
+      for all `r` in the range `[0, lhs.rank())`, then `true`; 
+    * Otherwise, `false`.
 
 <br/>
 ```c++
@@ -1023,9 +1046,9 @@ template<ptrdiff_t... LHS, ptrdiff_t... RHS>
     * `E` denotes a specialization of `extents`.
     * `e` denotes an object of type `E` defining a domain multidimensional index space.
     * `r` is a value of an integral type such that 0 <= `r` < `e.rank()`.
-    * `i...` and `j...` are packs of an integer type denoting values in the multidimensional index space `e`, the `r`*th member of packs `i...` and `j...` are denoted by `i[r]` and `j[r]`, and `sizeof...(i)==E::rank()`, 0 <= `i[r]` < `e.extent(r)`, `sizeof...(j)==E::rank()`, and 0 <= `j[r]` < `e.extent(r)`.
+    * `i...` and `j...` are packs of an integer type denoting values in the multidimensional index space `e`. Denote the `r`*th member of packs `i...` and `j...` by `i[r]` and `j[r]`, respectively. `sizeof...(i)==E::rank()` is `true`, 0 <= `i[r]` < `e.extent(r)`, `sizeof...(j)==E::rank()`, and 0 <= `j[r]` < `e.extent(r)`.
     * `M` denotes a layout mapping class.
-    * `m` denotes an object of type `M` that maps a multi-index `i...` to an integral value.
+    * `m` denotes an object of type `M` that maps a pack `i...` denoting a multi-index to an integral value.
 
 Table � — Layout mapping policy and layout mapping requirements
 <table border=1>
@@ -1055,24 +1078,24 @@ Table � — Layout mapping policy and layout mapping requirements
   <td>`m(i...)`</td>
   <td>`E::index_type`</td>
   <td>*Returns:* Mapping of a multi-index `i...` </td>
-  <td>*Requires:* `0 <= m(i...)` </td>
+  <td>*Requires:* `0 <= m(i...)` is `true`. </td>
 </tr>
 <tr>
   <td>`m.required_span_size()`</td>
   <td>`E::index_type`</td>
-  <td>*Returns:* one plus the maximum value of `m(i...)`.</td>
+  <td>*Returns:* 1 plus the maximum value of `m(i...)`.</td>
   <td></td>
 </tr>
 <tr>
   <td>`m.is_unique()`</td>
   <td>`bool`</td>
-  <td>*Returns:* `true` if for every `i...!=j...`, `m(i...)!=m(j...)`. </td>
+  <td>*Returns:* `true` if for every `i...!=j...`, `m(i...)!=m(j...)` is `true`. </td>
   <td></td>
 </tr>
 <tr>
   <td>`m.is_contiguous()`</td>
   <td>`bool`</td>
-  <td>*Returns:* `true` if the set of values defined by `m(i)...` is equal to the set of values consisting of `0`...`m.required_span_size()-1`. </td>
+  <td>*Returns:* `true` if the set defined by `m(i)...` equals the set {0, ..., `m.required_span_size()-1`}. </td>
   <td></td>
 </tr>
 <tr>
@@ -1285,17 +1308,11 @@ template<class... Indices>
 * *Constraints:* 
     * `sizeof...(Indices)==extents().rank()` is `true`, and
     * `is_convertible_v<Indices, typename Extents::index_type> && ...` is `true`.
-* *Returns:* The sum of <math>i<sub>k</sub></math> * `stride(k)` for 0 <= k < `extents.rank()`, where <math>i<sub>k</sub></math> denotes the k-th member of `i...`, and the sum of zero terms is zero.
-
-<!--
-* *Returns:* Equivalent to `offset` in the following:
-```
-Extents::index_type offset = 0 ;
-for(size_t k=0; k<extents.rank(); ++k) 
-  offset += i_k * stride(k);
-```
--->
-
+* *Returns:* 
+    * If `extents.rank()` is zero, then zero;
+    * Otherwise, the sum of <math>i<sub>k</sub></math> &#10799; `stride(k)` 
+      for 0 <= k < `extents.rank()`, where <math>i<sub>k</sub></math>
+      denotes the k-th member of `i...` .
 
 <br/>
 ```c++
@@ -1315,13 +1332,11 @@ constexpr bool is_strided() const;
 typename Extents::index_type stride(size_t r) const;
 ```
 
-* *Returns:* Equivalent to `s` in
-
-```
-Extents::index_type s = 1;
-for(size_t k=0; k<r; ++k)
-  s *= extents().extent(k);
-```
+* *Returns:*
+    * If `r` is zero, then `1`;
+    * Otherwise, the product of `extents().extent(k)`
+      for 0 <= k < `r`, where <math>i<sub>k</sub></math>
+      denotes the k-th member of `i...` .
 
 <br/>
 ```c++
@@ -2449,7 +2464,8 @@ namespace fundamentals_v3 {
 
   // [mdspan.subspan], subspan creation
   template&lt;class ... Args>
-  constexpr size_t mdspan_subspan_rank_v = <i>see below</i>;<i> // exposition only</i>
+  constexpr size_t mdspan_subspan_rank_v =
+    <i>see below</i>;<i> // exposition only</i>
 
   template&lt;class ElementType, class Extents, class LayoutPolicy,
            class AccessorPolicy, class... SliceSpecifiers>
@@ -2471,12 +2487,16 @@ namespace fundamentals_v3 {
     mdspan_subspan_t&lt;ElementType, Extents, LayoutPolicy,
                      AccessorPolicy, SliceSpecifiers...>
       subspan(const basic_mdspan&lt;ElementType, Extents, LayoutPolicy,
-                                 AccessorPolicy>& src, SliceSpecifiers ... slices) noexcept;
+                                 AccessorPolicy>& src,
+				 SliceSpecifiers ... slices) noexcept;
 
 }}}
 </pre>
 
-Define the exposition-only metafunction `mdspan_subspan_rank_v` as follows:<br/>
+The exposition-only metafunction `mdspan_subspan_rank_v`,
+specifies the rank of the `basic_mdspan` returned by `subspan`.
+Define `mdspan_subspan_rank_v` as follows:
+
 <pre highlight="c++">
   template&lt;class ... Args>
   struct mdspan_subspan_rank;
@@ -2498,23 +2518,35 @@ Define the exposition-only metafunction `mdspan_subspan_rank_v` as follows:<br/>
   constexpr size_t mdspan_subspan_rank_v = mdspan_subspan_rank&lt;Args...>::value;
 </pre>
 
-The exposition-only `struct mdspan_subspan` defines the type returned by `subspan`.
-The `extents_t` type alias is a specialization of `extents` **[mdspan.extents]**
-determined by the pre- and postconditions of `subspan` specified below.
-The `layout_t` type alias meets the requirements of a layout mapping policy **[mdspan.layout.reqs]**
-and is implementation defined.
+In the exposition-only `struct mdspan_subspan`,
 
-`subspan` creates a `basic_mdspan` that is a view of a (potentially trivial) subset of another `basic_mdspan`.
-The `SliceSpecifier` parameters indicate the subset that the return value references.
-<br/>
+    * The `extents_t` type alias is a specialization of
+      `extents` **[mdspan.extents]**, and is determined by
+      the description of the semantics of `subspan` given below;
+    * The `layout_t` type alias meets the requirements
+      of a layout mapping policy **[mdspan.layout.reqs]**
+      and is implementation defined; and
+    * The `type` type alias specifies the type returned by `subspan`.
+
+The `subspan` function creates a `basic_mdspan` that is a view
+of a (potentially trivial) subset of another `basic_mdspan`.
+The `SliceSpecifier` template argument(s)
+and the corresponding value(s) of the arguments of `subspan` after `src`
+determine the subset of `src` that the return value views.
+
+Define the exposition-only `array`s `first`, `last`, and `R` as 
 
 <pre highlight="c++">
+template&lt;class ... SliceSpecifier>
+void first_last_and_R (array&lt;ptrdiff_t, sizeof...(SliceSpecifier)>& first,
+                       array&lt;ptrdiff_t, sizeof...(SliceSpecifier)>& last,
+                       array&lt;ptrdiff_t, sizeof...(SliceSpecifier)>& R,
+		       SliceSpecifier... slices)
+{
   constexpr size_t result_rank = mdspan_subspan_rank_v(slices...);
-
+  constexpr size_t num_args = sizeof...(SliceSpecifier);
+  
   auto slices_tuple = forward_as_tuple(slices...);
-  array&lt;ptrdiff_t, sizeof...(slices)> first;
-  array&lt;ptrdiff_t, sizeof...(slices)> last;
-  array&lt;size_t, result_rank> R;
   
   size_t current_R_position = 0;
   for(size_t r=0; r&lt;sizeof...(slices); r++) {
@@ -2539,24 +2571,23 @@ The `SliceSpecifier` parameters indicate the subset that the return value refere
 
 </pre>
 
-Let `sub` be the return value of `subspan(src, slices...)`,
-and let `E` be `mdspan_subspan<ElementType, Extents, LayoutPolicy, AccessorPolicy, SliceSpecifiers...>::extents_t`.
-<br/>
+Let `sub` be the return value of `subspan(src, slices...)`.
 
 * *Requires:*
     * `sizeof(slices...)` equals `src.rank()`.
-    * For all `r` in `0`, `1`, ..., `sizeof...(slices)-1`,
+    * For all `r` in 0, 1, ..., `sizeof...(slices)-1`,
       `0 <= first[r] && first[r] < last[r] && last[r] <= src.extent(r)` is `true`.
 * *Constraints:*
     * For all types `T` in the parameter pack `SliceSpecifiers...`,
       `is_convertible_v<T, ptrdiff_t> || is_convertible_v<T, pair<ptrdiff_t, ptrdiff_t>> || is_convertible_v<T, all_type>` is `true`.
 * *Ensures:*
-    * `E::rank()` equals `result_rank`.
+    * `mdspan_subspan<ElementType, Extents, LayoutPolicy, AccessorPolicy, SliceSpecifiers...>::extents_t::rank()` equals `result_rank`.
     * Let `I...` be a multi-index such that `I[k] < sub.extents(k)` and
       `J...` be a multi-index where `J[R[k]]=first[R[k]]+I[k]` or `J[r]=first[r]` for `r` not in `R`.
       Then, `sub(I...)` and `src(J...)` refer to the same element.
     * `sub.extent(k)` equals `last[R[k]] - first[R[k]]`.
-    * If `src.is_strided()`, then `sub.is_strided()` and `sub.stride(k)` equals `src.stride(R[k])`.
+    * If `src.is_strided()`, then `sub.is_strided()` is `true` and
+      `sub.stride(k)` equals `src.stride(R[k])`.
     * If `src.static_extent(R[k])` does not equal `dynamic_extent` and
       `is_convertible_v<decltype(slices_tuple.get<R[k]>()), all_type>` is `true`,
       then `sub.static_extent(k)` equals `src.static_extent(R[k])`.

--- a/P0009/P0009.bs
+++ b/P0009/P0009.bs
@@ -2472,23 +2472,25 @@ The `SliceSpecifier` parameters indicate the subset that the return value refere
   constexpr size_t result_rank = slices_result_rank(slices...);
 
   auto slices_tuple = forward_as_tuple(slices...);
-  array<ptrdiff_t, sizeof...(slices)> first;
-  array<ptrdiff_t, sizeof...(slices)> last;
-  array<size_t, result_rank> R;
+  array&lt;ptrdiff_t, sizeof...(slices)> first;
+  array&lt;ptrdiff_t, sizeof...(slices)> last;
+  array&lt;size_t, result_rank> R;
   
   size_t current_R_position = 0;
   for(size_t r=0; r&lt;sizeof...(slices); r++) {
-    if constexpr (is_convertible_v<decltype(slices_tuple.get<r>()), ptrdiff_t>) {
+    using cur_type = decltype(slices_tuple.get&lt;r>());
+
+    if constexpr (is_convertible_v&lt;cur_type, ptrdiff_t>) {
       first[r] = slices_tuple.get<r>();
       last[r] = first[r] + 1;
     }
-    else if constexpr (is_convertible_v<decltype(slices_tuple.get<r>()), pair<ptrdiff_t,ptrdiff_t>>) {
-      const pair<ptrdiff_t, ptrdiff_t> slices_r = slices_tuple.get<r>();
+    else if constexpr (is_convertible_v&lt;cur_type, pair&lt;ptrdiff_t, ptrdiff_t>>) {
+      const pair&lt;ptrdiff_t, ptrdiff_t> slices_r = slices_tuple.get&lt;r>();
       first[r] = slices_r.first;
       last[r] = slices_r.second;
       R[current_R_position++] = r;      
     }
-    else if constexpr (is_convertible_v<slices_tuple.get<r>(), all_type>) {
+    else if constexpr (is_convertible_v&lt;cur_type, all_type>) {
       first[r] = 0;
       last[r] = src.extent(r);
       R[current_R_position++] = r;      

--- a/P0009/P0009.bs
+++ b/P0009/P0009.bs
@@ -1046,7 +1046,16 @@ template<ptrdiff_t... LHS, ptrdiff_t... RHS>
     * `E` denotes a specialization of `extents`.
     * `e` denotes an object of type `E` defining a domain multidimensional index space.
     * `r` is a value of an integral type such that 0 <= `r` < `e.rank()`.
-    * `i...` and `j...` are packs of an integer type denoting values in the multidimensional index space `e`. Denote the `r`*th member of packs `i...` and `j...` by `i[r]` and `j[r]`, respectively. `sizeof...(i)==E::rank()` is `true`, 0 <= `i[r]` < `e.extent(r)`, `sizeof...(j)==E::rank()`, and 0 <= `j[r]` < `e.extent(r)`.
+    * If `k...` is a pack of an integer type, we say that "`k...` is in `e`" 
+      if `k...` denotes a multi-index in `e`.
+      Let the packs of integer type `i...` and `j...` be in `e`.
+      Denote the <math>r</math>-th member of packs `i...` and `j...` by 
+      <math>i<sub>r</sub></math> and <math>j<sub>r</sub></math>, respectively. 
+      Let `r` equal <math>r</math>.
+      `sizeof...(i)==E::rank()` is `true`, 
+      0 <= <math>i<sub>r</sub></math> < `e.extent(r)`, 
+      `sizeof...(j)==E::rank()`, and
+      0 <= <math>j<sub>r</sub></math> < `e.extent(r)`.
     * `M` denotes a layout mapping class.
     * `m` denotes an object of type `M` that maps a pack `i...` denoting a multi-index to an integral value.
 
@@ -1078,7 +1087,7 @@ Table � — Layout mapping policy and layout mapping requirements
   <td>`m(i...)`</td>
   <td>`E::index_type`</td>
   <td>*Returns:* Mapping of a multi-index `i...` </td>
-  <td>*Requires:* `0 <= m(i...)` is `true`. </td>
+  <td>*Requires:* 0 <= `m(i...)`. </td>
 </tr>
 <tr>
   <td>`m.required_span_size()`</td>
@@ -1101,7 +1110,12 @@ Table � — Layout mapping policy and layout mapping requirements
 <tr>
   <td>`m.is_strided()`</td>
   <td>`bool`</td>
-  <td>*Returns:* `true` if `m(j...) - m(i...) = s[r]` when all members of `j...` and `i...` are equal except for exactly one `r`*th* member such that `j[r]==i[r]+1`. `s[r]` is the *stride* of ordinate `r`.</td>
+  <td>*Returns:* `true` if there exists an integer <math>s<sub>r</sub></math>
+       such that, for all `j...` and `i...` in `e`,
+       if all members of `j...` and `i...` are equal
+       except for exactly one r-th member where
+       <math>j<sub>r</sub></math> equals <math>i<sub>r</sub></math> + 1, 
+       then `m(j...) - m(i...)` equals <math>s<sub>r</sub></math>.</td>
   <td></td>
 </tr>
 <tr>
@@ -1125,7 +1139,8 @@ Table � — Layout mapping policy and layout mapping requirements
 <tr>
   <td>`m.stride(r)`</td>
   <td>`E::index_type`</td>
-  <td>*Returns:* `m(j...) - m(i...)` when all members of `j...` and `i...` are equal except for the `r`*th* member such that `j[r]==i[r]+1`.</td>
+  <td>*Returns:* <math>s<sub>r</sub></math>, as defined for `m.is_strided()` above.
+      We say that <math>s<sub>r</sub></math> is the *stride* of ordinate `r`. </td>
   <td>*Requires:* `m.is_strided()` is `true`. </td>
 </tr>
 </table>
@@ -1149,9 +1164,9 @@ Table � — Layout mapping policy and layout mapping requirements
 <br/>
 <b>26.7.�.2 Class layout_left [mdspan.layout.left]</b>
 
-1. `layout_left` meets the requirements of layout mapping policy.  *[Note:* Thus, any well-formed specialization of `layout_left::template mapping` meets the requirements of layout mapping *—end note]*
+1. `layout_left` meets the requirements of layout mapping policy.  *[Note:* Thus, any well-formed specialization of `layout_left::template mapping` meets the requirements of layout mapping. *—end note]*
 2. `layout_left` gives a layout mapping where the left-most extent is stride one and strides increase left-to-right as the product of extents.
-3. If `Extents` is not a (possibly cv-qualified) specialization of `extents`, the program is ill-formed.
+3. If `Extents` is not a (possibly cv-qualified) specialization of `extents`, then the program is ill-formed.
 
 <pre highlight="c++">
 namespace std {
@@ -1293,9 +1308,7 @@ Extents extents() const noexcept;
 typename Extents::index_type required_span_size() const noexcept;
 ```
 
-* *Returns:* The product of `extents().extent(r)` for all `r` where 0 <= `r` < `extents().rank()`. <!-- TODO WHAT IF rank is zero?!? -->
-
-<!-- TODO FIX EASY STUFF BELOW HERE -->
+* *Returns:* The product of `extents().extent(r)` for all `r` where 0 <= `r` < `extents().rank()`. <!-- FIXME (mfh 29 Sep 2018) See GitHub Issue #71 -->
 
 <!-- --- -->
 
@@ -1308,11 +1321,10 @@ template<class... Indices>
 * *Constraints:* 
     * `sizeof...(Indices)==extents().rank()` is `true`, and
     * `is_convertible_v<Indices, typename Extents::index_type> && ...` is `true`.
-* *Returns:* 
-    * If `extents.rank()` is zero, then zero;
+* *Returns:* Let <math>i<sub>k</sub></math> denote the k-th member of `i...`, and let R equal `extents::rank()`:
+    * If R is zero, then zero;
     * Otherwise, the sum of <math>i<sub>k</sub></math> &#10799; `stride(k)` 
-      for 0 <= k < `extents.rank()`, where <math>i<sub>k</sub></math>
-      denotes the k-th member of `i...` .
+      for 0 <= k < R.
 
 <br/>
 ```c++
@@ -1333,7 +1345,7 @@ typename Extents::index_type stride(size_t r) const;
 ```
 
 * *Returns:*
-    * If `r` is zero, then `1`;
+    * If `r` is zero, then one;
     * Otherwise, the product of `extents().extent(k)`
       for 0 <= k < `r`, where <math>i<sub>k</sub></math>
       denotes the k-th member of `i...` .
@@ -1368,7 +1380,7 @@ template<class OtherExtents>
 <br/>
 <b>26.7.�.3 Class layout_right [mdspan.layout.right]</b>
 
-1. `layout_right` meets the requirements of layout mapping policy.  *[Note:* Thus, any well-formed specialization of `layout_right::template mapping` meets the requirements of layout mapping *—end note]*
+1. `layout_right` meets the requirements of layout mapping policy.  *[Note:* Thus, any well-formed specialization of `layout_right::template mapping` meets the requirements of layout mapping. *—end note]*
 2. The layout mapping property `layout_right` gives a layout mapping where the right-most extent is stride one and strides increase right-to-left as the product of extents.
 3. If `Extents` is not a (possibly cv-qualified) specialization of `extents`, the program is ill-formed.
 
@@ -1525,7 +1537,10 @@ template<class... Indices>
 * *Constraints:* 
     * `sizeof...(Indices)==extents().rank()` is `true`, and
     * `is_convertible_v<Indices, typename Extents::index_type> && ...` is `true`.
-* *Returns:* The sum of <math>i<sub>k</sub></math> * `stride(k)` for 0 <= k < `Extents::rank()`, where <math>i<sub>k</sub></math> denotes the k-th member of `i...`, and the sum of zero terms is zero.
+* *Returns:* Let <math>i<sub>k</sub></math> denote the k-th member of `i...`, and let R equal `Extents::rank()`:
+    * If R is zero, then zero;
+    * Otherwise, the sum of <math>i<sub>k</sub></math> &#10799; `stride(k)`
+      for 0 <= k < R.
 
 <!--
 Let `i[k]` denote the `k`*th* member of `i...`.
@@ -1557,8 +1572,7 @@ constexpr bool is_strided() const noexcept;
 typename Extents::index_type stride(size_t r) const noexcept;
 ```
 
-* *Returns:* Equivalent to `s` in
-
+* *Returns:* Equivalent to `s` in the following:
 ```
 Extents::index_type s = 1;
 for(size_t k=r+1; k<extents().rank(); ++k)
@@ -1670,19 +1684,25 @@ struct layout_stride {
 constexpr mapping() noexcept;
 ```
 * *Effects:* Default-initializes `extents_`.
-* *Ensures:* `extents()==Extents() && strides()==array<typename Extents::index_type, Extents::rank()>()` is `true`.
+* *Ensures:*
+    * `extents()==Extents()` is `true`, and
+    * `strides()==array<typename Extents::index_type, Extents::rank()>()` is `true`.
 
 ```c++
 constexpr mapping(const mapping& other) noexcept;
 ```
 * *Effects:* Initializes `extents_` with `other.extents_`.
-* *Ensures:* `extents()==other.extents() && strides()==other.strides()` is `true`.
+* *Ensures:* 
+    * `extents()==other.extents()` is `true`, and
+    * `strides()==other.strides()` is `true`.
 
 ```c++
 constexpr mapping(mapping&& other) noexcept;
 ```
 * *Effects:* Initializes `extents_` with `move(other.extents_)`.
-* *Ensures:* `extents()` equals the result of `other.extents()` before the invocation of the move, and `strides()` equals the result of `other.strides()` before the invocation of the move.
+* *Ensures:*
+    * `extents()` equals the result of `other.extents()` before the invocation of the move, and
+    * `strides()` equals the result of `other.strides()` before the invocation of the move.
 
 
 ```c++
@@ -1734,8 +1754,16 @@ template <class... Indices>
 * *Constraints:*
     * `sizeof...(Indices)==Extents::rank()` is `true`, and
     * `is_convertible_v<Indices, typename Extents::index_type> && ...` is `true`.
-* *Returns:* If `i...` is `i0, i1, i2`, ..., `ik` (where `k==Extents::rank() - 1` is `true`) and `s` is `strides()`, returns `i0*s[1]+i1*s[2]+`...`+ik*s[k]`. <!-- FIXME CODE TO MATH -->
+* *Returns:* Let <math>i<sub>k</sub></math> denote the k-th member of `i...`, let R equal `Extents::rank()`, and let `s` be `strides()`:
+    * If R is zero, then zero;
+    * Otherwise, the sum of <math>i<sub>k</sub> &#10799; `s[k]` for 0 <= k < R.
 
+<!-- FIXME (mfh 29 Sep 2018) This used to say:
+
+* *Returns:* If `i...` is `i0, i1, i2`, ..., `ik` (where `k==Extents::rank() - 1` is `true`) and `s` is `strides()`, returns `i0*s[1]+i1*s[2]+`...`+ik*s[k]`.
+
+THAT LOOKS WRONG, so I fixed it.
+-->
 
 ```c++
 static constexpr bool is_always_unique() noexcept;

--- a/P0009/P0009.bs
+++ b/P0009/P0009.bs
@@ -2422,6 +2422,9 @@ namespace experimental {
 namespace fundamentals_v3 {
 
   // [mdspan.subspan], subspan creation
+  template&lt;class ... Args>
+  constexpr size_t mdspan_subspan_rank_v = <i>see below</i>;<i> // exposition only</i>
+
   template&lt;class ElementType, class Extents, class LayoutPolicy,
            class AccessorPolicy, class... SliceSpecifiers>
   struct mdspan_subspan { // <i>exposition only</i>
@@ -2447,7 +2450,27 @@ namespace fundamentals_v3 {
 }}}
 </pre>
 
-<!-- basic_mdspan&lt;ElementType, E /* see-below */, L /* see-below */, typename AccessorPolicy::offset_policy > -->
+Define the exposition-only metafunction `mdspan_subspan_rank_v` as follows:<br/>
+<pre highlight="c++">
+  template&lt;class ... Args>
+  struct mdspan_subspan_rank;
+
+  template&lt;class First, class ... Rest>
+  struct mdspan_subspan_rank&lt;First, Rest...> {
+    constexpr size_t value =
+      ((is_convertible_v&lt;First, pair&lt;ptrdiff_t, ptrdiff_t>> ||
+        is_convertible_v&lt;First, all_type>) ? 1 : 0) +
+      mdspan_subspan_rank&lt;Rest...>::value;
+  };
+  
+  template&lt;>
+  struct mdspan_subspan_rank&lt;> {
+    constexpr size_t value = 0;
+  };
+
+  template&lt;class ... Args>
+  constexpr size_t mdspan_subspan_rank_v = mdspan_subspan_rank&lt;Args...>::value;
+</pre>
 
 The exposition-only `struct mdspan_subspan` defines the type returned by `subspan`.
 The `extents_t` type alias is a specialization of `extents` **[mdspan.extents]**
@@ -2460,15 +2483,25 @@ The `SliceSpecifier` parameters indicate the subset that the return value refere
 <br/>
 
 <pre highlight="c++">
-  constexpr size_t slices_result_rank () {
-    return 0;
-  }
+  template&lt;class ... Args>
+  struct mdspan_subspan_rank;
+
   template&lt;class First, class ... Rest>
-  constexpr size_t slices_result_rank (First, Rest... args) {
-    constexpr bool conv_to_pair = is_convertible_v<First, pair&lt;ptrdiff_t, ptrdiff_t>>;
-    constexpr bool conv_to_all = is_convertible_v<First, all_type>;
-    return (conv_to_pair || conv_to_all ? 1 : 0) + slices_result_rank (args...);
-  }
+  struct mdspan_subspan_rank&lt;First, Rest...> {
+    constexpr size_t value =
+      (is_convertible_v<First, pair&lt;ptrdiff_t, ptrdiff_t>> ||
+       is_convertible_v<First, all_type> ? 1 : 0) +
+      mdspan_subspan_rank<Rest...>::value;
+  };
+  
+  template&lt;>
+  struct mdspan_subspan_rank&lt;> {
+    constexpr size_t value = 0;
+  };
+
+  template&lt;class ... Args>
+  constexpr size_t mdspan_subspan_rank_v = mdspan_subspan_rank<Args...>::value;
+
   constexpr size_t result_rank = slices_result_rank(slices...);
 
   auto slices_tuple = forward_as_tuple(slices...);

--- a/P0009/P0009.bs
+++ b/P0009/P0009.bs
@@ -1708,13 +1708,21 @@ constexpr mapping(mapping&& other) noexcept;
 ```c++
 constexpr mapping(Extents e, array<typename Extents::index_type, Extents::rank()> s) noexcept;
 ```
+Let R equal `Extents::rank()`.
+If <math>p</math> is a permutation of the integers 0, ..., R-1,
+then let `p` be an exposition-only array of `size_t` of length R
+such that `p[i]` equals <math>p<sub>i</sub></math> for 0 <= i < R.
+
+<!-- FIXME (mfh 2x Sep 2018) See GitHub Issue #72 -->
+
 * *Requires:*
-    * `s[i]>0` is `true` for 0 < `i` <= `Extents::rank()`.
-    * If `Extents::rank()` is nonzero, then there exists a permutation `o(i)` 
-      of the integers `0`, ..., `Extents::rank()-1` 
-      with 0 <= `i` < `Extents::rank()` such that
-      `s(o(i))>=s(o(i-1))*e.extent(o(i-1))` is `true` 
-      for 1 <= `i` < `Extents::rank()`. <!-- FIXME CODE TO MATH -->
+    * `s[i] > 0` is `true` for 0 < `i` <= R.
+    * If R is nonzero, then
+      there exists a permutation <math>p</math>
+      of the integers 0, ..., R-1
+      with 0 <= i < R such that
+      `s(p[i]) >= s(p[i-1])*e.extent(p[i-1])` is `true` 
+      for 1 <= `i` < R.
 * *Effects:* Initializes `extents_` with `e` and `strides_` with `s`.
 * *Ensures:* `extents()==e && strides()==s` is `true`.
 * *Throws:* Nothing.
@@ -1782,7 +1790,20 @@ static constexpr bool is_always_contiguous() noexcept;
 ```c++
 constexpr bool is_contiguous() const noexcept;
 ```
-* *Returns:* `true` if there is a permutation `o(i)` of the numbers `0`, ..., `Extents::rank()-1` with 0 <= `i` < `Extents::rank()` such that `min(stride(o(i))==1` is `true` and `stride(o(i))==stride(o(i-1))*extents().extent(o(i-1))` with 1 <= `i` < `Extents::rank()`.  Otherwise, returns `false`. <!-- FIXME CODE TO MATH --> <!-- FIXME what if zero length? -->
+Let R equal `Extents::rank()`.
+If <math>p</math> is a permutation of the integers 0, ..., R-1,
+then let `p` be an exposition-only array of `size_t` of length R
+such that `p[i]` equals <math>p<sub>i</sub></math> for 0 <= i < R.
+
+* *Returns:*
+    * If `R` is zero, then `true`;
+    * Else, if there is a permutation <math>p</math> 
+      of the integers 0, ..., R-1
+      with 0 <= i < R such that
+      `min(stride(p[i])==1` is `true` and
+      `stride(p[i])==stride(p[i-1])*extents().extent(p[i-1])` 
+      with 1 <= `i` < R, then `true`;
+    * Otherwise, `false`.
 
 ```c++
 typename Extents::index_type stride(size_t r) const noexcept;

--- a/P0009/P0009.bs
+++ b/P0009/P0009.bs
@@ -2460,9 +2460,23 @@ The `SliceSpecifier` parameters indicate the subset that the return value refere
 <br/>
 
 <pre highlight="c++">
+  constexpr size_t slices_result_rank () {
+    return 0;
+  }
+  template&lt;class First, class ... Rest>
+  constexpr size_t slices_result_rank (First, Rest... args) {
+    constexpr bool conv_to_pair = is_convertible_v<First, pair&lt;ptrdiff_t, ptrdiff_t>>;
+    constexpr bool conv_to_all = is_convertible_v<First, all_type>;
+    return (conv_to_pair || conv_to_all ? 1 : 0) + slices_result_rank (args...);
+  }
+  constexpr size_t result_rank = slices_result_rank(slices...);
+
   auto slices_tuple = forward_as_tuple(slices...);
   array<ptrdiff_t, sizeof...(slices)> first;
   array<ptrdiff_t, sizeof...(slices)> last;
+  array<size_t, result_rank> R;
+  
+  size_t current_R_position = 0;
   for(size_t r=0; r&lt;sizeof...(slices); r++) {
     if constexpr (is_convertible_v<decltype(slices_tuple.get<r>()), ptrdiff_t>) {
       first[r] = slices_tuple.get<r>();
@@ -2471,44 +2485,44 @@ The `SliceSpecifier` parameters indicate the subset that the return value refere
     else if constexpr (is_convertible_v<decltype(slices_tuple.get<r>()), pair<ptrdiff_t,ptrdiff_t>>) {
       const pair<ptrdiff_t, ptrdiff_t> slices_r = slices_tuple.get<r>();
       first[r] = slices_r.first;
-      last[r] = slices_r.second;      
+      last[r] = slices_r.second;
+      R[current_R_position++] = r;      
     }
     else if constexpr (is_convertible_v<slices_tuple.get<r>(), all_type>) {
       first[r] = 0;
       last[r] = src.extent(r);
+      R[current_R_position++] = r;      
     }
     else {
       // <i>emit an implementation-defined diagnostic</i>
       static_assert(false);
     }
   }
+
 </pre>
 
-Define `R[K]` as follows: <br/>
-<pre highlight="c++">
-  size_t k = 0;
-  for(size_t r=0; r&lt;sizeof...(slices); r++)
-    if ( slices_tuple.get<r>() <i>convertible to</i> pair&lt;ptrdiff_t,ptrdiff_t> <i>or</i> all_type ) R[k++] = r;
-  size_t K = k;
-</pre>
-Let `sub` be the return value of `subspan`,
+Let `sub` be the return value of `subspan(src, slices...)`,
 and let `E` be `mdspan_subspan<ElementType, Extents, LayoutPolicy, AccessorPolicy, SliceSpecifiers...>::extents_t`.
 <br/>
 
 Requires: <br/>
-    * `sizeof(slices...)==src.rank()` <br/>
-    * `slices_tuple.get<r>()` is convertible to `ptrdiff_t`, `pair<ptrdiff_t,ptrdiff_t>` or `all_type` <br/>
-    * 0 <= `first[r]` < `last[r]` <= `src.extent(r)` <br/>
+    * `sizeof(slices...)` equals `src.rank()`. <br/>
+    * For all `r` in `0`, `1`, ..., `sizeof...(slices)-1`,
+      `0 <= first[r] && first[r] < last[r] && last[r] <= src.extent(r)` is `true`.
 
-Postcondition: <br/>
-    * `E::rank()==K` <br/>
+Mandates: <br/>
+    * For all types `T` in the parameter pack `SliceSpecifiers...`,
+      `is_convertible_v<T, ptrdiff_t> || is_convertible_v<T, pair<ptrdiff_t, ptrdiff_t>> || is_convertible_v<T, all_type>` is `true`. <br/>
+
+Ensures: <br/>
+    * `E::rank()` equals `result_rank`. <br/>
     * Let `I...` be a multi-index such that `I[k] < sub.extents(k)` and
       `J...` be a multi-index where `J[R[k]]=first[R[k]]+I[k]` or `J[r]=first[r]` for `r` not in `R`.
       Then, `sub(I...)` and `src(J...)` refer to the same element.
     * `sub.extent(k)` equals `last[R[k]] - first[R[k]]`.
     * If `src.is_strided()`, then `sub.is_strided()` and `sub.stride(k)` equals `src.stride(R[k])`. <br/>
     * If `src.static_extent(R[k])` does not equal `dynamic_extent` and
-      `slices_tuple.get<R[k]>()` is convertible to `all_type`, 
+      `is_convertible_v<decltype(slices_tuple.get<R[k]>()), all_type>` is `true`,
       then `sub.static_extent(k)` equals `src.static_extent(R[k])`.
 <br/>
 
@@ -2534,8 +2548,9 @@ auto a_sub = subspan(a,1,std::pair<int,int>(4,6),std::pair<int,int>(1,6));
 
 // Print values of subspan
 for(int i0=0; i0<a_sub.extent(0); i0++) {
-  for(int i1=0; i1<a_sub.extent(1); i1++)
+  for(int i1=0; i1<a_sub.extent(1); i1++) {
     std::cout << a_sub(i0,i1) << " ";
+  }
   std::cout << std::endl;
 }
 

--- a/P0009/P0009.bs
+++ b/P0009/P0009.bs
@@ -2583,85 +2583,103 @@ The `SliceSpecifier` template argument(s)
 and the corresponding value(s) of the arguments of `subspan` after `src`
 determine the subset of `src` that the return value views.
 
-Define the exposition-only function `mdspan_subspan_fill_first_and_last` as follows:
+<!-- TODO add `mdspan_subspan_compute_bounds` to synopsis (2x above) -->
+
+Define the exposition-only function `mdspan_subspan_compute_bounds` as follows:
 
 <pre highlight="c++">
-template&lt;class... SliceSpecifier, size_t r>
-constexpr void mdspan_subspan_fill_first_and_last(
-  array&lt;ptrdiff_t, sizeof...(SliceSpecifier)>& first,
-  array&lt;ptrdiff_t, sizeof...(SliceSpecifier)>& last,
-  SliceSpecifier... slices)
-{
-  auto slices_tuple = forward_as_tuple(slices...);
-  using cur_type = decltype(slices_tuple.get&lt;r>());
+template&lt;class ElementType, class Extents, class LayoutPolicy,
+	 class AccessorPolicy, size_t N, size_t r,
+	 class... SliceSpecifiers>
+struct mdspan_subspan_compute_bounds_impl {};
 
-  if constexpr (is_convertible_v&lt;cur_type, ptrdiff_t>) {
-    first[r] = slices_tuple.get&lt;r>();
-    last[r] = first[r] + 1;
+template&lt;class ElementType, class Extents, class LayoutPolicy,
+	 class AccessorPolicy, size_t N, size_t r>
+struct mdspan_subspan_compute_bounds_impl&lt;ElementType, Extents, LayoutPolicy,
+                                          AccessorPolicy, N, r>
+{
+  using array_type = array&lt;ptrdiff_t, N>;
+  using mdspan_type = basic_mdspan&lt;ElementType, Extents, LayoutPolicy,
+				   AccessorPolicy>;
+  static void run (array_type& first, array_type& last, const mdspan_type&) {}
+};
+
+template&lt;class ElementType, class Extents, class LayoutPolicy,
+	 class AccessorPolicy, size_t N, size_t r,
+	 class HeadSliceSpecifier, class... TailSliceSpecifiers>
+struct mdspan_subspan_compute_bounds_impl&lt;ElementType, Extents, LayoutPolicy,
+                                          AccessorPolicy, N, r, HeadSliceSpecifier,
+                                          TailSliceSpecifiers...>
+{
+  using array_type = array&lt;ptrdiff_t, N>;
+  using mdspan_type = basic_mdspan&lt;ElementType, Extents, LayoutPolicy,
+				   AccessorPolicy>;
+  static void run (array_type& first, array_type& last, const mdspan_type& src,
+		   HeadSliceSpecifier head, TailSliceSpecifiers... tail)
+  {
+    if constexpr (is_convertible_v&lt;HeadSliceSpecifier, ptrdiff_t>) {
+      first[r] = head;
+      last[r] = first[r] + 1;
+    }
+    else if constexpr (is_convertible_v&lt;HeadSliceSpecifier,
+		                        pair&lt;ptrdiff_t, ptrdiff_t>>) {
+      const pair&lt;ptrdiff_t, ptrdiff_t> cur_bounds = head;
+      first[r] = cur_bounds.first;
+      last[r] = cur_bounds.second;
+    }
+    else if constexpr (is_convertible_v&lt;HeadSliceSpecifier, all_type>) {
+      first[r] = 0;
+      last[r] = src.extent(r);
+    }
+
+    using recurse_type =
+      mdspan_subspan_compute_bounds_impl&lt;ElementType, Extents, LayoutPolicy,
+					 AccessorPolicy, N, r+1,
+					 TailSliceSpecifiers...>;
+    recurse_type::run (first, last, src, tail...);
   }
-  else if constexpr (is_convertible_v&lt;cur_type, pair&lt;ptrdiff_t, ptrdiff_t>>) {
-    const pair&lt;ptrdiff_t, ptrdiff_t> slices_r = slices_tuple.get&lt;r>();
-    first[r] = slices_r.first;
-    last[r] = slices_r.second;
-  }
-  else if constexpr (is_convertible_v&lt;cur_type, all_type>) {
-    first[r] = 0;
-    last[r] = src.extent(r);
-  }
+};
+
+template&lt;class ElementType, class Extents, class LayoutPolicy,
+	 class AccessorPolicy, class... SliceSpecifier>
+void mdspan_subspan_compute_bounds (array&lt;ptrdiff_t, sizeof...(SliceSpecifier)>& first,
+				    array&lt;ptrdiff_t, sizeof...(SliceSpecifier)>& last,
+				    const basic_mdspan&lt;ElementType, Extents, LayoutPolicy, AccessorPolicy>& src,
+				    SliceSpecifier... slices)
+{
+  constexpr size_t N = sizeof...(SliceSpecifier);
+  constexpr size_t r = 0;
+  using impl_type =
+    mdspan_subspan_compute_bounds_impl&lt;ElementType, Extents, LayoutPolicy,
+				       AccessorPolicy, N, r, SliceSpecifier...>;
+  impl_type::run (first, last, src, slices...);
 }
 </pre>
 
-Define the exposition-only struct `mdspan_subspan_first_and_last` as follows:
-
-Let `first` and `last` be exposition-only 
-`array<ptrdiff_t, sizeof...(SliceSpecifier)`.
-Define `first` and `last` as in the following code:
-
-Let `R` be an exposition-only
-`array<ptrdiff_t, mdspan_subspan_rank_v<SliceSpecifier...>>`.
-Define `R` as in the following code:
-
-
+Let `first` and `last` be exposition-only `array<ptrdiff_t, sizeof...(SliceSpecifier)>`, computed as if in the code that follows, where `src` and `slices...` are the arguments given to `subspan`:
 <pre highlight="c++">
-  constexpr size_t result_rank = mdspan_subspan_rank_v(slices...);
-  constexpr size_t num_args = sizeof...(SliceSpecifier);
-  
-  auto slices_tuple = forward_as_tuple(slices...);
-  
-  size_t current_R_position = 0;
-  for(size_t r=0; r&lt;sizeof...(slices); r++) {
-    using cur_type = decltype(slices_tuple.get&lt;r>());
-
-    if constexpr (is_convertible_v&lt;cur_type, ptrdiff_t>) {
-      first[r] = slices_tuple.get<r>();
-      last[r] = first[r] + 1;
-    }
-    else if constexpr (is_convertible_v&lt;cur_type, pair&lt;ptrdiff_t, ptrdiff_t>>) {
-      const pair&lt;ptrdiff_t, ptrdiff_t> slices_r = slices_tuple.get&lt;r>();
-      first[r] = slices_r.first;
-      last[r] = slices_r.second;
-      R[current_R_position++] = r;      
-    }
-    else if constexpr (is_convertible_v&lt;cur_type, all_type>) {
-      first[r] = 0;
-      last[r] = src.extent(r);
-      R[current_R_position++] = r;      
-    }
-  }
-
+array&lt;ptrdiff_t, sizeof...(SliceSpecifier)>> first;
+array&lt;ptrdiff_t, sizeof...(SliceSpecifier)>> last;
+mdspan_subspan_compute_bounds (first, last, src, slices...);
 </pre>
 
-*[Note:* The code above is not a suggested implementation. *— end note]*
-
-
-Let `sub` be the return value of `subspan(src, slices...)`.
-Let &rho; equal `sub.rank()`.
-Denote the value of the <math>k</math>-th member of `slices...`
-by <math>s<sub>k</sub></math>.
 If `i...` is a pack of integers other than `slices...`,
 then denote the value of the
 <math>k</math>-th member of `i...` by <math>i<sub>k</sub></math>.
-We say that the integer r "is not in `R`" when, for 0 <= k < &rho;, r &ne; `R[k]`.
+
+Let &rho; equal `sub.rank()`.
+
+Denote the value of the <math>k</math>-th member of `slices...`
+by <math>s<sub>k</sub></math>.
+
+Define `rank_map` as the length &rho; `std::integer_sequence` of `ptrdiff_t` consisting of all k such that `is_convertible_v<`<math>s<sub>k</sub></math>`, pair<ptrdiff_t, ptrdiff_t>> || is_convertible_v<`<math>s<sub>k</sub></math>`, all_type>` is `true`.
+
+Define the exposition-only `constexpr` function `get_seq<k>(seq)` as the function returning the `k`-th entry of the `std::integer_sequence` `seq`.
+
+We say that the integer r "is not in `rank_map`" when,
+for 0 <= `k` < &rho;, r does not equal `get_seq<k>(rank_map)`.
+
+Let `sub` be the return value of `subspan(src, slices...)`.
 
 * *Requires:*
     * `sizeof(slices...)` equals `src.rank()`.
@@ -2671,24 +2689,27 @@ We say that the integer r "is not in `R`" when, for 0 <= k < &rho;, r &ne; `R[k]
     * For all types `T` in the parameter pack `SliceSpecifiers...`,
       `is_convertible_v<T, ptrdiff_t> || is_convertible_v<T, pair<ptrdiff_t, ptrdiff_t>> || is_convertible_v<T, all_type>` is `true`.
 * *Ensures:*
-    * `mdspan_subspan<ElementType, Extents, LayoutPolicy, AccessorPolicy, SliceSpecifiers...>::extents_t::rank()` equals `result_rank`.
+    * `mdspan_subspan<ElementType, Extents, LayoutPolicy, AccessorPolicy, SliceSpecifiers...>::extents_t::rank()` equals &rho;.
     * Let the pack `i...` denote a multi-index in the domain of `sub`
       such that i<sub>k</sub></math> < `sub.extents(k)` for 0 <= `k` < &rho;.
       Let the pack `j...` denote a multi-index in the domain of `src` where
-      <math>j<sub>`R[k]`</sub></math> equals `first[R[k]]` + <math>i<sub>k</sub></math>
+      the `get_seq<k>(rank_map)`-th entry of `j`
+      equals `first[get_seq<k>(rank_map)]` + <math>i<sub>k</sub></math>
       for 0 <= `k` < <math>&rho;</math>, 
       and <math>j<sub>r</sub></math> equals `first[r]`
-      for all `r` such that 0 <= `r` < `src.rank()` and `r` is not in `R`.
+      for all `r` such that 0 <= `r` < `src.rank()` and `r` is not in `rank_map`.
       Then, `sub(i...)` and `src(j...)` refer to the same element.
-    * `sub.extent(k)` equals `last[R[k]] - first[R[k]]`.
+    * `sub.extent(k)` equals
+      `last[get_seq<k>(rank_map)] - first[get_seq<k>(rank_map)]`.
     * If `src.is_strided()`, then `sub.is_strided()` is `true` and
-      `sub.stride(k)` equals `src.stride(R[k])`.
+      `sub.stride(k)` equals `src.stride(get_seq<k>(rank_map))`.
     * Let `slices_tuple` equal `forward_as_tuple(slices...)`.
-      For all 0 <= k < &rho;, 
-      if `src.static_extent(R[k])` does not equal `dynamic_extent` and
-      `is_convertible_v<decltype(slices_tuple.get<R[k]>()), all_type>` is `true`,
-      then `sub.static_extent(k)` equals `src.static_extent(R[k])`.
-      *[Note:* `R[k]` is a `constexpr` integer. *— end note]*
+      For all 0 <= `k` < &rho;, 
+      if `src.static_extent(get_seq<k>(rank_map))` does not equal
+      `dynamic_extent` and
+      `is_convertible_v<decltype(slices_tuple.get<get_seq<k>(rank_map)>()), all_type>` is `true`,
+      then `sub.static_extent(k)` equals
+      `src.static_extent(get_seq<k>(rank_map))`.
 
 <br/>
 

--- a/P0009/P0009.bs
+++ b/P0009/P0009.bs
@@ -956,7 +956,7 @@ static constexpr size_t rank() const noexcept;
 ```c++
 static constexpr size_t rank_dynamic() const noexcept;
 ```
-* *Returns:* `((Extents==dynamic_extent)+...)` *[Note:* This is the number of dynamic extents *—end note]*
+* *Returns:* `((Extents==dynamic_extent)+...)`. *[Note:* This is the number of dynamic extents. *—end note]*
 
 <br/>
 ```c++
@@ -990,7 +990,7 @@ template<ptrdiff_t... LHS, ptrdiff_t... RHS>
   constexpr bool operator!=(const extents<LHS...>& lhs, const extents<RHS...>& rhs) noexcept;
 ```
 
-* *Returns:* `!(lhs==rhs)`
+* *Returns:* `!(lhs==rhs)`.
 
 <!--
 888                                     888                                                  d8b
@@ -1014,9 +1014,9 @@ template<ptrdiff_t... LHS, ptrdiff_t... RHS>
 
 1. A *layout mapping policy* is a class that contains a *layout mapping*, a nested class template.
 
-2. A *layout mapping policy* shall meet the requirements in Table �.
+2. A *layout mapping policy* meets the requirements in Table �.
 
-3. A *layout mapping* shall meet the requirements of `DefaultConstructible`, `CopyAssignable`, `EqualityComparable`, and the requirements in Table �.
+3. A *layout mapping* meets the requirements of *Cpp17DefaultConstructible*, *Cpp17CopyAssignable*, *Cpp17EqualityComparable*, and the requirements in Table �.
 
 4. In Table �:
     * `MP` denotes a layout mapping policy.
@@ -1032,8 +1032,8 @@ Table � — Layout mapping policy and layout mapping requirements
 <tr>
   <th>Expression</th>
   <th>Return Type</th>
-  <th>Operational Semantics</th>
-  <th>Requires/Remarks</th>
+  <th>Returns</th>
+  <th>Requires</th>
 </tr>
 <tr>
   <td>`MP::template mapping<E>`</td>
@@ -1066,13 +1066,13 @@ Table � — Layout mapping policy and layout mapping requirements
 <tr>
   <td>`m.is_unique()`</td>
   <td>`bool`</td>
-  <td>*Returns:* `true` if `m(i...)!=m(j...)` for every `i...!=j...` </td>
+  <td>*Returns:* `true` if for every `i...!=j...`, `m(i...)!=m(j...)`. </td>
   <td></td>
 </tr>
 <tr>
   <td>`m.is_contiguous()`</td>
   <td>`bool`</td>
-  <td>*Returns:* `true` if the set of values defined by `m(i)...` is equal to the set of values consisting of `0`...`m.required_span_size()-1` </td>
+  <td>*Returns:* `true` if the set of values defined by `m(i)...` is equal to the set of values consisting of `0`...`m.required_span_size()-1`. </td>
   <td></td>
 </tr>
 <tr>
@@ -1084,26 +1084,26 @@ Table � — Layout mapping policy and layout mapping requirements
 <tr>
   <td>`M::is_always_unique()`</td>
   <td>`bool`</td>
-  <td>*Returns:* `true` if `m.is_unique()==true` for any object of type `M`.</td>
+  <td>*Returns:* `true` if `m.is_unique()` is `true` for any object of type `M`.</td>
   <td></td>
 </tr>
 <tr>
   <td>`M::is_always_contiguous()`</td>
   <td>`bool`</td>
-  <td>*Returns:* `true` if `m.is_contiguous()==true` for any object of type `M`.</td>
+  <td>*Returns:* `true` if `m.is_contiguous()` is `true` for any object of type `M`.</td>
   <td></td>
 </tr>
 <tr>
   <td>`M::is_always_strided()`</td>
   <td>`bool`</td>
-  <td>*Returns:* true if `m.is_strided()==true` for any object of type `M`.</td>
+  <td>*Returns:* true if `m.is_strided()` is `true` for any object of type `M`.</td>
   <td></td>
 </tr>
 <tr>
   <td>`m.stride(r)`</td>
   <td>`E::index_type`</td>
   <td>*Returns:* `m(j...) - m(i...)` when all members of `j...` and `i...` are equal except for the `r`*th* member such that `j[r]==i[r]+1`.</td>
-  <td>*Requires:* `m.is_strided()==true`</td>
+  <td>*Requires:* `m.is_strided()` is `true`. </td>
 </tr>
 </table>
 
@@ -1198,7 +1198,7 @@ constexpr mapping() noexcept;
 ```
 
 * *Effects:* Default-initializes `extents_`.
-* *Postconditions:* `extents()==Extents()`
+* *Ensures:* `extents()==Extents()` is `true`.
 
 <!-- --- -->
 
@@ -1209,7 +1209,7 @@ constexpr mapping(const mapping& other) noexcept;
 ```
 
 * *Effects:* Initializes `extents_` with `other.extents_`.
-* *Postconditions:* `extents()==other.extents()`.
+* *Ensures:* `extents()==other.extents()` is `true`.
 
 <!-- --- -->
 
@@ -1220,7 +1220,8 @@ constexpr mapping(mapping&& other) noexcept;
 ```
 
 * *Effects:* Initializes `extents_` with `move(other.extents_)`.
-* *Postconditions:* `extents()` returns a copy of an `Extents` that is equal to the copy returned by `other.extents()` before the invocation of the move.
+* *Ensures:* `extents()` equals the result of `other.extents()` before the invocation of the move.
+<!-- TODO "before the invocation of the move"??? sequenced-before??? -->
 
 <!-- --- -->
 
@@ -1231,8 +1232,7 @@ constexpr mapping(const Extents & e) noexcept;
 ```
 
 * *Effects:* Initializes `extents_` with `e`.
-* *Postconditions:* `extents()==e`.
-
+* *Ensures:* `extents()==e` is `true`.
 
 <br/>
 
@@ -1243,8 +1243,8 @@ constexpr mapping(const mapping<OtherExtents>& other);
 
 * *Requires:* `other.extents()` meets the requirements for use in the initialization of `extents_`.
 * *Effects:* Initializes `extents_` with `other.extents()`.
-* *Postconditions:* `extents()==other.extents_`.
-* *Throws:* nothing.
+* *Ensures:* `extents()==other.extents_` is `true`.
+* *Throws:* Nothing.
 
 <br/>
 
@@ -1270,7 +1270,9 @@ Extents extents() const noexcept;
 typename Extents::index_type required_span_size() const noexcept;
 ```
 
-* *Returns:* The product of `extents().extent(r)` for all `r` where 0 <= `r` < `extents().rank()`
+* *Returns:* The product of `extents().extent(r)` for all `r` where 0 <= `r` < `extents().rank()`. <!-- TODO WHAT IF rank is zero?!? -->
+
+<!-- TODO FIX EASY STUFF BELOW HERE -->
 
 <!-- --- -->
 
@@ -1282,6 +1284,7 @@ template<class... Indices>
 
 Let `i[k]` denote the `k`*th* member of `i...`.
 
+* *Constraints:* `sizeof...(Indices)==extents().rank() && (is_convertible_v<Indices, typename Extents::index_type> && ...)` is `true`.
 * *Returns:* Equivalent to `offset` in
 
 ```
@@ -1290,9 +1293,6 @@ for(size_t k=0; k<extents.rank(); ++k)
   offset += i[k]*stride(k);
 ```
 
-* *Remarks:* This operator shall not participate in overload resolution unless
-    * `sizeof...(Indices)==extents().rank()`,
-    * and `is_convertible_v<Indices, typename Extents::index_type> && ...`
 
 
 ```
@@ -1313,7 +1313,7 @@ constexpr bool is_strided() const;
 <br/>
 
 ```c++
-typename Extents::index_type stride(size_t r) const
+typename Extents::index_type stride(size_t r) const;
 ```
 
 * *Returns:* Equivalent to `s` in
@@ -1330,7 +1330,7 @@ template<class OtherExtents>
   constexpr bool operator==(const mapping<OtherExtents>& other) const noexcept;
 ```
 
-* *Returns:* `extents()==other.extents()`.
+* *Returns:* `extents()==other.extents()` is `true`.
 
 <br/>
 ```c++
@@ -1338,7 +1338,7 @@ template<class OtherExtents>
   constexpr bool operator!=(const mapping<OtherExtents>& other) const noexcept;
 ```
 
-* *Returns:* `extents()!=other.extents()`.
+* *Returns:* `extents()!=other.extents()` is `true`.
 
 
 <!--
@@ -1425,7 +1425,7 @@ constexpr mapping() noexcept;
 ```
 
 * *Effects:* Default-initializes `extents_`.
-* *Postconditions:* `extents()==Extents()`
+* *Ensures:* `extents()==Extents()` is `true`.
 
 <!-- --- -->
 
@@ -1436,7 +1436,7 @@ constexpr mapping(const mapping& other) noexcept;
 ```
 
 * *Effects:* Initializes `extents_` with `other.extents_`.
-* *Postconditions:* `extents()==other.extents()`.
+* *Ensures:* `extents()==other.extents()` is `true`.
 
 <!-- --- -->
 
@@ -1447,7 +1447,7 @@ constexpr mapping(mapping&& other) noexcept;
 ```
 
 * *Effects:* Initializes `extents_` with `move(other.extents_)`.
-* *Postconditions:* `extents()` returns a copy of an `Extents` that is equal to the copy returned by `other.extents()` before the invocation of the move.
+* *Ensures:* `extents()` equals the result of `other.extents()` before the invocation of the move.
 
 <!-- --- -->
 
@@ -1458,7 +1458,7 @@ constexpr mapping(Extents e) noexcept;
 ```
 
 * *Effects:* Initializes `extents_` with `e`.
-* *Postconditions:* `extents()==e`.
+* *Ensures:* `extents()==e` is `true`.
 
 <br/>
 
@@ -1469,7 +1469,7 @@ template<class OtherExtents>
 
 * *Requires:* `other.extents()` meets the requirements for use in the initialization of `extents_`.
 * *Effects:* Initializes `extents_` with `other.extents()`.
-* *Postconditions:* `extents()==other.extents()`.
+* *Ensures:* `extents()==other.extents()` is `true`.
 * *Throws:* nothing.
 <!-- --- -->
 
@@ -1497,7 +1497,7 @@ Extents extents() const noexcept;
 typename Extents::index_type required_span_size() const noexcept;
 ```
 
-* *Returns:* The product of `extents().extent(r)` for all `r` where 0 <= `r` < `extents().rank()`
+* *Returns:* The product of `extents().extent(r)` for all `r` where 0 <= `r` < `extents().rank()`.
 
 <!-- --- -->
 
@@ -1510,6 +1510,7 @@ template<class... Indices>
 
 Let `i[k]` denote the `k`*th* member of `i...`.
 
+* *Constraints:* `sizeof...(Indices)==extents().rank() && (is_convertible_v<Indices, typename Extents::index_type> && ...)` is `true`.
 * *Returns:* Equivalent to `offset` in
 
 ```
@@ -1517,11 +1518,6 @@ index_type offset = 0;
 for(size_t k=0; k<Extents::rank(); ++k) 
   offset += i[k]*stride(k);
 ```
-
-* *Remarks:* This operator shall not participate in overload resolution unless
-    * `sizeof...(Indices)==extents().rank()`,
-    * and `is_convertible_v<Indices, typename Extents::index_type> && ...`
-
 
 <br/>
 
@@ -1534,7 +1530,7 @@ constexpr bool is_contiguous() const noexcept;
 constexpr bool is_strided() const noexcept;
 ```
 
-* *Returns:* `true`
+* *Returns:* `true`.
 
 <br/>
 
@@ -1556,7 +1552,7 @@ template<class OtherExtents>
   constexpr bool operator==(const mapping<OtherExtents>& other) const noexcept;
 ```
 
-* *Returns:* `extents()==other.extents()`.
+* *Returns:* `extents()==other.extents()` is `true`.
 
 <br/>
 ```c++
@@ -1564,7 +1560,7 @@ template<class OtherExtents>
   constexpr bool operator!=(const mapping<OtherExtents>& other) const noexcept;
 ```
 
-* *Returns:* `extents()!=other.extents()`.
+* *Returns:* `extents()!=other.extents()` is `true`.
 
 
 <!-- 
@@ -1654,40 +1650,42 @@ struct layout_stride {
 ```c++
 constexpr mapping() noexcept;
 ```
-* Effects: Default-initializes extents_.
-* Postconditions: `extents()==Extents()` and `strides()==array<typename Extents::index_type, Extents::rank()>()`
+* *Effects:* Default-initializes `extents_`.
+* *Ensures:* `extents()==Extents() && strides()==array<typename Extents::index_type, Extents::rank()>()` is `true`.
 
 ```c++
 constexpr mapping(const mapping& other) noexcept;
 ```
-* Effects: Initializes extents_ with other.extents_.
-* Postconditions: `extents()==other.extents()` and `strides()==other.strides()`
+* *Effects:* Initializes `extents_` with `other.extents_`.
+* *Ensures:* `extents()==other.extents() && strides()==other.strides()` is `true`.
 
 ```c++
 constexpr mapping(mapping&& other) noexcept;
 ```
-* Effects: Initializes extents_ with `move(other.extents_)`.
-* Postconditions: `extents()` returns a copy of an Extents that is equal to the copy returned by `other.extents()` before the invocation of the move and `strides()` returns a copy of an `array<typename Extents::index_type,Extents::rank()>` that is equal to the copy returned by `other.strides()` before the invocation of the move
+* *Effects:* Initializes `extents_` with `move(other.extents_)`.
+* *Ensures:* `extents()` equals the result of `other.extents()` before the invocation of the move, and `strides()` equals the result of `other.strides()` before the invocation of the move.
 
 
 ```c++
 constexpr mapping(Extents e, array<typename Extents::index_type, Extents::rank()> s) noexcept;
 ```
-* Requires: 
+* *Requires:*
    + `s[i]>0` for 0 < `i` <= `Extents::rank()`
-   + there is a permutation of the numbers `0,`...`,Extents::rank()-1` `o(i)` with 0 <= `i` < `Extents::rank()` such that `s(o(i))>=s(o(i-1))*e.extent(o(i-1))` for 1 <= `i` < `Extents::rank()`
-* Effects: Initializes `extents_` with `e` and `strides_` with `s`
-* Postconditions: `extents()==e` and `strides()==s`.
-* Throws: nothing
+   + There exists a permutation `o(i)` of the numbers `0`, ..., `Extents::rank()-1` 
+     with 0 <= `i` < `Extents::rank()` such that
+     `s(o(i))>=s(o(i-1))*e.extent(o(i-1))` for 1 <= `i` < `Extents::rank()`. <!-- FIXME CODE TO MATH -->
+* *Effects:* Initializes `extents_` with `e` and `strides_` with `s`.
+* *Ensures:* `extents()==e && strides()==s` is `true`.
+* *Throws:* Nothing.
 
 ```c++
 template<class OtherExtents>
   constexpr mapping(const mapping<OtherExtents>& other);
 ```
-* Requires: other.extents() meets the requirements for use in the initialization of extents_.
-* Effects: Initializes `extents_` with `other.extents()` and initializes `strides_` with `other.strides()`.
-* Postconditions: `extents()==other.extents()` and `strides()==other.strides()`.
-* Throws: nothing.
+* *Requires:* `other.extents()` meets the requirements for use in the initialization of `extents_`.
+* *Effects:* Initializes `extents_` with `other.extents()`, and initializes `strides_` with `other.strides()`.
+* *Ensures:* `extents()==other.extents() && strides()==other.strides()` is `true`.
+* *Throws:* Nothing.
 
 
 <b>26.7.�.4.2 layout_stride::mapping operations [mdspan.layout.stride.ops]</b>
@@ -1695,27 +1693,27 @@ template<class OtherExtents>
 ```c++
 Extents extents() const noexcept;
 ```
-* Returns: extents_.
+* *Returns:* `extents_`.
 
 ```c++
 array<typename Extents::index_type, Extents::rank()> strides() const noexcept;
 ```
-* Returns: strides_.
+* *Returns:* `strides_`.
 
 ```c++
 typename Extents::index_type required_span_size() const noexcept;
 ```
-* Returns: The maximum of `extents().extent(r)*stride(r)` for all `r` where 0 <= `r` < `extents().rank()`
+* *Returns:* The maximum of `extents().extent(r)*stride(r)` for all `r` where 0 <= `r` < `extents().rank()`.
 
 
 ```c++
 template <class... Indices>
   typename Extents::index_type operator()(Indices... i) const noexcept;
 ```
-* Returns: If `i...` is `i0, i1, i2,`...`, ik` (where `k==Extents::rank() - 1`) and `s = strides()`, returns `i0*s[1]+i1*s[2]+`...`+ik*s[k]`
-* Remarks: This operator shall not participate in overload resolution unless
-  * `sizeof...(Indices)==Extents::rank()`,
-  * and `is_convertible_v<Indices, typename Extents::index_type> && ...`
+* *Constraints:*
+  * `sizeof...(Indices)==Extents::rank()` is `true`, and
+  * `is_convertible_v<Indices, typename Extents::index_type> && ...` is `true`.
+* *Returns:* If `i...` is `i0, i1, i2`, ..., `ik` (where `k==Extents::rank() - 1` is `true`) and `s` is `strides()`, returns `i0*s[1]+i1*s[2]+`...`+ik*s[k]`. <!-- FIXME CODE TO MATH -->
 
 
 ```c++
@@ -1724,23 +1722,23 @@ static constexpr bool is_always_strided() noexcept;
 constexpr bool is_unique() const noexcept;
 constexpr bool is_strided() const noexcept;
 ```
-* Returns: true
+* *Returns:* `true`.
 
 
 ```c++
 static constexpr bool is_always_contiguous() noexcept;
 ```
-* Returns: false
+* *Returns:* `false`.
 
 ```c++
 constexpr bool is_contiguous() const noexcept;
 ```
-* Returns: true if there is a permutation of the numbers `0,`...`,Extents::rank()-1` `o(i)` with 0 <= `i` < `Extents::rank()` such that `min(stride(o(i))==1` and `stride(o(i))==stride(o(i-1))*extents().extent(o(i-1))` with 1 <= `i` < `Extents::rank()` otherwise returns false
+* *Returns:* `true` if there is a permutation `o(i)` of the numbers `0`, ..., `Extents::rank()-1` with 0 <= `i` < `Extents::rank()` such that `min(stride(o(i))==1` is `true` and `stride(o(i))==stride(o(i-1))*extents().extent(o(i-1))` with 1 <= `i` < `Extents::rank()`.  Otherwise, returns `false`. <!-- FIXME CODE TO MATH -->
 
 ```c++
 typename Extents::index_type stride(size_t r) const noexcept;
 ```
-* Returns: `strides_(r)`
+* *Returns:* `strides_[r]`.
 
 
 <br/>
@@ -1774,10 +1772,6 @@ template<class OtherExtents>
 
 -->
 
-<!-- TODO: @CRT review whether these requirements are flexible enough -->
-<!-- TODO: Review changes here. This was too hard to specify as a nested class, and I'm not sure it buys us anything. 
-(specifically, it was getting really messy trying to allow accessor implementations to constrain what types they are valid for.) -->
-
 <br/>
 <br/>
 
@@ -1789,16 +1783,22 @@ a contiguous set of objects of type *ElementType* are accessed.
 <br/>
 <b>26.7.�.1 Accessor policy requirements [mdspan.accessor.reqs]</b>
 
-An accessor policy defines an accessor type and operations for applying
-subscripting-like [expr.sub],
-conversion to pointer [conv.array],
-and offset operations to an accessor.
-The subscript operation returns an object which provides access to the indexed element,
-this return type may not be `T&`.
-The offset operation returns an accessor for the contiguous subset of elements beginning at the offste value,
-this return type may not be the same accessor type..
-An accessor constructor may impose additional restrictions on the 
-contiguous set of objects; e.g., restrict `T` to be trivially copyable or have a wider alignment.
+An accessor policy defines
+a type through which a single element is accessed,
+a type through which the contiguous set of elements is accessed, 
+and the following operations:
+  * Access to elements in a subscripting-like **[expr.sub]** way,
+  * Conversion to a pointer **[conv.array]**, and
+  * Offsetting a pointer.
+
+The access operation returns an object that gives access to the indexed element.
+The type of this object need not necessarily be `T&`.
+The offset operation returns an object that gives access to the contiguous subset of elements beginning at the offset value; 
+the returned object need not necessarily have the same type as the object giving access to the original contiguous set of elements.
+The constructor of the object representing the contiguous set of objects
+may impose additional restrictions on the contiguous set of objects, 
+such as restricting `T` to be trivially copyable or 
+requiring a larger alignment than `alignment_of_v<T>`.
 
 In Table �:
   * `A` denotes an accessor policy.
@@ -1822,7 +1822,7 @@ Table �: Accessor policy requirements
   <td>`A::pointer`</td>
   <td></td>
   <td>Type through which the contiguous set of elements are accessed. 
-      <br>*Requires:* Meets the requirements of *DefaultConstructible*, *CopyConstructible*, and *CopyAssignable* 
+      <br>*Requires:* *Cpp17DefaultConstructible*, *Cpp17CopyConstructible*, and *Cpp17CopyAssignable*.
   </td>
 </tr>
 <tr>
@@ -1893,22 +1893,22 @@ namespace fundamentals_v3 {
 
 ```c++
 constexpr typename offset_policy::pointer
-  offset(pointer p,ptrdiff_t i ) const noexcept ;
+  offset(pointer p,ptrdiff_t i ) const noexcept;
 ```
 
-* *Returns:* `p+i` <br/>
+* *Returns:* `p+i`. <br/>
 
 ```c++
-constexpr reference access(pointer p,ptrdiff_t i) const noexcept ;
+constexpr reference access(pointer p,ptrdiff_t i) const noexcept;
 ```
 
-* *Returns:* `p[i]` <br/>
+* *Returns:* `p[i]`. <br/>
 
 ```c++
-constexpr pointer decay(pointer p) const noexcept ;
+constexpr pointer decay(pointer p) const noexcept;
 ```
 
-* *Returns:* `p` <br/>
+* *Returns:* `p`. <br/>
 
 <!--
 888                        d8b                                      888
@@ -1934,12 +1934,12 @@ constexpr pointer decay(pointer p) const noexcept ;
 <b>26.7.� Class template `basic_mdspan` [mdspan.basic]</b>
 
 1. The `basic_mdspan` class template maps a multi-index within a multi-index *domain* to a reference to an element in the *codomain* `span`.
-2. The multi-index domain space is the Cartesian product of the extents: `[0, extent(0)) * [0, extent(1)) *` ... `* [0, extent(rank() - 1))`. Each extent may be statically or dynamically specified.
+2. The multi-index domain space is the Cartesian product of the extents: `[0, extent(0)) * [0, extent(1)) *` ... `* [0, extent(rank() - 1))`. Each extent may be statically or dynamically specified. <!-- FIXME CODE TO MATH -->
 2. As with `span`, the storage of the objects in the codomain `span` of a `basic_mdspan` is owned by some other object.
 3. `ElementType` is required to be a complete object type that is not an abstract class type or an array type.
 4. `Extents` is required to be a (cv-unqualified) specialization of `extents`.
-5. `LayoutPolicy` is required meet the layout mapping policy requirements, otherwise the program is ill-formed.
-6. `AccessorPolicy` is required meet the accessor policy requirements and `!std::is_same_v<typename AccessorPolicy::element_type,ElementType>`, otherwise the program is ill-formed.
+5. `LayoutPolicy` is required to meet the layout mapping policy requirements, otherwise the program is ill-formed.
+6. `AccessorPolicy` is required to meet the accessor policy requirements and `std::is_same_v<typename AccessorPolicy::element_type,ElementType>` must be `false`, otherwise the program is ill-formed.
 
 
 <pre highlight="c++">
@@ -2042,16 +2042,15 @@ private:
 constexpr basic_mdspan() noexcept = default;
 ```
 
-<!-- TODO check for periods, commas, and "and" here. -->
 <!-- TODO: decide if we want to include invocation of `span()` in the postconditions. An accessor may want to make this undefined behavior. -->
 * *Effects:*
-    * zero-initializes `ptr_`
-    * value-initializes `map_`
-    * value-initializes `acc_`
-* *Postconditions:* 
-    + `size()==0`
-    + `extents()==Extents()`
-    + `mapping()==mapping_type()`
+    * Zero-initializes `ptr_`,
+    * Value-initializes `map_`, and
+    * Value-initializes `acc_`.
+* *Ensures:* 
+    + `size()==0` is `true`,
+    + `extents()==Extents()` is `true`, and
+    + `mapping()==mapping_type()` is `true`.
 
 <br/>
 
@@ -2060,13 +2059,13 @@ constexpr basic_mdspan(const basic_mdspan& other) noexcept = default;
 ```
 
 * *Effects:*
-    + initializes `ptr_` with `other.ptr_`
-    + initializes `map_` with `other.map_`
-    + initializes `acc_` with `other.acc_`
-* *Postconditions:*
-    + `size()==other.size()`
-    + `extents()==other.extents()`
-    + `mapping()==other.mapping()`
+    + Initializes `ptr_` with `other.ptr_`,
+    + Initializes `map_` with `other.map_`, and
+    + Initializes `acc_` with `other.acc_`.
+* *Ensures:*
+    + `size()==other.size()` is `true`,
+    + `extents()==other.extents()` is `true`, and
+    + `mapping()==other.mapping()` is `true`.
 
 <br/>
 
@@ -2075,9 +2074,9 @@ constexpr basic_mdspan(basic_mdspan&& other) noexcept;
 ```
 
 * *Effects:*
-    + initializes `ptr_` with `move(other.ptr_)`
-    + initializes `map_` with `move(other.map_)`
-    + initializes `acc_` with `move(other.acc_)`
+    + Initializes `ptr_` with `move(other.ptr_)`,
+    + Initializes `map_` with `move(other.map_)`, and
+    + Initializes `acc_` with `move(other.acc_)`.
 
 <br/>
 
@@ -2086,20 +2085,19 @@ template<class... IndexType>
   explicit constexpr basic_mdspan(pointer ptr, IndexType... dynamic_extents);
 ```
 
-* *Requires:* `[accessor_type().decay(ptr), accessor_type().decay(ptr)+mapping_type(Extents(dynamic_extents...)).required_span_size())` shall be a valid range.
+* *Constraints:* 
+    + `is_convertible_v<IndexType, index_type> && ...` is `true`,
+    + `sizeof...(dynamic_extents)==rank_dynamic()` is `true`,
+    + `is_constructible_v<mapping_type, Extents>` is `true`, and
+    + `is_constructible_v<accessor_type, pointer>` is `true`.
+* *Requires:* `[accessor_type().decay(ptr), accessor_type().decay(ptr)+mapping_type(Extents(dynamic_extents...)).required_span_size())` is a valid range.
 * *Effects:*
-    + initializes `ptr_` with `ptr`
-    + initializes `map_` with `Extents(dynamic_extents...)`
-    + value-initializes `acc_`
-* *Postconditions:* 
-    + `extents()==Extents(dynamic_extents...)`
-    + `mapping()==mapping_type(Extents(dynamic_extents...))`
-* *Remarks:* This constructor will not participate in overload resolution unless:
-    + `(is_convertible_v<IndexType, index_type> && ...)`,
-    + `sizeof...(dynamic_extents)==rank_dynamic()`,
-    + `is_constructible_v<mapping_type, Extents>`, and
-    + `is_constructible_v<accessor_type, pointer>`.
-
+    + Initializes `ptr_` with `ptr`,
+    + Initializes `map_` with `Extents(dynamic_extents...)`, and
+    + Value-initializes `acc_`.
+* *Ensures:* 
+    + `extents()==Extents(dynamic_extents...)` is `true`, and
+    + `mapping()==mapping_type(Extents(dynamic_extents...))` is `true`.
 * *Throws:* Nothing.
 
 <br/>
@@ -2109,13 +2107,13 @@ template<class IndexType, size_t N>
   explicit constexpr basic_mdspan(pointer p, const array<IndexType, N>& dynamic_extents);
 ```
 
-* *Requires:* `[acc_.decay(ptr), acc_.decay(ptr)+mapping_type(Extents(dynamic_extents)).required_span_size())` shall be a valid range.
+* *Constraints:*
+    + `is_convertible_v<IndexType, index_type>` is `true`, 
+    + `N==rank_dynamic()` is `true`,
+    + `is_constructible_v<mapping_type, Extents>` is `true`, and
+    + `is_constructible_v<accessor_type, pointer>` is `true`.
+* *Requires:* `[acc_.decay(ptr), acc_.decay(ptr)+mapping_type(Extents(dynamic_extents)).required_span_size())` is a valid range.
 * *Effects:* Equivalent to `basic_mdspan(p, dynamic_extents[Rs]...)`, with `Rs...` from `index_sequence<Rs...>` matching `make_index_sequence<N>`.
-* *Remarks:* This constructor does not participate in overload resolution unless
-    + `IndexType` is convertible to `index_type`, and
-    + `N==rank_dynamic()`,
-    + `is_constructible_v<mapping_type, Extents>`, and
-    + `is_constructible_v<accessor_type, pointer>`.
 * *Throws:* Nothing.
 
 <br/>
@@ -2124,16 +2122,15 @@ template<class IndexType, size_t N>
 constexpr basic_mdspan(pointer p, const mapping_type& m);
 ```
 
-* *Requires:* `[acc_.decay(ptr), acc_.decay(ptr)+m.required_span_size())` shall be a valid range.
+* *Constraints:* `is_constructible_v<accessor_type, pointer>` is `true`.
+* *Requires:* `[acc_.decay(ptr), acc_.decay(ptr)+m.required_span_size())` is a valid range.
 * *Effects:*
-    + initializes `ptr_` with `p`
-    + initializes `map_` with `m`
-    + value-initializes `acc_`
-* *Remarks:* This constructor does not participate in overload resolution unless
-    + `is_constructible_v<accessor_type, pointer>`.
-* *Postconditions:* 
-    + `extents()==m.extents()`
-    + `mapping()==m`
+    + Initializes `ptr_` with `p`,
+    + Initializes `map_` with `m`, and
+    + Value-initializes `acc_`
+* *Ensures:* 
+    + `extents()==m.extents()` is `true`, and
+    + `mapping()==m` is `true`.
 * *Throws:* Nothing.
 
 <br/>
@@ -2142,14 +2139,14 @@ constexpr basic_mdspan(pointer p, const mapping_type& m);
 constexpr basic_mdspan(pointer p, const mapping_type& m, const accessor_type& a);
 ```
 
-* *Requires:* `[ptr, ptr+m.required_span_size())` shall be a valid range.
+* *Requires:* `[ptr, ptr+m.required_span_size())` is a valid range.
 * *Effects:*
-    + initializes `ptr_` with `p`
-    + initializes `map_` with `m`
-    + initializes `acc_` with `a`
-* *Postconditions:* 
-    + `extents()==m.extents()`
-    + `mapping()==m`
+    + Initializes `ptr_` with `p`,
+    + Initializes `map_` with `m`, and
+    + Initializes `acc_` with `a`.
+* *Ensures:* 
+    + `extents()==m.extents()` is `true`, and
+    + `mapping()==m` is `true`.
 * *Throws:* Nothing.
 
 <br/>
@@ -2160,21 +2157,20 @@ template<class OtherElementType, class OtherExtents, class OtherLayoutPolicy, cl
   constexpr basic_mdspan(const basic_mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessor>& other);
 ```
 
+* *Constraints:*
+    + `is_convertible_v<OtherElementType(*)[], ElementType(*)[]>` is `true`, <!-- lifted directly from span wording -->
+    + `is_convertible_v<OtherLayoutPolicy::template mapping<OtherExtents>, mapping_type` is `true`,
+    + `is_convertible_v<OtherAccessor, Accessor>` is `true`, and
+    + `is_convertible_v<OtherAccessor::pointer, pointer>` is `true`.
 * *Requires:*
-    + For all `r` in the range `[0, rank())`, if `other.static_extent(r)==dynamic_extent` or `static_extent(r)==dynamic_extent`, then `other.extent(r)==extent(r)`
+    + For all `r` in the range `[0, rank())`, if `other.static_extent(r)==dynamic_extent || static_extent(r)==dynamic_extent` is `true`, then `other.extent(r)==extent(r)` is `true`.
 * *Effects:*
-    + initializes `ptr_` with `other.ptr_`
-    + initializes `map_` with `other.map_`
-    + initializes `acc_` with `other.acc_`
-* *Postconditions:* 
-    + `extents()==Extents(other.extents())`
-    + `mapping()==mapping_type(other.mapping())`
-
-* *Remarks:* This constructor will not participate in overload resolution unless all of the following conditions are met:
-    + `OtherElementType(*)[]` is convertible to `ElementType(*)[]`, <!-- lifted directly from span wording -->
-    + `OtherLayoutPolicy::template mapping<OtherExtents>` is convertible to `mapping_type`
-    + `OtherAccessor` is convertible to `Accessor`, and
-    + `OtherAccessor::pointer` is convertible to `pointer`.
+    + Initializes `ptr_` with `other.ptr_`,
+    + Initializes `map_` with `other.map_`, and
+    + Initializes `acc_` with `other.acc_`.
+* *Ensures:* 
+    + `extents()==Extents(other.extents())` is `true`, and
+    + `mapping()==mapping_type(other.mapping())` is `true`.
 * *Throws:* Nothing.
 
 <br/>
@@ -2184,20 +2180,21 @@ template<class OtherElementType, class OtherExtents, class OtherLayoutPolicy, cl
   constexpr basic_mdspan& operator=(const basic_mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessor>& other);
 ```
 
+<!-- NOTE is_assignable_v<T,U> means T is assignable from U -->
+* *Constraints:*
+    + `is_assignable_v<ElementType(*)[], OtherElementType(*)[]>` is `true`, <!-- lifted directly from span wording -->
+    + `is_assignable_v<mapping_type, OtherLayoutPolicy::template mapping<OtherExtents>>` is `true`,
+    + `is_assignable_v<Accessor, OtherAccessor>` is `true`, and
+    + `is_assignable_v<pointer, OtherAccessor::pointer>` is `true`.
 * *Requires:*
-    + For all `r` in the range `[0, rank())`, if `other.static_extent(r)==dynamic_extent` or `static_extent(r)==dynamic_extent`, then `other.extent(r)==extent(r)`
+    + For all `r` in the range `[0, rank())`, if `other.static_extent(r)==dynamic_extent || static_extent(r)==dynamic_extent` is `true`, then `other.extent(r)==extent(r)` is `true`.
 * *Effects:*
-    + assigns `other.ptr_` to `ptr_`.
-    + assigns `other.map_` to `map_`
-    + assigns `other.acc_` to `acc_`
-* *Postconditions:* 
-    + `extents()==Extents(other.extents())`
-    + `mapping()==mapping_type(other.mapping())`
-* *Remarks:* This constructor will not participate in overload resolution unless all of the following conditions are met:
-    + `OtherElementType(*)[]` is assignable to `ElementType(*)[]`, <!-- lifted directly from span wording -->
-    + `OtherLayoutPolicy::template mapping<OtherExtents>` is assignable to `mapping_type`
-    + `OtherAccessor` is assignable to `Accessor`, and
-    + `OtherAccessor::pointer` is assignable to `pointer`.
+    + Assigns `other.ptr_` to `ptr_`,
+    + Assigns `other.map_` to `map_`, and
+    + Assigns `other.acc_` to `acc_`.
+* *Ensures:* 
+    + `extents()==Extents(other.extents())` is `true`, and
+    + `mapping()==mapping_type(other.mapping())` is `true`.
 * *Throws:* Nothing.
 
 
@@ -2217,8 +2214,8 @@ template<class OtherElementType, class OtherExtents, class OtherLayoutPolicy, cl
 constexpr reference operator[](index_type i) const;
 ```
 
+* *Constraints:* `rank()==1` is `true`.
 * *Effects:* Equivalent to `return (*this)(i);`.
-* *Remarks:* This operator does not participate in overload resolution unless `rank()==1`
 
 <br/>
 
@@ -2227,12 +2224,12 @@ template<class... IndexType>
   constexpr reference operator()(IndexType... indices) const;
 ```
 
+* *Constraints:*
+    + `is_convertible_v<IndexType, index_type> && ...` is `true`, and
+    + `sizeof...(IndexType)==rank()` is `true`.
 * *Requires:* 0 <= `array<index_type, sizeof...(indices)>{indices...}[r]` < `extent(r)` for all `r` in the range `[0, rank())`.
-* *Effects:* Equivalent to `return acc_.access(ptr_, map_(indices...));`
-* *Remarks:* This operator does not participate in overload resolution unless
-    + `is_convertible_v<IndexType, index_type> && ...`
-    + `sizeof...(IndexType)==rank()`
-* *Throws:* nothing.
+* *Effects:* Equivalent to `return acc_.access(ptr_, map_(indices...));`.
+* *Throws:* Nothing.
 
 <br/>
 
@@ -2242,12 +2239,11 @@ template<class IndexType, size_t N>
 ```
 
 <!-- TODO: Do I need a requires clause if I already have an equivalent effects clause? -->
-* *Effects:* Equivalent to `return std::apply(*this, indices);`
-* *Remarks:* This operator does not participate in overload resolution unless
-    + `is_convertible_v<IndexType, index_type>`
-    + `rank()==N`
+* *Constraints:*
+    + `is_convertible_v<IndexType, index_type>` is `true`, and
+    + `rank()==N` is `true`.
+* *Effects:* Equivalent to `return std::apply(*this, indices);`.
 * *Throws:* nothing.
-
 
 ```c++
 accessor_type accessor() const;
@@ -2316,7 +2312,7 @@ constexpr index_type size() const noexcept;
 constexpr index_type unique_size() const noexcept;
 ```
 
-* *Returns:* The number of unique elements in the codomain. *[Note:* If `mapping().is_unique()` is `true`, this is identical to `size()` *—end note]*
+* *Returns:* The number of unique elements in the codomain. *[Note:* If `mapping().is_unique()` is `true`, this is identical to `size()`. *—end note]*
 
 
 <!--
@@ -2361,7 +2357,7 @@ constexpr pointer data() const noexcept;
 static constexpr bool is_always_unique() noexcept;
 ```
 
-* *Returns:* `mapping_type::is_always_unique()`
+* *Returns:* `mapping_type::is_always_unique()`.
 
 <br/>
 
@@ -2369,7 +2365,7 @@ static constexpr bool is_always_unique() noexcept;
 static constexpr bool is_always_contiguous() noexcept;
 ```
 
-* *Returns:* `mapping_type::is_always_contiguous()`
+* *Returns:* `mapping_type::is_always_contiguous()`.
 
 <br/>
 
@@ -2377,7 +2373,7 @@ static constexpr bool is_always_contiguous() noexcept;
 static constexpr bool is_always_strided() noexcept;
 ```
 
-* *Returns:* `mapping_type::is_always_strided()`
+* *Returns:* `mapping_type::is_always_strided()`.
 
 <br/>
 
@@ -2385,7 +2381,7 @@ static constexpr bool is_always_strided() noexcept;
 constexpr mapping_type mapping() const noexcept;
 ```
 
-* *Returns:* `map_`
+* *Returns:* `map_`.
 
 <br/>
 
@@ -2393,7 +2389,7 @@ constexpr mapping_type mapping() const noexcept;
 constexpr bool is_unique() const noexcept;
 ```
 
-* *Returns:* `mapping().is_unique()`
+* *Returns:* `mapping().is_unique()`.
 
 <br/>
 
@@ -2401,7 +2397,7 @@ constexpr bool is_unique() const noexcept;
 constexpr bool is_contiguous() const noexcept;
 ```
 
-* *Returns:* `mapping().is_contiguous()`
+* *Returns:* `mapping().is_contiguous()`.
 
 <br/>
 
@@ -2409,7 +2405,7 @@ constexpr bool is_contiguous() const noexcept;
 constexpr bool is_strided() const noexcept;
 ```
 
-* *Returns:* `mapping().is_strided()`
+* *Returns:* `mapping().is_strided()`.
 
 <br/>
 
@@ -2417,7 +2413,7 @@ constexpr bool is_strided() const noexcept;
 constexpr index_type stride(size_t r) const;
 ```
 
-* *Returns:* `mapping().stride(r)`
+* *Returns:* `mapping().stride(r)`.
 
 
 <!--
@@ -2499,7 +2495,7 @@ Define the exposition-only metafunction `mdspan_subspan_rank_v` as follows:<br/>
 The exposition-only `struct mdspan_subspan` defines the type returned by `subspan`.
 The `extents_t` type alias is a specialization of `extents` **[mdspan.extents]**
 determined by the pre- and postconditions of `subspan` specified below.
-The `layout_t` type alias meets the requirements of a layout mapping policy [mdspan.layout.reqs]
+The `layout_t` type alias meets the requirements of a layout mapping policy **[mdspan.layout.reqs]**
 and is implementation defined.
 
 `subspan` creates a `basic_mdspan` that is a view of a (potentially trivial) subset of another `basic_mdspan`.

--- a/P0009/P0009.bs
+++ b/P0009/P0009.bs
@@ -1083,7 +1083,7 @@ Table � — Layout mapping policy and layout mapping requirements
 <tr>
   <td>`m(i...)`</td>
   <td>`E::index_type`</td>
-  <td>*Returns:* Mapping of a multi-index `i...` </td>
+  <td>*Returns:* Mapping of a multi-index `i...` . </td>
   <td>*Requires:* 0 <= `m(i...)`. </td>
 </tr>
 <tr>
@@ -1321,8 +1321,8 @@ template<class... Indices>
     * `is_convertible_v<Indices, typename Extents::index_type> && ...` is `true`.
 * *Returns:* Let <math>i<sub>k</sub></math> denote the k-th member of `i...`, and let R equal `extents::rank()`:
     * If R is zero, then zero;
-    * Otherwise, the sum of <math>i<sub>k</sub></math> &#10799; `stride(k)` 
-      for 0 <= k < R.
+    * Otherwise, the sum of <math>i<sub>`k`</sub></math> &#10799; `stride(k)` 
+      for 0 <= `k` < R.
 
 <br/>
 ```c++
@@ -1334,7 +1334,7 @@ constexpr bool is_contiguous() const;
 constexpr bool is_strided() const;
 ```
 
-* *Returns:* `true`
+* *Returns:* `true`.
 
 <br/>
 
@@ -1494,7 +1494,7 @@ template<class OtherExtents>
 * *Requires:* `other.extents()` meets the requirements for use in the initialization of `extents_`.
 * *Effects:* Initializes `extents_` with `other.extents()`.
 * *Ensures:* `extents()==other.extents()` is `true`.
-* *Throws:* nothing.
+* *Throws:* Nothing.
 <!-- --- -->
 
 <br/>
@@ -1709,7 +1709,7 @@ constexpr mapping(Extents e, array<typename Extents::index_type, Extents::rank()
 Let R equal `Extents::rank()`.
 If <math>p</math> is a permutation of the integers 0, ..., R-1,
 then let `p` be an exposition-only array of `size_t` of length R
-such that `p[i]` equals <math>p<sub>i</sub></math> for 0 <= i < R.
+such that `p[i]` equals <math>p<sub>`i`</sub></math> for 0 <= `i` < R.
 
 <!-- FIXME (mfh 2x Sep 2018) See GitHub Issue #72 -->
 
@@ -1791,7 +1791,7 @@ constexpr bool is_contiguous() const noexcept;
 Let R equal `Extents::rank()`.
 If <math>p</math> is a permutation of the integers 0, ..., R-1,
 then let `p` be an exposition-only array of `size_t` of length R
-such that `p[i]` equals <math>p<sub>i</sub></math> for 0 <= i < R.
+such that `p[i]` equals <math>p<sub>`i`</sub></math> for 0 <= `i` < R.
 
 * *Returns:*
     * If `R` is zero, then `true`;
@@ -2005,7 +2005,7 @@ constexpr pointer decay(pointer p) const noexcept;
 <b>26.7.� Class template `basic_mdspan` [mdspan.basic]</b>
 
 1. The `basic_mdspan` class template maps a multi-index within a multi-index *domain* to a reference to an element in the *codomain* `span`.
-2. The multi-index domain space is the Cartesian product of the extents: `[0, extent(0)) * [0, extent(1)) *` ... `* [0, extent(rank() - 1))`. Each extent may be statically or dynamically specified. <!-- FIXME CODE TO MATH -->
+2. The multi-index domain space is the Cartesian product of the extents: <math>[0, `extent(0)`) &#10799; [0, `extent(1)`) &#10799; ... &#10799; [0, `extent(rank()-1)`)</math>.  Each extent may be statically or dynamically specified.
 2. As with `span`, the storage of the objects in the codomain `span` of a `basic_mdspan` is owned by some other object.
 3. `ElementType` is required to be a complete object type that is not an abstract class type or an array type.
 4. `Extents` is required to be a (cv-unqualified) specialization of `extents`.

--- a/P0009/P0009.bs
+++ b/P0009/P0009.bs
@@ -689,9 +689,10 @@ needed for `basic_mdspan`.
 
 �. The header `<mdspan>` defines the view `basic_mdspan`, the type alias `mdspan`, 
 and other facilities for interacting with these views.
-The `basic_mdspan` object maps a multi-index within its domain
+The `basic_mdspan` object maps a multidimensional index within its domain
 to a reference of an element in the codomain.
 The *domain* of a `basic_mdspan` object is a multidimensional index space.
+A *multidimensional index space* is a Cartesian product <math>[0, N<sub>0</sub>) &#10799; [0, N<sub>1</sub>) &#10799; ...</math> of half-open integer intervals.
 The *codomain* of a `basic_mdspan` object is a `span` of elements.
 
 �. The `subspan` function generates a `basic_mdspan` with a *domain*
@@ -754,6 +755,9 @@ namespace fundamentals_v3 {
     constexpr bool operator!=(const extents&lt;LHS...>& lhs, const extents&lt;RHS...>& rhs) noexcept;
 
   // [mdspan.subspan], subspan creation
+  template&lt;class ... Args>
+  constexpr size_t mdspan_subspan_rank_v = <i>see below</i>;<i> // exposition only</i>
+
   template&lt;class ElementType, class Extents, class LayoutPolicy,
            class AccessorPolicy, class... SliceSpecifiers>
   struct mdspan_subspan { // <i>exposition only</i>
@@ -799,10 +803,10 @@ Y8b.     .d8""8b. Y88b. Y8b.     888  888 Y88b.       X88
 
 <b>26.7.�.1 Overview [mdspan.extents.overview]</b>
 
-1. An `extents` object defines a *multidimensional index space* which is the Cartesian product of integers extents `[0..N0) * [0..N1) *`....
-2. The *dynamic extents* of an `extents` object correspond to the `StaticExtents` template parameters that are equal to `dynamic_extent`.  Let *DynamicRank[i]* denote the index of the *i*th such extent in the `StaticExtents` template parameter pack, and let *DynamicIndex[r]* indicate the number of such extents in the first *r* entries of the `StaticExtents` parameter pack
+1. An `extents` object defines a multidimensional index space.
+2. The *dynamic extents* of an `extents` object correspond to the template arguments in the `Extents` parameter pack that equal `dynamic_extent`.  Let *DynamicRank[i]* denote the index of the *i*th dynamic extent in the `Extents` template parameter pack, and let *DynamicIndex[r]* indicate the number of dynamic extents in the first *r* entries of the `Extents` parameter pack.
 3. An `extents` object is expected to store dynamic extents.  *[Note:* An implementation should not consume storage for static extents. *— end note]* 
-4. If any of `StaticExtents` are negative and not equal to `dynamic_extent`, the program is ill-formed.
+4. If any template arguments in `Extents` are negative and not equal to `dynamic_extent`, the program is ill-formed.
 
 <!-- TODO review change to make rank() and rank_dynamic() size_t -->
 <!-- TODO review addition of array constructor -->
@@ -815,7 +819,7 @@ namespace std {
 namespace experimental {
 namespace fundamentals_v3 {
 
-template&lt;ptrdiff_t... StaticExtents>
+template&lt;ptrdiff_t... Extents>
 class extents {
 public:
   // types
@@ -829,14 +833,14 @@ public:
   constexpr extents(IndexType... dynamic_extents) noexcept;
   template&lt;class IndexType, size_t rank_dynamic>
   constexpr extents(const array&lt;IndexType, rank_dynamic>&) noexcept;
-  template&lt;ptrdiff_t... OtherStaticExtents>
-  constexpr extents(const extents&lt;OtherStaticExtents...>& other);
+  template&lt;ptrdiff_t... OtherExtents>
+  constexpr extents(const extents&lt;OtherExtents...>& other);
   ~extents() = default;
 
   constexpr extents& operator=(const extents&) noexcept = default;
   constexpr extents& operator=(extents&&) noexcept = default;
-  template&lt;ptrdiff_t... OtherStaticExtents>
-  constexpr extents& operator=(const extents&lt;OtherStaticExtents...>& other);
+  template&lt;ptrdiff_t... OtherExtents>
+  constexpr extents& operator=(const extents&lt;OtherExtents...>& other);
 
   // [mdspan.extents.obs], Observers of the domain multi-index space
   static constexpr size_t rank() noexcept;
@@ -857,8 +861,11 @@ private:
 constexpr extents() noexcept;
 ```
 
-* *Effects:* Aggregate-initializes `dynamic_extents_` to `{ }`
-* *Postconditions:* `extent(r)` if `static_extent(r)==dynamic_extent` for all `r` in the range `[0, rank())`
+* *Effects:* Aggregate-initializes `dynamic_extents_` to `{ }`.
+* *Ensures:* Let <math>R</math> equal `rank()`.
+             <math>&forall; `r` &isin; [0, R)</math>, 
+             if `static_extent(r)` equals `dynamic_extent`, then
+             `extent(r)` equals `0`.
 
 <br/>
 
@@ -867,23 +874,33 @@ constexpr extents(const extents& other);
 constexpr extents(extents&& other);
 ```
 
-* *Effects:* Initializes `dynamic_extents_` with `other.dynamic_extents_`
-* *Postconditions:* `extent(r)==other.extent(r)` for all `r` in the range `[0, rank())`
+* *Effects:* Initializes `dynamic_extents_` with `other.dynamic_extents_`.
+* *Ensures:* Let <math>R</math> equal `rank()`.
+             <math>&forall; `r` &isin; [0, R)</math>, 
+             `extent(r)` equals `other.extent(r)`.
 
 <br/>
 
 ```c++
-template<ptrdiff_t... OtherStaticExtents>
-constexpr extents(const extents<OtherStaticExtents...>& other);
+template<ptrdiff_t... OtherExtents>
+constexpr extents(const extents<OtherExtents...>& other);
 ```
 
-* *Requires:* For each `r` in the range `[0, rank())`, if `static_extent(r)!=dynamic_extent`, then `static_extent(r)==other.extent(r)`.
-* *Effects:* For each `r` in the range `[0, rank())`, if `static_extent(r)==dynamic_extent`, initializes `dynamic_extents_[`*DynamicRank[*`r`*]*`]` with `other.extent(r)`.
+* *Requires:* Let <math>R</math> equal `rank()`.
+             <math>&forall; `r` &isin; [0, R)</math>, 
+             if `static_extent(r)` does not equal `dynamic_extent`, 
+             then `static_extent(r)` equals `other.extent(r)`.
+* *Constraints:* `sizeof...(Extents)` equals `sizeof...(OtherExtents)`.
+* *Effects:* Let <math>R</math> equal `rank()`.
+             <math>&forall; `r` &isin; [0, R)</math>, 
+             if `static_extent(r)` equals `dynamic_extent`, 
+             then this initializes `dynamic_extents_[`*DynamicRank[*`r`*]*`]` with `other.extent(r)`.
+* *Ensures:* `*this == other` is `true`.
 * *Throws:* Nothing.
-* *Postconditions:* `*this==other`
-* *Remarks:* This constructor shall not participate in overload resolution unless `sizeof...(StaticExtents)==sizeof...(OtherStaticExtents)`.
 
 <br/>
+
+<!-- TODO BELOW HERE -->
 
 ```c++
 template<class... IndexType>
@@ -911,16 +928,16 @@ constexpr extents(const array<IndexType, rank_dynamic> & dynamic_extents) noexce
     + `is_convertible_v<IndexType, index_type>`
 
 ```c++
-template<ptrdiff_t... OtherStaticExtents>
-constexpr extents& operator=(const extents<OtherStaticExtents...>& other);
+template<ptrdiff_t... OtherExtents>
+constexpr extents& operator=(const extents<OtherExtents...>& other);
 ```
 
-* *Requires:* For each `r` in the range `[0, rank())`, if `static_extent(r)!=dynamic_extent`, then `static_extent(r)==other.extent(r)`.
-* *Effects:* For each `r` in the range `[0, rank())`, if `static_extent(r)==dynamic_extent`, assigns `dynamic_extents_[`*DynamicRank[*`r`*]*`]` to `other.extent(r)`.
+* *Requires:* For each `r` in the range `[0, rank())`, `static_extent(r) != dynamic_extent || static_extent(r) == other.extent(r)` is `true`.
+* *Effects:* For each `r` in the range `[0, rank())`, if `static_extent(r)` equals `dynamic_extent`, assigns `dynamic_extents_[`*DynamicRank[*`r`*]*`]` to `other.extent(r)`.
 * *Throws:* Nothing.
 * *Postconditions:* `*this==other`
 * *Returns:* `*this`.
-* *Remarks:* This constructor shall not participate in overload resolution unless `sizeof...(StaticExtents)==sizeof...(OtherStaticExtents)`.
+* *Remarks:* This constructor shall not participate in overload resolution unless `sizeof...(Extents)==sizeof...(OtherExtents)`.
 
 <br/>
 
@@ -932,20 +949,20 @@ constexpr extents& operator=(const extents<OtherStaticExtents...>& other);
 static constexpr size_t rank() const noexcept;
 ```
 
-* *Returns:* `sizeof...(StaticExtents)`
+* *Returns:* `sizeof...(Extents)`
 
 <br/>
 ```c++
 static constexpr size_t rank_dynamic() const noexcept;
 ```
-* *Returns:* `((StaticExtents==dynamic_extent)+...)` *[Note:* This is the number of dynamic extents *—end note]*
+* *Returns:* `((Extents==dynamic_extent)+...)` *[Note:* This is the number of dynamic extents *—end note]*
 
 <br/>
 ```c++
 static constexpr index_type static_extent(size_t r) const noexcept;
 ```
 
-* *Returns:* The `r`th entry in the `StaticExtents` parameter pack if 0 <= `r` < `rank()`, or 1 otherwise.
+* *Returns:* The `r`th entry in the `Extents` parameter pack if 0 <= `r` < `rank()`, or 1 otherwise.
 
 <br/>
 ```c++


### PR DESCRIPTION
- Math-ify mdspan.subspan, as discussed with @crtrott today in #74 comments
- Clean up accessor policy, per discussion with @crtrott today
- Fix #71, at least partly

"At least partly" means that we may still need to look at the definitions of `required_span_size()` for specific layouts.