### PR TITLE
P1673R2: 2020 Jan 06 wording changes

### DIFF
--- a/D1673/blas_interface.md
+++ b/D1673/blas_interface.md
@@ -2704,9 +2704,9 @@ The `scaled_view` function takes a value `alpha` and a `basic_mdspan`
 as `x`, that represents the elementwise product of `alpha` with each
 element of `x`.
 
-*Example:*
-
+[*Example:*
 ```c++
+// z = alpha * x + y
 void z_equals_alpha_times_x_plus_y(
   mdspan<double, extents<dynamic_extent>> z,
   const double alpha,
@@ -2716,6 +2716,7 @@ void z_equals_alpha_times_x_plus_y(
   linalg_add(scaled_view(alpha, x), y, y);
 }
 
+// w = alpha * x + beta * y
 void w_equals_alpha_times_x_plus_beta_times_y(
   mdspan<double, extents<dynamic_extent>> w,
   const double alpha,
@@ -2726,6 +2727,7 @@ void w_equals_alpha_times_x_plus_beta_times_y(
   linalg_add(scaled_view(alpha, x), scaled_view(beta, y), w);
 }
 ```
+--*end example*]
 
 *[Note:*
 
@@ -2886,8 +2888,7 @@ return basic_mdspan<ElementType, Extents, Layout,
     accessor_scaled<ScalingFactor, Accessor>(s, a.accessor()));
 ```
 
-*Example:*
-
+[*Example:*
 ```c++
 void test_scaled_view(basic_mdspan<double, extents<10>> a)
 {
@@ -2897,6 +2898,7 @@ void test_scaled_view(basic_mdspan<double, extents<10>> a)
   }
 }
 ```
+--*end example*]
 
 ### Conjugated in-place transformation [linalg.conj]
 
@@ -3099,8 +3101,7 @@ return basic_mdspan<ElementType, Extents, Layout, Accessor>(
   a.accessor().nested_accessor());
 ```
 
-*Example:*
-
+[*Example:*
 ```c++
 void test_conjugate_view_complex(
   basic_mdspan<complex<double>, extents<10>> a)
@@ -3128,6 +3129,7 @@ void test_conjugate_view_real(
   }
 }
 ```
+--*end example*]
 
 ### Transpose in-place transformation [linalg.transp]
 
@@ -3420,8 +3422,7 @@ return basic_mdspan<EltType, Extents, Layout, Accessor>(a.data(),
   a.mapping().nested_mapping(), a.accessor());
 ```
 
-*Example:*
-
+[*Example:*
 ```c++
 void test_transpose_view(basic_mdspan<double, extents<3, 4>> a)
 {
@@ -3453,6 +3454,7 @@ void test_transpose_view(basic_mdspan<double, extents<3, 4>> a)
   }
 }
 ```
+--*end example*]
 
 ### Conjugate transpose transform [linalg.conj_transp]
 
@@ -3513,8 +3515,7 @@ conjugate_transpose_view(
 * *Effects:* Equivalent to
   `return conjugate_view(transpose_view(a));`.
 
-*Example:*
-
+[*Example:*
 ```c++
 void test_ct_view(basic_mdspan<complex<double>, extents<3, 4>> a)
 {
@@ -3547,6 +3548,7 @@ void test_ct_view(basic_mdspan<complex<double>, extents<3, 4>> a)
   }
 }
 ```
+--*end example*]
 
 ### Algorithms [linalg.algs]
 
@@ -4260,6 +4262,38 @@ void matrix_vector_product(ExecutionPolicy&& exec,
 
 * *Effects:* Assigns to the elements of `y` the product of the matrix
   `A` with the vector `x`.
+
+[*Example:*
+```c++
+constexpr ptrdiff_t num_rows = 5;
+constexpr ptrdiff_t num_cols = 6;
+
+// y = 3.0 * A * x
+void scaled_matvec_1(mdspan<double, extents<num_rows, num_cols>> A,
+  mdspan<double, extents<num_cols>> x,
+  mdspan<double, extents<num_rows>> y)
+{
+  matrix_vector_product(scaled_view(3.0, A), x, y);
+}
+
+// y = 3.0 * A * x + 2.0 * y
+void scaled_matvec_2(mdspan<double, extents<num_rows, num_cols>> A,
+  mdspan<double, extents<num_cols>> x,
+  mdspan<double, extents<num_rows>> y)
+{
+  matrix_vector_product(scaled_view(3.0, A), x,
+                        scaled_view(2.0, y), y);
+}
+
+// z = 7.0 times the transpose of A, times y
+void scaled_matvec_2(mdspan<double, extents<num_rows, num_cols>> A,
+  mdspan<double, extents<num_rows>> y,
+  mdspan<double, extents<num_cols>> z)
+{
+  matrix_vector_product(scaled_view(7.0, transpose_view(A)), y, z);
+}
+```
+--*end example*]
 
 ###### Updating matrix-vector product
 
@@ -6088,35 +6122,3 @@ Reference BLAS does not have a `xTPSM` function. --*end note]*
     of `A` all equal one. *[Note:* This does not imply that the
     function needs to be able to form an `element_type` value equal to
     one. --*end note]
-
-## Examples
-
-```c++
-using vector_t = basic_mdspan<double, extents<dynamic_extent>>;
-using dy_ext2_t = extents<dynamic_extent, dynamic_extent>;
-using matrix_t = basic_mdspan<double, dy_ext2_t>;
-
-// Create vectors
-vector_t x = ...;
-vector_t y = ...;
-vector_t z = ...;
-
-// Create matrices
-matrix_t A = ...;
-matrix_t B = ...;
-matrix_t C = ...;
-
-// z = 2.0 * x + y;
-linalg_add(par, scaled_view(2.0, x), y, z);
-// y = 2.0 * y + z;
-linalg_add(par, z, scaled_view(2.0, y), y);
-
-// y = 3.0 * A * x;
-matrix_vector_product(par, scaled_view(3.0, A), x, y);
-// y = 3.0 * A * x + 2.0 * y;
-matrix_vector_product(par, scaled_view(3.0, A), x,
-                      scaled_view(2.0, y), y);
-
-// y = transpose(A) * x;
-matrix_vector_product(par, transpose_view(A), x, y);
-```

--- a/D1673/blas_interface.md
+++ b/D1673/blas_interface.md
@@ -1090,11 +1090,265 @@ Some of our functions explicitly require outputs with specific
 nonunique layouts.  This includes low-rank updates to symmetric or
 Hermitian matrices.
 
+## Acknowledgments
+
+Sandia National Laboratories is a multimission laboratory managed and
+operated by National Technology & Engineering Solutions of Sandia,
+LLC, a wholly owned subsidiary of Honeywell International, Inc., for
+the U.S. Department of Energy’s National Nuclear Security
+Administration under contract DE-NA0003525.
+
+Special thanks to Bob Steagall and Guy Davidson for boldly leading the
+charge to add linear algebra to the C++ Standard Library, and for many
+fruitful discussions.  Thanks also to Andrew Lumsdaine for his
+pioneering efforts and history lessons.
+
+## References
+
+### References by coathors
+
+* G. Ballard, E. Carson, J. Demmel, M. Hoemmen, N. Knight, and
+  O. Schwartz, ["Communication lower bounds and optimal algorithms for
+  numerical linear
+  algebra,"](https://doi.org/10.1017/S0962492914000038), *Acta
+  Numerica*, Vol. 23, May 2014, pp. 1-155.
+
+* H. C. Edwards, B. A. Lelbach, D. Sunderland, D. Hollman, C. Trott,
+  M. Bianco, B. Sander, A. Iliopoulos, J. Michopoulos, and M. Hoemmen,
+  "`mdspan`: a Non-Owning Multidimensional Array Reference,"
+  [P0009R0](http://wg21.link/p0009r9), Jan. 2019.
+
+* M. Hoemmen, D. Hollman, and C. Trott, "Evolving a Standard C++
+  Linear Algebra Library from the BLAS," P1674R0, Jun. 2019.
+
+* M. Hoemmen, J. Badwaik, M. Brucher, A. Iliopoulos, and
+  J. Michopoulos, "Historical lessons for C++ linear algebra library
+  standardization," [(P1417R0)](http://wg21.link/p1417r0), Jan. 2019.
+
+* D. Hollman, C. Trott, M. Hoemmen, and D. Sunderland, "`mdarray`: An
+  Owning Multidimensional Array Analog of `mdspan`",
+  [P1684R0](https://isocpp.org/files/papers/P1684R0.pdf), Jun. 2019.
+
+* D. Hollman, C. Kohlhoff, B. Lelbach, J. Hoberock, G. Brown, and
+  M. Dominiak, "A General Property Customization Mechanism,"
+  [P1393R0](http://wg21.link/p1393r0), Jan. 2019.
+
+### Other references
+
+* [Basic Linear Algebra Subprograms Technical (BLAST) Forum
+  Standard](http://netlib.org/blas/blast-forum/blas-report.pdf),
+  International Journal of High Performance Applications and
+  Supercomputing, Vol. 16. No. 1, Spring 2002.
+
+* L. S. Blackford, J. Demmel, J. Dongarra, I. Duff, S. Hammarling,
+  G. Henry, M. Heroux, L. Kaufman, A. Lumsdaine, A. Petitet, R. Pozo,
+  K. Remington, and R. C. Whaley, ["An updated set of basic linear
+  algebra subprograms (BLAS),"](https://doi.org/10.1145/567806.567807)
+  *ACM Transactions on Mathematical Software* (TOMS), Vol. 28, No. 2,
+  Jun. 2002, pp. 135-151.
+
+* G. Davidson and B. Steagall, "A proposal to add linear algebra
+  support to the C++ standard library,"
+  [P1385R4](http://wg21.link/p1385r4), Nov. 2019.
+
+* B. Dawes, H. Hinnant, B. Stroustrup, D. Vandevoorde, and M. Wong,
+  "Direction for ISO C++," [P0939R0](http://wg21.link/p0939r0), Feb. 2018.
+
+* J. Dongarra, R. Pozo, and D. Walker, "LAPACK++: A Design Overview of
+  Object-Oriented Extensions for High Performance Linear Algebra," in
+  Proceedings of Supercomputing '93, IEEE Computer Society Press,
+  1993, pp. 162-171.
+
+* M. Gates, P. Luszczek, A. Abdelfattah, J. Kurzak, J. Dongarra,
+  K. Arturov, C. Cecka, and C. Freitag, ["C++ API for BLAS and
+  LAPACK,"](https://www.icl.utk.edu/files/publications/2017/icl-utk-1031-2017.pdf)
+  SLATE Working Notes, Innovative Computing Laboratory, University of
+  Tennessee Knoxville, Feb. 2018.
+
+* K. Goto and R. A. van de Geijn, "Anatomy of high-performance matrix
+  multiplication,"](https://doi.org/10.1145/1356052.1356053), *ACM
+  Transactions on Mathematical Software* (TOMS), Vol. 34, No. 3, May
+  2008.
+
+* J. Hoberock, "Integrating Executors with Parallel Algorithms,"
+  [P1019R2](http://wg21.link/p1019r2), Jan. 2019.
+
+* N. A. Josuttis, "The C++ Standard Library: A Tutorial and Reference,"
+  Addison-Wesley, 1999.
+
+* M. Kretz, "Data-Parallel Vector Types & Operations,"
+  [P0214r9](http://wg21.link/p0214r9), Mar. 2018.
+
+* D. Vandevoorde and N. A. Josuttis, "C++ Templates: The Complete
+  Guide," Addison-Wesley Professional, 2003.
+
 ## Wording
 
-### Tag classes
+> Text in blockquotes is not proposed wording, but rather instructions for generating proposed wording.
+> The � character is used to denote a placeholder section number which the editor shall determine.
+> First, apply all wording from P0009R9 (this proposal is a "rebase" atop the changes proposed by P0009R9).
+> At the end of Table � ("Numerics library summary") in *[numerics.general]*, add the following: [linalg], Linear algebra, `<linalg>`.
+> At the end of *[numerics]*, add all the material that follows.
 
-#### Storage order tags
+### Header `<linalg>` synopsis [linalg.syn]
+
+```c++
+namespace std {
+// [linalg.tags.order], storage order tags
+struct column_major_t;
+inline constexpr column_major_t column_major;
+struct row_major_t;
+inline constexpr row_major_t row_major;
+
+// [linalg.tags.triangle], triangle tags
+struct upper_triangle_t;
+inline constexpr upper_triangle_t upper_triangle;
+struct lower_triangle_t;
+inline constexpr lower_triangle_t lower_triangle;
+
+// [linalg.tags.diagonal], diagonal tags
+struct implicit_unit_diagonal_t;
+inline constexpr implicit_unit_diagonal_t implicit_unit_diagonal;
+struct explicit_diagonal_t;
+inline constexpr explicit_diagonal_t explicit_diagonal;
+
+// [linalg.tags.side], side tags
+struct left_side_t;
+inline constexpr left_side_t left_side;
+struct right_side_t { };
+inline constexpr right_side_t right_side;
+
+// [linalg.layouts.general], class template layout_blas_general
+template<class StorageOrder>
+class layout_blas_general;
+
+// [linalg.layouts.packed], class template layout_blas_packed
+template<class Triangle,
+         class StorageOrder>
+class layout_blas_packed;
+
+// [linalg.scaled.scaled_scalar], class template scaled_scalar
+template<class ScalingFactor,
+         class Reference>
+class scaled_scalar;
+
+// [linalg.scaled.accessor_scaled], class template accessor_scaled
+template<class ScalingFactor,
+         class Accessor>
+class accessor_scaled;
+
+// [linalg.scaled.scaled_view], scaled in-place transformation
+template<class ScalingFactor,
+         class ElementType,
+         class Extents,
+         class Layout,
+         class Accessor>
+basic_mdspan<ElementType, Extents, Layout,
+             accessor_scaled<ScalingFactor, Accessor>>
+scaled_view(
+  const ScalingFactor& s,
+  const basic_mdspan<ElementType, Extents, Layout, Accessor>& a);
+
+// [linalg.conj.conjugated_scalar], class template conjugated_scalar
+template<class Reference,
+         class T>
+class conjugated_scalar;
+
+// [linalg.conj.accessor_conjugate], class template accessor_conjugate
+template<class Accessor>
+class accessor_conjugate;
+
+// [linalg.conj.conjugate_view], conjugated in-place transformation
+template<class ElementType,
+         class Extents,
+         class Layout,
+         class Accessor>
+basic_mdspan<ElementType, Extents, Layout,
+             accessor_conjugate<Accessor>>
+conjugate_view(
+  basic_mdspan<ElementType, Extents, Layout, Accessor> a);
+template<class ElementType,
+         class Extents,
+         class Layout,
+         class Accessor>
+basic_mdspan<ElementType, Extents, Layout, Accessor>
+conjugate_view(basic_mdspan<ElementType, Extents, Layout,
+  accessor_conjugate<Accessor>> a);
+
+// [linalg.transp.layout_transpose], class template layout_transpose
+template<class Layout>
+class layout_transpose;
+
+// [linalg.transp.transpose_view], transposed in-place transformation
+template<class ElementType,
+         class Extents,
+         class Layout,
+         class Accessor>
+basic_mdspan<ElementType, transpose_extents_t<Extents>,
+             layout_transpose<Layout>, Accessor>
+transpose_view(
+  basic_mdspan<ElementType, Extents, Layout, Accessor> a);
+template<class EltType,
+         class Extents,
+         class Layout,
+         class Accessor>
+basic_mdspan<EltType, Extents, Layout, Accessor>
+transpose_view(basic_mdspan<EltType, Extents,
+               layout_transpose<Layout>, Accessor> a);
+
+// [linalg.conj_transp], conjugated transposed in-place transformation
+template<class ElementType,
+         class Extents,
+         class Layout,
+         class Accessor>
+basic_mdspan<ElementType, Extents,
+             layout_transpose<Layout>,
+             accessor_conjugate<Accessor>>
+conjugate_transpose_view(
+  basic_mdspan<ElementType, Extents,
+               Layout,
+               Accessor> a);
+template<class ElementType,
+         class Extents,
+         class Layout,
+         class Accessor>
+basic_mdspan<ElementType, Extents,
+             Layout,
+             accessor_conjugate<Accessor>>
+conjugate_transpose_view(
+  basic_mdspan<ElementType, Extents,
+               layout_transpose<Layout>,
+               Accessor> a);
+template<class ElementType,
+         class Extents,
+         class Layout,
+         class Accessor>
+basic_mdspan<ElementType, Extents,
+             layout_transpose<Layout>,
+             Accessor>
+conjugate_transpose_view(
+  basic_mdspan<ElementType, Extents,
+               Layout,
+               accessor_conjugate<Accessor>> a);
+template<class ElementType,
+         class Extents,
+         class Layout,
+         class Accessor>
+basic_mdspan<ElementType, Extents,
+             Layout,
+             Accessor>
+conjugate_transpose_view(
+  basic_mdspan<ElementType, Extents,
+               layout_transpose<Layout>,
+               accessor_conjugate<Accessor>> a);
+
+// [linalg.algs.blas1], BLAS 1 functions
+}
+```
+
+### Tag classes [linalg.tags]
+
+#### Storage order tags [linalg.tags.order]
 
 ```c++
 struct column_major_t { };
@@ -1109,7 +1363,7 @@ indicates a row-major order.  The interpretation of each depends on
 the specific layout that uses the tag.  See `layout_blas_general` and
 `layout_blas_packed` below.
 
-#### Triangle tags
+#### Triangle tags [linalg.tags.triangle]
 
 Some linear algebra algorithms distinguish between the "upper
 triangle," "lower triangle," and "diagonal" of a matrix.
@@ -1139,12 +1393,12 @@ access the upper triangle (`upper_triangular_t`) or lower triangle
 restrictions of `implicit_unit_diagonal_t` if that tag is also
 applied; see below.
 
-#### Diagonal tags
+#### Diagonal tags [linalg.tags.diagonal]
 
 ```c++
 struct implicit_unit_diagonal_t { };
 inline constexpr implicit_unit_diagonal_t
-implicit_unit_diagonal = { };
+  implicit_unit_diagonal = { };
 
 struct explicit_diagonal_t { };
 inline constexpr explicit_diagonal_t explicit_diagonal = { };
@@ -1165,7 +1419,7 @@ The `implicit_unit_diagonal_t` tag indicates two things:
 The tag `explicit_diagonal_t` indicates that algorithms and other
 users of the viewer may access the matrix's diagonal entries directly.
 
-#### Side tags
+#### Side tags [linalg.tags.side]
 
 Some linear algebra algorithms distinguish between applying some
 operator to the left side of an object, or the right side of an
@@ -1174,19 +1428,19 @@ matrix generally do not commute. --*end note]*
 
 ```c++
 struct left_side_t { };
-constexpr left_side_t left_side = { };
+inline constexpr left_side_t left_side = { };
 
 struct right_side_t { };
-constexpr right_side_t right_side = { };
+inline constexpr right_side_t right_side = { };
 ```
 
 These tag classes specify whether algorithms should apply some
 operator to the left side (`left_side_t`) or right side
 (`right_side_t`) of an object.
 
-### Layouts for general and packed matrix types
+### Layouts for general and packed matrix types [linalg.layouts]
 
-#### `layout_blas_general`
+#### `layout_blas_general` [linalg.layouts.general]
 
 `layout_blas_general` is a `basic_mdspan` layout mapping policy.  Its
 `StorageOrder` template parameter determines whether the matrix's data
@@ -1429,7 +1683,7 @@ constexpr bool is_strided() const noexcept;
 
 * *Returns:* `true`.
 
-#### `layout_blas_packed`
+#### `layout_blas_packed` [linalg.layouts.packed]
 
 `layout_blas_packed` is a `basic_mdspan` layout mapping policy that
 represents a square matrix that stores only the entries in one
@@ -1645,7 +1899,7 @@ constexpr bool is_strided() const noexcept;
 
 * *Returns:* `true` if `extent(0)` is less than 2, else `false`.
 
-### Scaled in-place transformation
+### Scaled in-place transformation [linalg.scaled]
 
 The `scaled_view` function takes a value `alpha` and a `basic_mdspan`
 `x`, and returns a new read-only `basic_mdspan` with the same domain
@@ -1685,7 +1939,7 @@ run-time value(s) of the relevant BLAS function arguments (e.g.,
 
 --*end note]*
 
-#### `scaled_scalar`
+#### `scaled_scalar` [linalg.scaled.scaled_scalar]
 
 `scaled_scalar` expresses a read-only scaled version of an existing
 scalar.  It is part of the implementation of `scaled_accessor` (see
@@ -1693,7 +1947,8 @@ below).  *[Note:* It is read only to avoid confusion with the
 definition of "assigning to a scaled scalar." --*end note]*
 
 ```c++
-template<class ScalingFactor, class Reference>
+template<class ScalingFactor,
+         class Reference>
 class scaled_scalar {
 private:
   const ScalingFactor scaling_factor; // exposition only
@@ -1729,11 +1984,15 @@ operator result_type() const;
 
 * *Effects:* Equivalent to `return scaling_factor * value;`.
 
-#### `accessor_scaled`
+#### `accessor_scaled` [linalg.scaled.accessor_scaled]
 
-Accessor to make `basic_mdspan` return a `scaled_scalar`.
+`accessor_scaled` is a `basic_mdspan` accessor policy whose reference
+type represents the product of a scaling factor and its nested
+`basic_mdspan` accessor's reference.
+
 ```c++
-template<class ScalingFactor, class Accessor>
+template<class ScalingFactor,
+         class Accessor>
 class accessor_scaled {
 public:
   using element_type  = Accessor::element_type;
@@ -1800,7 +2059,7 @@ ScalingFactor scaling_factor() const;
 
 * *Effects:* Equivalent to `return scaling_factor_;`.
 
-#### `scaled_view`
+#### `scaled_view` [linalg.scaled.scaled_view]
 
 The `scaled_view` function takes a value `alpha` and a `basic_mdspan`
 `x`, and returns a new read-only `basic_mdspan` with the same domain
@@ -1841,7 +2100,7 @@ void test_scaled_view(basic_mdspan<double, extents<10>> a)
 }
 ```
 
-#### Conjugated in-place transformation
+### Conjugated in-place transformation [linalg.conj]
 
 The `conjugate_view` function takes a `basic_mdspan` `x`, and returns
 a new read-only `basic_mdspan` `y` with the same domain as `x`, whose
@@ -1861,7 +2120,7 @@ BLAS function.
 
 --*end note]*
 
-#### `conjugated_scalar`
+#### `conjugated_scalar` [linalg.conj.conjugated_scalar]
 
 `conjugated_scalar` expresses a read-only conjugated version of the
 value of a reference to an element of a `basic_mdspan`.  It is part of
@@ -1870,7 +2129,8 @@ to avoid likely confusion with the definition of "assigning to the
 conjugate of a scalar." --*end note]*
 
 ```c++
-template<class Reference, class T>
+template<class Reference,
+         class T>
 class conjugated_scalar {
 public:
   conjugated_scalar(Reference v);
@@ -1903,7 +2163,7 @@ operator T() const;
 
 * *Effects:* Equivalent to `return conj(val);`.
 
-#### `accessor_conjugate`
+#### `accessor_conjugate` [linalg.conj.accessor_conjugate]
 
 The `accessor_conjugate` Accessor makes `basic_mdspan` access return a
 `conjugated_scalar` if the scalar type is `complex<T>` for some `T`.
@@ -1999,7 +2259,7 @@ Accessor nested_accessor() const;
 
 * *Effects:* Equivalent to `return acc;`.
 
-#### `conjugate_view`
+#### `conjugate_view` [linalg.conj.conjugate_view]
 
 ```c++
 template<class ElementType,
@@ -2071,7 +2331,7 @@ void test_conjugate_view_real(
 }
 ```
 
-### Transpose in-place transformation
+### Transpose in-place transformation [linalg.transp]
 
 `layout_transpose` is a `basic_mdspan` layout mapping policy that
 swaps the rightmost two indices, extents, and strides (if applicable)
@@ -2091,7 +2351,7 @@ value(s) of the relevant `TRANS*` BLAS function arguments.
 
 --*end note]*
 
-#### `layout_transpose`
+#### `layout_transpose` [linalg.transp.layout_transpose]
 
 `layout_transpose` is a `basic_mdspan` layout mapping policy that
 swaps the rightmost two indices, extents, and strides (if applicable)
@@ -2308,7 +2568,7 @@ stride(typename Extents::index_type r) const
 * *Effects:* Equivalent to `return nested_mapping_.stride(s);',
   where `s` is 0 if `r` is 1 and `s` is 1 if `r` is 0.
 
-#### `transpose_view`
+#### `transpose_view` [linalg.transp.transpose_view]
 
 The `transpose_view` function takes a rank-2 `basic_mdspan`
 representing a matrix, and returns a new read-only `basic_mdspan`
@@ -2396,7 +2656,7 @@ void test_transpose_view(basic_mdspan<double, extents<3, 4>> a)
 }
 ```
 
-#### Conjugate transpose transform
+### Conjugate transpose transform [linalg.conj_transp]
 
 The `conjugate_transpose_view` function returns a conjugate transpose
 view of an object.  This combines the effects of `transpose_view` and
@@ -2490,9 +2750,9 @@ void test_ct_view(basic_mdspan<complex<double>, extents<3, 4>> a)
 }
 ```
 
-### Algorithms
+### Algorithms [linalg.algs]
 
-#### Requirements
+#### Requirements [linalg.algs.reqs]
 
 Throughout this Clause, where the template parameters are not
 constrained, the names of template parameters are used to express type
@@ -2556,7 +2816,7 @@ or other things as appropriate.
   reference to a `basic_mdspan`, or a (non-`const`) rvalue reference to a
   `basic_mdspan`.
 
-#### BLAS 1 functions
+#### BLAS 1 functions [linalg.algs.blas1]
 
 *[Note:*
 
@@ -5063,95 +5323,3 @@ matrix_vector_product(par, scaled_view(3.0, A), x,
 // y = transpose(A) * x;
 matrix_vector_product(par, transpose_view(A), x, y);
 ```
-
-## Acknowledgments
-
-Sandia National Laboratories is a multimission laboratory managed and
-operated by National Technology & Engineering Solutions of Sandia,
-LLC, a wholly owned subsidiary of Honeywell International, Inc., for
-the U.S. Department of Energy’s National Nuclear Security
-Administration under contract DE-NA0003525.
-
-Special thanks to Bob Steagall and Guy Davidson for boldly leading the
-charge to add linear algebra to the C++ Standard Library, and for many
-fruitful discussions.  Thanks also to Andrew Lumsdaine for his
-pioneering efforts and history lessons.
-
-## References
-
-### References by coathors
-
-* G. Ballard, E. Carson, J. Demmel, M. Hoemmen, N. Knight, and
-  O. Schwartz, ["Communication lower bounds and optimal algorithms for
-  numerical linear
-  algebra,"](https://doi.org/10.1017/S0962492914000038), *Acta
-  Numerica*, Vol. 23, May 2014, pp. 1-155.
-
-* H. C. Edwards, B. A. Lelbach, D. Sunderland, D. Hollman, C. Trott,
-  M. Bianco, B. Sander, A. Iliopoulos, J. Michopoulos, and M. Hoemmen,
-  "`mdspan`: a Non-Owning Multidimensional Array Reference,"
-  [P0009R0](http://wg21.link/p0009r9), Jan. 2019.
-
-* M. Hoemmen, D. Hollman, and C. Trott, "Evolving a Standard C++
-  Linear Algebra Library from the BLAS," P1674R0, Jun. 2019.
-
-* M. Hoemmen, J. Badwaik, M. Brucher, A. Iliopoulos, and
-  J. Michopoulos, "Historical lessons for C++ linear algebra library
-  standardization," [(P1417R0)](http://wg21.link/p1417r0), Jan. 2019.
-
-* D. Hollman, C. Trott, M. Hoemmen, and D. Sunderland, "`mdarray`: An
-  Owning Multidimensional Array Analog of `mdspan`",
-  [P1684R0](https://isocpp.org/files/papers/P1684R0.pdf), Jun. 2019.
-
-* D. Hollman, C. Kohlhoff, B. Lelbach, J. Hoberock, G. Brown, and
-  M. Dominiak, "A General Property Customization Mechanism,"
-  [P1393R0](http://wg21.link/p1393r0), Jan. 2019.
-
-### Other references
-
-* [Basic Linear Algebra Subprograms Technical (BLAST) Forum
-  Standard](http://netlib.org/blas/blast-forum/blas-report.pdf),
-  International Journal of High Performance Applications and
-  Supercomputing, Vol. 16. No. 1, Spring 2002.
-
-* L. S. Blackford, J. Demmel, J. Dongarra, I. Duff, S. Hammarling,
-  G. Henry, M. Heroux, L. Kaufman, A. Lumsdaine, A. Petitet, R. Pozo,
-  K. Remington, and R. C. Whaley, ["An updated set of basic linear
-  algebra subprograms (BLAS),"](https://doi.org/10.1145/567806.567807)
-  *ACM Transactions on Mathematical Software* (TOMS), Vol. 28, No. 2,
-  Jun. 2002, pp. 135-151.
-
-* G. Davidson and B. Steagall, "A proposal to add linear algebra
-  support to the C++ standard library,"
-  [P1385R4](http://wg21.link/p1385r4), Nov. 2019.
-
-* B. Dawes, H. Hinnant, B. Stroustrup, D. Vandevoorde, and M. Wong,
-  "Direction for ISO C++," [P0939R0](http://wg21.link/p0939r0), Feb. 2018.
-
-* J. Dongarra, R. Pozo, and D. Walker, "LAPACK++: A Design Overview of
-  Object-Oriented Extensions for High Performance Linear Algebra," in
-  Proceedings of Supercomputing '93, IEEE Computer Society Press,
-  1993, pp. 162-171.
-
-* M. Gates, P. Luszczek, A. Abdelfattah, J. Kurzak, J. Dongarra,
-  K. Arturov, C. Cecka, and C. Freitag, ["C++ API for BLAS and
-  LAPACK,"](https://www.icl.utk.edu/files/publications/2017/icl-utk-1031-2017.pdf)
-  SLATE Working Notes, Innovative Computing Laboratory, University of
-  Tennessee Knoxville, Feb. 2018.
-
-* K. Goto and R. A. van de Geijn, "Anatomy of high-performance matrix
-  multiplication,"](https://doi.org/10.1145/1356052.1356053), *ACM
-  Transactions on Mathematical Software* (TOMS), Vol. 34, No. 3, May
-  2008.
-
-* J. Hoberock, "Integrating Executors with Parallel Algorithms,"
-  [P1019R2](http://wg21.link/p1019r2), Jan. 2019.
-
-* N. A. Josuttis, "The C++ Standard Library: A Tutorial and Reference,"
-  Addison-Wesley, 1999.
-
-* M. Kretz, "Data-Parallel Vector Types & Operations,"
-  [P0214r9](http://wg21.link/p0214r9), Mar. 2018.
-
-* D. Vandevoorde and N. A. Josuttis, "C++ Templates: The Complete
-  Guide," Addison-Wesley Professional, 2003.

--- a/D1673/blas_interface.md
+++ b/D1673/blas_interface.md
@@ -1342,8 +1342,806 @@ conjugate_transpose_view(
                layout_transpose<Layout>,
                accessor_conjugate<Accessor>> a);
 
-// [linalg.algs.blas1], BLAS 1 functions
+// [linalg.algs.blas1.givens.setup], compute Givens rotation
+template<class Real>
+void givens_rotation_setup(const Real a,
+                           const Real b,
+                           Real& c,
+                           Real& s,
+                           Real& r);
+template<class Real>
+void givens_rotation_setup(const complex<Real>& a,
+                           const complex<Real>& a,
+                           Real& c,
+                           complex<Real>& s,
+                           complex<Real>& r);
+
+// [linalg.algs.blas1.givens.apply], apply computed Givens rotation
+template<class inout_vector_1_t,
+         class inout_vector_2_t,
+         class Real>
+void givens_rotation_apply(
+  inout_vector_1_t x,
+  inout_vector_2_t y,
+  const Real c,
+  const Real s);
+template<class ExecutionPolicy,
+         class inout_vector_1_t,
+         class inout_vector_2_t,
+         class Real>
+void givens_rotation_apply(
+  ExecutionPolicy&& exec,
+  inout_vector_1_t x,
+  inout_vector_2_t y,
+  const Real c,
+  const Real s);
+template<class inout_vector_1_t,
+         class inout_vector_2_t,
+         class Real>
+void givens_rotation_apply(
+  inout_vector_1_t x,
+  inout_vector_2_t y,
+  const Real c,
+  const complex<Real> s);
+template<class ExecutionPolicy,
+         class inout_vector_1_t,
+         class inout_vector_2_t,
+         class Real>
+void givens_rotation_apply(
+  ExecutionPolicy&& exec,
+  inout_vector_1_t x,
+  inout_vector_2_t y,
+  const Real c,
+  const complex<Real> s);
 }
+
+// [linalg.algs.blas1.swap], swap elements
+template<class inout_object_1_t,
+         class inout_object_2_t>
+void linalg_swap(inout_object_1_t x,
+                 inout_object_2_t y);
+template<class ExecutionPolicy,
+         class inout_object_1_t,
+         class inout_object_2_t>
+void linalg_swap(ExecutionPolicy&& exec,
+                 inout_object_1_t x,
+                 inout_object_2_t y);
+
+// [linalg.algs.blas1.scale], multiply elements by scalar
+template<class Scalar,
+         class inout_object_t>
+void scale(const Scalar alpha,
+           inout_object_t obj);
+template<class ExecutionPolicy,
+         class Scalar,
+         class inout_object_t>
+void scale(ExecutionPolicy&& exec,
+           const Scalar alpha,
+           inout_object_t obj);
+
+// [linalg.algs.blas1.copy], copy elements
+template<class in_object_t,
+         class out_object_t>
+void linalg_copy(in_object_t x,
+                 out_object_t y);
+template<class ExecutionPolicy,
+         class in_object_t,
+         class out_object_t>
+void linalg_copy(ExecutionPolicy&& exec,
+                 in_object_t x,
+                 out_object_t y);
+
+// [linalg.algs.blas1.add], add elementwise
+template<class in_object_1_t,
+         class in_object_2_t,
+         class out_object_t>
+void linalg_add(in_object_1_t x,
+                in_object_2_t y,
+                out_object_t z);
+template<class ExecutionPolicy,
+         class in_object_1_t,
+         class in_object_2_t,
+         class out_object_t>
+void linalg_add(ExecutionPolicy&& exec,
+                in_object_1_t x,
+                in_object_2_t y,
+                out_object_t z);
+
+// [linalg.algs.blas1.dot.nonconj], nonconjugated inner product
+template<class in_vector_1_t,
+         class in_vector_2_t,
+         class T>
+T dot(in_vector_1_t v1,
+      in_vector_2_t v2,
+      T init);
+template<class ExecutionPolicy,
+         class in_vector_1_t,
+         class in_vector_2_t,
+         class T>
+T dot(ExecutionPolicy&& exec,
+      in_vector_1_t v1,
+      in_vector_2_t v2,
+      T init);
+template<class in_vector_1_t,
+         class in_vector_2_t>
+auto dot(in_vector_1_t v1,
+         in_vector_2_t v2);
+template<class ExecutionPolicy,
+         class in_vector_1_t,
+         class in_vector_2_t>
+auto dot(ExecutionPolicy&& exec,
+         in_vector_1_t v1,
+         in_vector_2_t v2);
+
+// [linalg.algs.blas1.dot.conj], conjugated inner product
+template<class in_vector_1_t,
+         class in_vector_2_t,
+         class T>
+T dotc(in_vector_1_t v1,
+       in_vector_2_t v2,
+       T init);
+template<class ExecutionPolicy,
+         class in_vector_1_t,
+         class in_vector_2_t,
+         class T>
+T dotc(ExecutionPolicy&& exec,
+       in_vector_1_t v1,
+       in_vector_2_t v2,
+       T init);
+template<class in_vector_1_t,
+         class in_vector_2_t>
+auto dotc(in_vector_1_t v1,
+          in_vector_2_t v2);
+template<class ExecutionPolicy,
+         class in_vector_1_t,
+         class in_vector_2_t>
+auto dotc(ExecutionPolicy&& exec,
+          in_vector_1_t v1,
+          in_vector_2_t v2);
+
+// [linalg.algs.blas1.norm2], Euclidean vector norm
+template<class in_vector_t,
+         class T>
+T vector_norm2(in_vector_t v,
+               T init);
+template<class ExecutionPolicy,
+         class in_vector_t,
+         class T>
+T vector_norm2(ExecutionPolicy&& exec,
+               in_vector_t v,
+               T init);
+template<class in_vector_t>
+auto vector_norm2(in_vector_t v);
+template<class ExecutionPolicy,
+         class in_vector_t>
+auto vector_norm2(ExecutionPolicy&& exec,
+                  in_vector_t v);
+
+// [linalg.algs.blas1.abs_sum], sum of absolute values
+template<class in_vector_t,
+         class T>
+T vector_abs_sum(in_vector_t v,
+                 T init);
+template<class ExecutionPolicy,
+         class in_vector_t,
+         class T>
+T vector_abs_sum(ExecutionPolicy&& exec,
+                 in_vector_t v,
+                 T init);
+template<class in_vector_t>
+auto vector_abs_sum(in_vector_t v);
+template<class ExecutionPolicy,
+         class in_vector_t>
+auto vector_abs_sum(ExecutionPolicy&& exec,
+                    in_vector_t v);
+
+// [linalg.algs.blas1.idx_abs_max],
+// index of maximum absolute value of vector elements
+template<class in_vector_t>
+ptrdiff_t idx_abs_max(in_vector_t v);
+template<class ExecutionPolicy,
+         class in_vector_t>
+ptrdiff_t idx_abs_max(ExecutionPolicy&& exec,
+                      in_vector_t v);
+
+// [linalg.algs.blas2.general-matvec],
+// general matrix-vector product
+template<class in_vector_t,
+         class in_matrix_t,
+         class out_vector_t>
+void matrix_vector_product(in_matrix_t A,
+                           in_vector_t x,
+                           out_vector_t y);
+template<class ExecutionPolicy,
+         class in_vector_t,
+         class in_matrix_t,
+         class out_vector_t>
+void matrix_vector_product(ExecutionPolicy&& exec,
+                           in_matrix_t A,
+                           in_vector_t x,
+                           out_vector_t y);
+template<class in_vector_1_t,
+         class in_matrix_t,
+         class in_vector_2_t,
+         class out_vector_t>
+void matrix_vector_product(in_matrix_t A,
+                           in_vector_1_t x,
+                           in_vector_2_t y,
+                           out_vector_t z);
+template<class ExecutionPolicy,
+         class in_vector_1_t,
+         class in_matrix_t,
+         class in_vector_2_t,
+         class out_vector_t>
+void matrix_vector_product(ExecutionPolicy&& exec,
+                           in_matrix_t A,
+                           in_vector_1_t x,
+                           in_vector_2_t y,
+                           out_vector_t z);
+
+// [linalg.algs.blas2.symm-matvec],
+// symmetric matrix-vector product
+template<class in_matrix_t,
+         class Triangle,
+         class in_vector_t,
+         class out_vector_t>
+void symmetric_matrix_vector_product(in_matrix_t A,
+                                     Triangle t,
+                                     in_vector_t x,
+                                     out_vector_t y);
+template<class ExecutionPolicy,
+         class in_matrix_t,
+         class Triangle,
+         class in_vector_t,
+         class out_vector_t>
+void symmetric_matrix_vector_product(ExecutionPolicy&& exec,
+                                     in_matrix_t A,
+                                     Triangle t,
+                                     in_vector_t x,
+                                     out_vector_t y);
+template<class in_matrix_t,
+         class Triangle,
+         class in_vector_1_t,
+         class in_vector_2_t,
+         class out_vector_t>
+void symmetric_matrix_vector_product(
+  in_matrix_t A,
+  Triangle t,
+  in_vector_1_t x,
+  in_vector_2_t y,
+  out_vector_t z);
+
+template<class ExecutionPolicy,
+         class in_matrix_t,
+         class Triangle,
+         class in_vector_1_t,
+         class in_vector_2_t,
+         class out_vector_t>
+void symmetric_matrix_vector_product(
+  ExecutionPolicy&& exec,
+  in_matrix_t A,
+  Triangle t,
+  in_vector_1_t x,
+  in_vector_2_t y,
+  out_vector_t z);
+
+// [linalg.algs.blas2.herm-matvec],
+// Hermitian matrix-vector product
+template<class in_matrix_t,
+         class Triangle,
+         class in_vector_t,
+         class out_vector_t>
+void hermitian_matrix_vector_product(in_matrix_t A,
+                                     Triangle t,
+                                     in_vector_t x,
+                                     out_vector_t y);
+template<class ExecutionPolicy,
+         class in_matrix_t,
+         class Triangle,
+         class in_vector_t,
+         class out_vector_t>
+void hermitian_matrix_vector_product(ExecutionPolicy&& exec,
+                                     in_matrix_t A,
+                                     Triangle t,
+                                     in_vector_t x,
+                                     out_vector_t y);
+template<class in_matrix_t,
+         class Triangle,
+         class in_vector_1_t,
+         class in_vector_2_t,
+         class out_vector_t>
+void hermitian_matrix_vector_product(in_matrix_t A,
+                                     Triangle t,
+                                     in_vector_1_t x,
+                                     in_vector_2_t y,
+                                     out_vector_t z);
+
+template<class ExecutionPolicy,
+         class in_matrix_t,
+         class Triangle,
+         class in_vector_1_t,
+         class in_vector_2_t,
+         class out_vector_t>
+void hermitian_matrix_vector_product(ExecutionPolicy&& exec,
+                                     in_matrix_t A,
+                                     Triangle t,
+                                     in_vector_1_t x,
+                                     in_vector_2_t y,
+                                     out_vector_t z);
+
+// [linalg.algs.blas2.tri-matvec],
+// Triangular matrix-vector product
+template<class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_vector_t,
+         class out_vector_t>
+void triangular_matrix_vector_product(
+  in_matrix_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_vector_t x,
+  out_vector_t y);
+template<class ExecutionPolicy,
+         class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_vector_t,
+         class out_vector_t>
+void triangular_matrix_vector_product(
+  ExecutionPolicy&& exec,
+  in_matrix_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_vector_t x,
+  out_vector_t y);
+template<class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_vector_1_t,
+         class in_vector_2_t,
+         class out_vector_t>
+void triangular_matrix_vector_product(in_matrix_t A,
+                                      Triangle t,
+                                      DiagonalStorage d,
+                                      in_vector_1_t x,
+                                      in_vector_2_t y,
+                                      out_vector_t z);
+template<class ExecutionPolicy,
+         class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_vector_1_t,
+         class in_vector_2_t,
+         class out_vector_t>
+void triangular_matrix_vector_product(ExecutionPolicy&& exec,
+                                      in_matrix_t A,
+                                      Triangle t,
+                                      DiagonalStorage d,
+                                      in_vector_1_t x,
+                                      in_vector_2_t y,
+                                      out_vector_t z);
+
+// [linalg.algs.blas2.tri-solve],
+// Solve a triangular linear system
+template<class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_object_t,
+         class out_object_t>
+void triangular_matrix_vector_solve(
+  in_matrix_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_vector_t b,
+  out_vector_t x);
+template<class ExecutionPolicy,
+         class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_object_t,
+         class out_object_t>
+void triangular_matrix_vector_solve(
+  ExecutionPolicy&& exec,
+  in_matrix_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_vector_t b,
+  out_vector_t x);
+
+// [linalg.algs.blas2.rank1.nonconj], nonconjugated rank-1 matrix update
+template<class in_vector_1_t,
+         class in_vector_2_t,
+         class inout_matrix_t>
+void matrix_rank_1_update(
+  in_vector_1_t x,
+  in_vector_2_t y,
+  inout_matrix_t A);
+template<class ExecutionPolicy,
+         class in_vector_1_t,
+         class in_vector_2_t,
+         class inout_matrix_t>
+void matrix_rank_1_update(
+  ExecutionPolicy&& exec,
+  in_vector_1_t x,
+  in_vector_2_t y,
+  inout_matrix_t A);
+
+// [linalg.algs.blas2.rank1.conj], conjugated rank-1 matrix update
+template<class in_vector_1_t,
+         class in_vector_2_t,
+         class inout_matrix_t>
+void matrix_rank_1_update_c(
+  in_vector_1_t x,
+  in_vector_2_t y,
+  inout_matrix_t A);
+template<class ExecutionPolicy,
+         class in_vector_1_t,
+         class in_vector_2_t,
+         class inout_matrix_t>
+void matrix_rank_1_update_c(
+  ExecutionPolicy&& exec,
+  in_vector_1_t x,
+  in_vector_2_t y,
+  inout_matrix_t A);
+
+// [linalg.algs.blas2.rank1.symm], symmetric rank-1 matrix update
+template<class in_vector_t,
+         class inout_matrix_t,
+         class Triangle>
+void symmetric_matrix_rank_1_update(
+  in_vector_t x,
+  inout_matrix_t A,
+  Triangle t);
+template<class ExecutionPolicy,
+         class in_vector_t,
+         class inout_matrix_t,
+         class Triangle>
+void symmetric_matrix_rank_1_update(
+  ExecutionPolicy&& exec,
+  in_vector_t x,
+  inout_matrix_t A,
+  Triangle t);
+
+// [linalg.algs.blas2.rank1.herm], Hermitian rank-1 matrix update
+template<class in_vector_t,
+         class inout_matrix_t,
+         class Triangle>
+void hermitian_matrix_rank_1_update(
+  in_vector_t x,
+  inout_matrix_t A,
+  Triangle t);
+template<class ExecutionPolicy,
+         class in_vector_t,
+         class inout_matrix_t,
+         class Triangle>
+void hermitian_matrix_rank_1_update(
+  ExecutionPolicy&& exec,
+  in_vector_t x,
+  inout_matrix_t A,
+  Triangle t);
+
+// [linalg.algs.blas2.rank2.symm], symmetric rank-2 matrix update
+template<class in_vector_1_t,
+         class in_vector_2_t,
+         class inout_matrix_t,
+         class Triangle>
+void symmetric_matrix_rank_2_update(
+  in_vector_1_t x,
+  in_vector_2_t y,
+  inout_matrix_t A,
+  Triangle t);
+template<class ExecutionPolicy,
+         class in_vector_1_t,
+         class in_vector_2_t,
+         class inout_matrix_t,
+         class Triangle>
+void symmetric_matrix_rank_2_update(
+  ExecutionPolicy&& exec,
+  in_vector_1_t x,
+  in_vector_2_t y,
+  inout_matrix_t A,
+  Triangle t);
+
+// [linalg.algs.blas2.rank2.herm], Hermitian rank-2 matrix update
+template<class in_vector_1_t,
+         class in_vector_2_t,
+         class inout_matrix_t,
+         class Triangle>
+void hermitian_matrix_rank_2_update(
+  in_vector_1_t x,
+  in_vector_2_t y,
+  inout_matrix_t A,
+  Triangle t);
+template<class ExecutionPolicy,
+         class in_vector_1_t,
+         class in_vector_2_t,
+         class inout_matrix_t,
+         class Triangle>
+void hermitian_matrix_rank_2_update(
+  ExecutionPolicy&& exec,
+  in_vector_1_t x,
+  in_vector_2_t y,
+  inout_matrix_t A,
+  Triangle t);
+
+// [linalg.algs.blas3.gemm], general matrix-matrix product
+template<class in_matrix_1_t,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void matrix_product(in_matrix_1_t A,
+                    in_matrix_2_t B,
+                    out_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void matrix_product(ExecutionPolicy&& exec,
+                    in_matrix_1_t A,
+                    in_matrix_2_t B,
+                    out_matrix_t C);
+template<class in_matrix_1_t,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void matrix_product(in_matrix_1_t A,
+                    in_matrix_2_t B,
+                    in_matrix_3_t E,
+                    out_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void matrix_product(ExecutionPolicy&& exec,
+                    in_matrix_1_t A,
+                    in_matrix_2_t B,
+                    in_matrix_3_t E,
+                    out_matrix_t C);
+
+// [linalg.algs.blas3.symm], symmetric matrix-matrix product
+template<class in_matrix_1_t,
+         class Triangle,
+         class Side,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void symmetric_matrix_product(
+  in_matrix_1_t A,
+  Triangle t,
+  Side s,
+  in_matrix_2_t B,
+  out_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class Side,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void symmetric_matrix_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  Side s,
+  in_matrix_2_t B,
+  out_matrix_t C);
+template<class in_matrix_1_t,
+         class Triangle,
+         class Side,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void symmetric_matrix_product(
+  in_matrix_1_t A,
+  Triangle t,
+  Side s,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class Side,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void symmetric_matrix_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  Side s,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+
+// [linalg.algs.blas3.hemm], Hermitian matrix-matrix product
+template<class in_matrix_1_t,
+         class Triangle,
+         class Side,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void hermitian_matrix_product(
+  in_matrix_1_t A,
+  Triangle t,
+  Side s,
+  in_matrix_2_t B,
+  out_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class Side,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void hermitian_matrix_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  Side s,
+  in_matrix_2_t B,
+  out_matrix_t C);
+template<class in_matrix_1_t,
+         class Triangle,
+         class Side,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void hermitian_matrix_product(
+  in_matrix_1_t A,
+  Triangle t,
+  Side s,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class Side,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void hermitian_matrix_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  Side s,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+
+// [linalg.algs.blas3.trmm], triangular matrix-matrix product
+template<class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class Side,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void triangular_matrix_product(
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  Side s,
+  in_matrix_2_t B,
+  out_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class Side,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void triangular_matrix_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  Side s,
+  in_matrix_2_t B,
+  out_matrix_t C);
+template<class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class Side,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void triangular_matrix_product(
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  Side s,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class Side,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void triangular_matrix_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  Side s,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+
+// [linalg.alg.blas3.rank2k.symm], rank-2k symmetric matrix update
+template<class in_matrix_1_t,
+         class in_matrix_2_t,
+         class inout_matrix_t,
+         class Triangle>
+void symmetric_matrix_rank_2k_update(
+  in_matrix_1_t A,
+  in_matrix_2_t B,
+  inout_matrix_t C,
+  Triangle t);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class in_matrix_2_t,
+         class inout_matrix_t,
+         class Triangle>
+void symmetric_matrix_rank_2k_update(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  in_matrix_2_t B,
+  inout_matrix_t C,
+  Triangle t);
+
+// [linalg.alg.blas3.rank2k.herm], rank-2k Hermitian matrix update
+template<class in_matrix_1_t,
+         class in_matrix_2_t,
+         class inout_matrix_t,
+         class Triangle>
+void hermitian_matrix_rank_2k_update(
+  in_matrix_1_t A,
+  in_matrix_2_t B,
+  inout_matrix_t C,
+  Triangle t);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class in_matrix_2_t,
+         class inout_matrix_t,
+         class Triangle>
+void hermitian_matrix_rank_2k_update(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  in_matrix_2_t B,
+  inout_matrix_t C,
+  Triangle t);
+
+// [linalg.alg.blas3.trsm], solve multiple triangular linear systems
+template<class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class Side,
+         class in_object_t,
+         class out_object_t>
+void triangular_matrix_matrix_solve(
+  in_matrix_t A,
+  Triangle t,
+  DiagonalStorage d,
+  Side s,
+  in_object_t B,
+  out_object_t X);
+template<class ExecutionPolicy,
+         class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class Side,
+         class in_matrix_t,
+         class out_matrix_t>
+void triangular_matrix_matrix_solve(
+  ExecutionPolicy&& exec,
+  in_matrix_t A,
+  Triangle t,
+  DiagonalStorage d,
+  Side s,
+  in_matrix_t B,
+  out_matrix_t X);
 ```
 
 ### Tag classes [linalg.tags]
@@ -2830,9 +3628,9 @@ BLAS 1 operations, even though it only operates on scalars.
 
 --*end note]*
 
-##### Givens rotations
+##### Givens rotations [linalg.algs.blas1.givens]
 
-###### Compute Givens rotations
+###### Compute Givens rotations [linalg.algs.blas1.givens.setup]
 
 ```c++
 template<class Real>
@@ -2888,7 +3686,7 @@ note]*
 
 * *Throws:* Nothing.
 
-###### Apply a computed Givens rotation to vectors
+###### Apply a computed Givens rotation to vectors [linalg.algs.blas1.givens.apply]
 
 ```c++
 template<class inout_vector_1_t,
@@ -2966,7 +3764,7 @@ this.
   2 matrix and the input vectors were successive rows of a matrix with
   two rows.
 
-###### Swap matrix or vector elements
+###### Swap matrix or vector elements [linalg.algs.blas1.swap]
 
 ```c++
 template<class inout_object_1_t,
@@ -3005,7 +3803,7 @@ void linalg_swap(ExecutionPolicy&& exec,
 * *Effects:* Swap all corresponding elements of the objects
   `x` and `y`.
 
-##### Multiply the elements of an object in place by a scalar
+##### Multiply the elements of an object in place by a scalar [linalg.algs.blas1.scale]
 
 ```c++
 template<class Scalar,
@@ -3033,7 +3831,7 @@ void scale(ExecutionPolicy&& exec,
 
 * *Effects*: Multiply each element of `obj` in place by `alpha`.
 
-##### Copy elements of one matrix or vector into another
+##### Copy elements of one matrix or vector into another [linalg.algs.blas1.copy]
 
 ```c++
 template<class in_object_t,
@@ -3072,7 +3870,7 @@ void linalg_copy(ExecutionPolicy&& exec,
 * *Effects:* Overwrite each element of `y` with the corresponding
   element of `x`.
 
-##### Add vectors or matrices elementwise
+##### Add vectors or matrices elementwise [linalg.algs.blas1.add]
 
 ```c++
 template<class in_object_1_t,
@@ -3126,7 +3924,7 @@ void linalg_add(ExecutionPolicy&& exec,
 
 * *Effects*: Compute the elementwise sum z = x + y.
 
-##### Inner (dot) product of two vectors
+##### Inner (dot) product of two vectors [linalg.algs.blas1.dot]
 
 ###### Non-conjugated inner (dot) product
 
@@ -3207,7 +4005,7 @@ auto dot(ExecutionPolicy&& exec,
   two-parameter overload is equivalent to `dot(v1, v2, T{});`, and the
   three-parameter overload is equivalent to `dot(exec, v1, v2, T{});`.
 
-###### Conjugated inner (dot) product
+###### Conjugated inner (dot) product [linalg.algs.blas1.dot.conj]
 
 ```c++
 template<class in_vector_1_t,
@@ -3253,7 +4051,7 @@ auto dotc(ExecutionPolicy&& exec,
   two-parameter overload is equivalent to `dotc(v1, v2, T{});`, and the
   three-parameter overload is equivalent to `dotc(exec, v1, v2, T{});`.
 
-##### Euclidean (2) norm of a vector
+##### Euclidean (2) vector norm [linalg.algs.blas1.norm2]
 
 ```c++
 template<class in_vector_t,
@@ -3313,7 +4111,7 @@ auto vector_norm2(ExecutionPolicy&& exec,
   and the two-parameter overload is equivalent to
   `vector_norm2(exec, v, T{});`.
 
-##### Sum of absolute values
+##### Sum of absolute values of vector elements [linalg.algs.blas1.abs_sum]
 
 ```c++
 template<class in_vector_t,
@@ -3377,7 +4175,7 @@ auto vector_abs_sum(ExecutionPolicy&& exec,
   and the two-parameter overload is equivalent to
   `vector_abs_sum(exec, v, T{});`.
 
-##### Index of maximum absolute value of vector elements
+##### Index of maximum absolute value of vector elements [linalg.algs.blas1.idx_abs_max]
 
 ```c++
 template<class in_vector_t>
@@ -3399,9 +4197,9 @@ ptrdiff_t idx_abs_max(ExecutionPolicy&& exec,
   the first element of `v` having largest absolute value.  If `v` has
   zero elements, then returns `-1`.
 
-#### BLAS 2 functions
+#### BLAS 2 functions [linalg.algs.blas2]
 
-##### General matrix-vector product
+##### General matrix-vector product [linalg.algs.blas2.general-matvec]
 
 *[Note:* These functions correspond to the BLAS function
 `xGEMV`. --*end note]*
@@ -3493,7 +4291,7 @@ void matrix_vector_product(ExecutionPolicy&& exec,
 * *Effects:* Assigns to the elements of `z` the elementwise sum of
   `y`, and the product of the matrix `A` with the vector `x`.
 
-##### Symmetric matrix-vector product
+##### Symmetric matrix-vector product [linalg.algs.blas2.symm-matvec],
 
 *[Note:* These functions correspond to the BLAS functions `xSYMV` and
 `xSPMV`. --*end note]*
@@ -3610,7 +4408,7 @@ void symmetric_matrix_vector_product(
 * *Effects:* Assigns to the elements of `z` the elementwise sum of
   `y`, with the product of the matrix `A` with the vector `x`.
 
-##### Hermitian matrix-vector product
+##### Hermitian matrix-vector product [linalg.algs.blas2.herm-matvec],
 
 *[Note:* These functions correspond to the BLAS functions `xHEMV` and
 `xHPMV`. --*end note]*
@@ -3728,7 +4526,7 @@ void hermitian_matrix_vector_product(ExecutionPolicy&& exec,
 * *Effects:* Assigns to the elements of `z` the elementwise sum of
   `y`, and the product of the matrix `A` with the vector `x`.
 
-##### Triangular matrix-vector product
+##### Triangular matrix-vector product [linalg.algs.blas2.tri-matvec]
 
 *[Note:* These functions correspond to the BLAS functions `xTRMV` and
 `xTPMV`. --*end note]*
@@ -3861,7 +4659,7 @@ void triangular_matrix_vector_product(ExecutionPolicy&& exec,
 * *Effects:* Assigns to the elements of `z` the elementwise sum of
   `y`, with the product of the matrix `A` with the vector `x`.
 
-##### Solve a triangular linear system
+##### Solve a triangular linear system [linalg.algs.blas2.tri-solve]
 
 ```c++
 template<class in_matrix_t,
@@ -3954,9 +4752,9 @@ void triangular_matrix_vector_solve(
     function needs to be able to form an `element_type` value equal to
     one. --*end note]
 
-##### Rank-1 (outer product) update of a matrix
+##### Rank-1 (outer product) update of a matrix [linalg.algs.blas2.rank1]
 
-###### Nonsymmetric non-conjugated rank-1 update
+###### Nonsymmetric non-conjugated rank-1 update [linalg.algs.blas2.rank1.nonconj]
 
 ```c++
 template<class in_vector_1_t,
@@ -4012,7 +4810,7 @@ types). --*end note]*
 as a `conjugate_view`.  Alternately, they can use the shortcut
 `matrix_rank_1_update_c` below. --*end note]*
 
-###### Nonsymmetric conjugated rank-1 update
+###### Nonsymmetric conjugated rank-1 update [linalg.algs.blas2.rank1.conj]
 
 ```c++
 template<class in_vector_1_t,
@@ -4037,7 +4835,7 @@ void matrix_rank_1_update_c(
 * *Effects:* Equivalent to
   `matrix_rank_1_update(x, conjugate_view(y), A);`.
 
-###### Rank-1 update of a Symmetric matrix
+###### Rank-1 update of a Symmetric matrix [linalg.algs.blas2.rank1.symm]
 
 ```c++
 template<class in_vector_t,
@@ -4098,7 +4896,7 @@ void symmetric_matrix_rank_1_update(
   specified by the `Triangle` argument `t`, and will assume for
   indices `i,j` outside that triangle, that `A(j,i)` equals `A(i,j)`.
 
-###### Rank-1 update of a Hermitian matrix
+###### Rank-1 update of a Hermitian matrix [linalg.algs.blas2.rank1.herm]
 
 ```c++
 template<class in_vector_t,
@@ -4160,7 +4958,7 @@ void hermitian_matrix_rank_1_update(
   indices `i,j` outside that triangle, that `A(j,i)` equals
   `conj(A(i,j))`.
 
-##### Rank-2 update of a symmetric matrix
+##### Rank-2 update of a symmetric matrix [linalg.algs.blas2.rank2.symm]
 
 ```c++
 template<class in_vector_1_t,
@@ -4232,7 +5030,7 @@ void symmetric_matrix_rank_2_update(
   specified by the `Triangle` argument `t`, and will assume for
   indices `i,j` outside that triangle, that `A(j,i)` equals `A(i,j)`.
 
-##### Rank-2 update of a Hermitian matrix
+##### Rank-2 update of a Hermitian matrix [linalg.algs.blas2.rank2.herm]
 
 ```c++
 template<class in_vector_1_t,
@@ -4306,9 +5104,9 @@ void hermitian_matrix_rank_2_update(
   indices `i,j` outside that triangle, that `A(j,i)` equals
   `conj(A(i,j))`.
 
-#### BLAS 3 functions
+#### BLAS 3 functions [linalg.algs.blas3]
 
-##### General matrix-matrix product
+##### General matrix-matrix product [linalg.algs.blas3.gemm]
 
 *[Note:* These functions correspond to the BLAS function `xGEMM`.
 --*end note]*
@@ -4415,7 +5213,7 @@ void matrix_product(ExecutionPolicy&& exec,
 * *Remarks:* `C` and `E` may refer to the same matrix.  If so, then
   they must have the same layout.
 
-##### Symmetric matrix-matrix product
+##### Symmetric matrix-matrix product [linalg.algs.blas3.symm]
 
 *[Note:* These functions correspond to the BLAS function `xSYMM`.
 Unlike the symmetric rank-1 update functions, these functions assume
@@ -4611,7 +5409,7 @@ void symmetric_matrix_product(
 * *Remarks:* `C` and `E` may refer to the same matrix.  If so, then
   they must have the same layout.
 
-##### Hermitian matrix-matrix product
+##### Hermitian matrix-matrix product [linalg.algs.blas3.hemm]
 
 *[Note:* These functions correspond to the BLAS function `xHEMM`.
 Unlike the Hermitian rank-1 update functions, these functions assume
@@ -4808,7 +5606,7 @@ void hermitian_matrix_product(
 * *Remarks:* `C` and `E` may refer to the same matrix.  If so, then
   they must have the same layout.
 
-##### Triangular matrix-matrix product
+##### Triangular matrix-matrix product [linalg.algs.blas3.trmm]
 
 *[Note:* These functions correspond to the BLAS function `xTRMM`.
 --*end note]*
@@ -4995,7 +5793,6 @@ void triangular_matrix_product(
   out_matrix_t C);
 ```
 
-
 * *Constraints:*
 
   * If `Side` is `left_side_t`, then for `i,j` in the domain of `C`,
@@ -5019,13 +5816,13 @@ void triangular_matrix_product(
 * *Remarks:* `C` and `E` may refer to the same matrix.  If so, then
   they must have the same layout.
 
-##### Rank-2k update of a symmetric or Hermitian matrix
+##### Rank-2k update of a symmetric or Hermitian matrix [linalg.alg.blas3.rank2k]
 
 *[Note:* Users can achieve the effect of the `TRANS` argument of these
 BLAS functions, by making `C` a `transpose_view` or
 `conjugate_transpose_view`. --*end note]*
 
-###### Rank-2k update of a symmetric matrix
+###### Rank-2k symmetric matrix update [linalg.alg.blas3.rank2k.symm]
 
 ```c++
 template<class in_matrix_1_t,
@@ -5101,7 +5898,7 @@ The BLAS "quick reference" has a typo; the "ALPHA" argument of
   specified by the `Triangle` argument `t`, and will assume for
   indices `i,j` outside that triangle, that `C(j,i)` equals `C(i,j)`.
 
-###### Rank-2k update of a Hermitian matrix
+###### Rank-2k Hermitian matrix update [linalg.alg.blas3.rank2k.herm]
 
 ```c++
 template<class in_matrix_1_t,
@@ -5178,7 +5975,7 @@ void hermitian_matrix_rank_2k_update(
   indices `i,j` outside that triangle, that `C(j,i)` equals
   `conj(C(i,j))`.
 
-##### Solve multiple triangular linear systems with the same matrix
+##### Solve multiple triangular linear systems [linalg.alg.blas3.trsm]
 
 ```c++
 template<class in_matrix_t,

--- a/D1673/blas_interface.md
+++ b/D1673/blas_interface.md
@@ -1240,6 +1240,9 @@ public:
     constexpr mapping(const Extents& e,
       const typename Extents::index_type s);
 
+    template<class OtherExtents>
+    constexpr mapping(const mapping<OtherExtents>& e) noexcept;
+
     typename Extents::index_type
     operator() (typename Extents::index_type i,
                 typename Extents::index_type j) const;
@@ -1273,6 +1276,8 @@ public:
 
   * `StorageOrder` is either `column_major_t` or `row_major_t`.
 
+  * `Extents` is a specialization of `extents`.
+
   * `Extents::rank()` equals 2.
 
 ```c++
@@ -1298,6 +1303,20 @@ to a BLAS function, then the implementation must impose the
 requirement at run time.
 
 --*end note]*
+
+```c++
+template<class OtherExtents>
+constexpr mapping(const mapping<OtherExtents>& e) noexcept;
+```
+
+* *Constraints:*
+
+  * `OtherExtents` is a specialization of `extents`.
+
+  * `OtherExtents::rank()` equals 2.
+
+* *Effects:* Initializes `extents_` with `m.extents_`, and
+  initializes `stride_` with `m.stride_`.
 
 ```c++
 typename Extents::index_type
@@ -1453,6 +1472,9 @@ public:
     constexpr mapping(const Extents& e,
       const typename Extents::index_type s);
 
+    template<class OtherExtents>
+    constexpr mapping(const mapping<OtherExtents>& e) noexcept;
+
     typename Extents::index_type
     operator() (typename Extents::index_type i,
                 typename Extents::index_type j) const;
@@ -1487,6 +1509,8 @@ public:
 
   * `StorageOrder` is either `column_major_t` or `row_major_t`.
 
+  * `Extents` is a specialization of `extents`.
+
   * `Extents::rank()` equals 2.
 
 ```c++
@@ -1494,6 +1518,19 @@ constexpr mapping(const Extents& e);
 ```
 
 * *Requires:* `e.extent(0)` equals `e.extent(1)`.
+
+* *Effects:* Initializes `extents_` with `e`.
+
+```c++
+template<class OtherExtents>
+constexpr mapping(const mapping<OtherExtents>& e);
+```
+
+* *Constraints:*
+
+  * `OtherExtents` is a specialization of `extents`.
+
+  * `OtherExtents::rank()` equals 2.
 
 * *Effects:* Initializes `extents_` with `e`.
 


### PR DESCRIPTION
@crtrott @dalg24 @dhollman et alia: Most important changes:

  * Finished wording for `layout_blas_general` and `layout_blas_packed`
  * Moved or removed most non-wording introductory material out of the wording section
  * Made explicit where the wording section starts, by putting wording in a new section called "Wording"
  * (new as of 2020 Jan 07 AM) finished adding a synopsis and section headers