### PR TITLE
P1673R2: Fix *_view return type, etc. (10 Jan 2020)

### DIFF
--- a/D1673/blas_interface.md
+++ b/D1673/blas_interface.md
@@ -381,7 +381,7 @@ three categories:
    they have a different base name.
 
 3. The complex-arithmetic versions offer a choice between
-   non-conjugated or conjugated operations.
+   nonconjugated or conjugated operations.
 
 As an example of the second category, the BLAS functions `SASUM` and
 `DASUM` compute the sums of absolute values of a vector's elements.
@@ -393,11 +393,11 @@ but it requires fewer arithmetic operations.
 
 Examples of the third category include the following:
 
-* non-conjugated dot product `xDOTU` and conjugated dot product
+* nonconjugated dot product `xDOTU` and conjugated dot product
   `xDOTC`; and
 * rank-1 symmetric (`xGERU`) vs. Hermitian (`xGERC`) matrix update.
 
-The conjugate transpose and the (non-conjugated) transpose are the
+The conjugate transpose and the (nonconjugated) transpose are the
 same operation in real arithmetic (if one considers real arithmetic
 embedded in complex arithmetic), but differ in complex arithmetic.
 Different applications have different reasons to want either.  The C++
@@ -1329,7 +1329,7 @@ conjugate_transpose_view(
                layout_transpose<Layout>,
                accessor_conjugate<Accessor>> a);
 
-// [linalg.algs.blas1.givens.setup], compute Givens rotation
+// [linalg.algs.blas1.givens.lartg], compute Givens rotation
 template<class Real>
 void givens_rotation_setup(const Real a,
                            const Real b,
@@ -1343,7 +1343,7 @@ void givens_rotation_setup(const complex<Real>& a,
                            complex<Real>& s,
                            complex<Real>& r);
 
-// [linalg.algs.blas1.givens.apply], apply computed Givens rotation
+// [linalg.algs.blas1.givens.rot], apply computed Givens rotation
 template<class inout_vector_1_t,
          class inout_vector_2_t,
          class Real>
@@ -1394,7 +1394,7 @@ void linalg_swap(ExecutionPolicy&& exec,
                  inout_object_1_t x,
                  inout_object_2_t y);
 
-// [linalg.algs.blas1.scale], multiply elements by scalar
+// [linalg.algs.blas1.scal], multiply elements by scalar
 template<class Scalar,
          class inout_object_t>
 void scale(const Scalar alpha,
@@ -1434,7 +1434,11 @@ void linalg_add(ExecutionPolicy&& exec,
                 in_object_2_t y,
                 out_object_t z);
 
-// [linalg.algs.blas1.dot.nonconj], nonconjugated inner product
+// [linalg.algs.blas1.dot],
+// dot product of two vectors
+
+// [linalg.algs.blas1.dot.dotu],
+// nonconjugated dot product of two vectors
 template<class in_vector_1_t,
          class in_vector_2_t,
          class T>
@@ -1460,7 +1464,8 @@ auto dot(ExecutionPolicy&& exec,
          in_vector_1_t v1,
          in_vector_2_t v2);
 
-// [linalg.algs.blas1.dot.conj], conjugated inner product
+// [linalg.algs.blas1.dot.dotc],
+// conjugated dot product of two vectors
 template<class in_vector_1_t,
          class in_vector_2_t,
          class T>
@@ -1486,7 +1491,8 @@ auto dotc(ExecutionPolicy&& exec,
           in_vector_1_t v1,
           in_vector_2_t v2);
 
-// [linalg.algs.blas1.norm2], Euclidean vector norm
+// [linalg.algs.blas1.nrm2],
+// Euclidean norm of a vector
 template<class in_vector_t,
          class T>
 T vector_norm2(in_vector_t v,
@@ -1504,7 +1510,8 @@ template<class ExecutionPolicy,
 auto vector_norm2(ExecutionPolicy&& exec,
                   in_vector_t v);
 
-// [linalg.algs.blas1.abs_sum], sum of absolute values
+// [linalg.algs.blas1.asum],
+// sum of absolute values of vector elements
 template<class in_vector_t,
          class T>
 T vector_abs_sum(in_vector_t v,
@@ -1522,7 +1529,7 @@ template<class ExecutionPolicy,
 auto vector_abs_sum(ExecutionPolicy&& exec,
                     in_vector_t v);
 
-// [linalg.algs.blas1.idx_abs_max],
+// [linalg.algs.blas1.iamax],
 // index of maximum absolute value of vector elements
 template<class in_vector_t>
 ptrdiff_t idx_abs_max(in_vector_t v);
@@ -3789,7 +3796,7 @@ BLAS 1 operations, even though it only operates on scalars.
 
 ##### Givens rotations [linalg.algs.blas1.givens]
 
-###### Compute Givens rotations [linalg.algs.blas1.givens.setup]
+###### Compute Givens rotation [linalg.algs.blas1.givens.lartg]
 
 ```c++
 template<class Real>
@@ -3845,7 +3852,7 @@ note]*
 
 * *Throws:* Nothing.
 
-###### Apply a computed Givens rotation to vectors [linalg.algs.blas1.givens.apply]
+###### Apply a computed Givens rotation to vectors [linalg.algs.blas1.givens.rot]
 
 ```c++
 template<class inout_vector_1_t,
@@ -3962,7 +3969,7 @@ void linalg_swap(ExecutionPolicy&& exec,
 * *Effects:* Swap all corresponding elements of the objects
   `x` and `y`.
 
-##### Multiply the elements of an object in place by a scalar [linalg.algs.blas1.scale]
+##### Multiply the elements of an object in place by a scalar [linalg.algs.blas1.scal]
 
 ```c++
 template<class Scalar,
@@ -4083,9 +4090,9 @@ void linalg_add(ExecutionPolicy&& exec,
 
 * *Effects*: Compute the elementwise sum z = x + y.
 
-##### Inner (dot) product of two vectors [linalg.algs.blas1.dot]
+##### Dot product of two vectors [linalg.algs.blas1.dot]
 
-###### Non-conjugated inner (dot) product
+###### Nonconjugated dot product of two vectors [linalg.algs.blas1.dot.dotu]
 
 ```c++
 template<class in_vector_1_t,
@@ -4105,7 +4112,7 @@ T dot(ExecutionPolicy&& exec,
 ```
 
 *[Note:* These functions correspond to the BLAS functions `xDOT` (for
-real element types), `xDOTC`, and `xDOTU` (for complex element types).
+real element types) and `xDOTU` (for complex element types).
 --*end note]*
 
 * *Requires:*
@@ -4145,7 +4152,7 @@ for specific `ExecutionPolicy` types. --*end note]*
 as a `conjugate_view`.  Alternately, they can use the shortcut `dotc`
 below. --*end note]*
 
-###### Non-conjugated inner (dot) product with default result type
+###### Nonconjugated dot product with default result type
 
 ```c++
 template<class in_vector_1_t,
@@ -4164,7 +4171,7 @@ auto dot(ExecutionPolicy&& exec,
   two-parameter overload is equivalent to `dot(v1, v2, T{});`, and the
   three-parameter overload is equivalent to `dot(exec, v1, v2, T{});`.
 
-###### Conjugated inner (dot) product [linalg.algs.blas1.dot.conj]
+###### Conjugated dot product of two vectors [linalg.algs.blas1.dot.dotc]
 
 ```c++
 template<class in_vector_1_t,
@@ -4183,15 +4190,22 @@ T dotc(ExecutionPolicy&& exec,
        T init);
 ```
 
+*[Note:*
+
+These functions correspond to the BLAS functions `xDOT` (for real
+element types) and `xDOTC` (for complex element types).
+
+`dotc` exists to give users reasonable default inner product behavior
+for both real and complex element types.
+
+--*end note]*
+
 * *Effects:* The three-argument overload is equivalent to
   `dot(v1, conjugate_view(v2), init);`.
   The four-argument overload is equivalent to
   `dot(exec, v1, conjugate_view(v2), init);`.
 
-*[Note:* `dotc` exists to give users reasonable default inner product
-behavior for both real and complex element types. --*end note]*
-
-###### Conjugated inner (dot) product with default result type
+###### Conjugated dot product with default result type
 
 ```c++
 template<class in_vector_1_t,
@@ -4210,7 +4224,9 @@ auto dotc(ExecutionPolicy&& exec,
   two-parameter overload is equivalent to `dotc(v1, v2, T{});`, and the
   three-parameter overload is equivalent to `dotc(exec, v1, v2, T{});`.
 
-##### Euclidean (2) vector norm [linalg.algs.blas1.norm2]
+##### Euclidean norm of a vector [linalg.algs.blas1.nrm2]
+
+###### Euclidean norm with specified result type
 
 ```c++
 template<class in_vector_t,
@@ -4239,21 +4255,20 @@ T vector_norm2(ExecutionPolicy&& exec,
   recommended implementation for floating-point types.  See *Remarks*
   below. --*end note]*
 
-* *Effects:* Returns the Euclidean (2) norm of the vector `v`.
+* *Effects:* Returns the Euclidean norm (also called 2-norm)
+  of the vector `v`.
 
-* *Remarks:*
-
-  1. If `in_vector_t::element_type` and `T` are both
-     floating-point types or complex versions thereof, and if `T`
-     has higher precision than `in_vector_type::element_type`, then
-     implementations will use `T`'s precision or greater for
-     intermediate terms in the sum.
+* *Remarks:* If `in_vector_t::element_type` and `T` are both
+  floating-point types or complex versions thereof, and if `T` has
+  higher precision than `in_vector_type::element_type`, then
+  implementations will use `T`'s precision or greater for intermediate
+  terms in the sum.
 
 *[Note:* We recommend that implementers document their guarantees
 regarding overflow and underflow of `vector_norm2` for floating-point
 return types. --*end note]*
 
-##### Euclidean (2) norm of a vector with default result type
+###### Euclidean norm with default result type
 
 ```c++
 template<class in_vector_t>
@@ -4270,7 +4285,9 @@ auto vector_norm2(ExecutionPolicy&& exec,
   and the two-parameter overload is equivalent to
   `vector_norm2(exec, v, T{});`.
 
-##### Sum of absolute values of vector elements [linalg.algs.blas1.abs_sum]
+##### Sum of absolute values of vector elements [linalg.algs.blas1.asum]
+
+###### Sum of absolute values with specified result type
 
 ```c++
 template<class in_vector_t,
@@ -4318,7 +4335,7 @@ one-norm for many linear algebra algorithms in practice. --*end note]*
   implementations will use `T`'s precision or greater for intermediate
   terms in the sum.
 
-##### Sum of absolute values with default result type
+###### Sum of absolute values with default result type
 
 ```c++
 template<class in_vector_t>
@@ -4334,7 +4351,7 @@ auto vector_abs_sum(ExecutionPolicy&& exec,
   and the two-parameter overload is equivalent to
   `vector_abs_sum(exec, v, T{});`.
 
-##### Index of maximum absolute value of vector elements [linalg.algs.blas1.idx_abs_max]
+##### Index of maximum absolute value of vector elements [linalg.algs.blas1.iamax]
 
 ```c++
 template<class in_vector_t>
@@ -4945,7 +4962,7 @@ void triangular_matrix_vector_solve(
 
 ##### Rank-1 (outer product) update of a matrix [linalg.algs.blas2.rank1]
 
-###### Nonsymmetric non-conjugated rank-1 update [linalg.algs.blas2.rank1.geru]
+###### Nonsymmetric nonconjugated rank-1 update [linalg.algs.blas2.rank1.geru]
 
 ```c++
 template<class in_vector_1_t,
@@ -6236,9 +6253,9 @@ The BLAS "quick reference" has a typo; the "ALPHA" argument of
     `C.static_extent(1)`.
 
 * *Effects:* Assigns to `C` on output, the elementwise sum of `C` on
-  input with (the matrix product of `A` and the non-conjugated
+  input with (the matrix product of `A` and the nonconjugated
   transpose of `B`) and (the matrix product of `B` and the
-  non-conjugated transpose of `A`.)
+  nonconjugated transpose of `A`.)
 
 * *Remarks:* The functions will only access the triangle of `C`
   specified by the `Triangle` argument `t`, and will assume for

--- a/D1673/blas_interface.md
+++ b/D1673/blas_interface.md
@@ -1214,12 +1214,6 @@ inline constexpr implicit_unit_diagonal_t implicit_unit_diagonal;
 struct explicit_diagonal_t;
 inline constexpr explicit_diagonal_t explicit_diagonal;
 
-// [linalg.tags.side], side tags
-struct left_side_t;
-inline constexpr left_side_t left_side;
-struct right_side_t { };
-inline constexpr right_side_t right_side;
-
 // [linalg.layouts.general], class template layout_blas_general
 template<class StorageOrder>
 class layout_blas_general;

--- a/D1673/blas_interface.md
+++ b/D1673/blas_interface.md
@@ -3053,6 +3053,8 @@ return basic_mdspan<ElementType, Extents, Layout,
     accessor_scaled<ScalingFactor, Accessor>(s, a.accessor()));
 ```
 
+* *Remarks:* The elements of the returned `basic_mdspan` are read only.
+
 [*Example:*
 ```c++
 void test_scaled_view(basic_mdspan<double, extents<10>> a)
@@ -3583,6 +3585,8 @@ return basic_mdspan<ElementType,
   a.accessor());
 ```
 
+* *Remarks:* The elements of the returned `basic_mdspan` are read only.
+
 ```c++
 template<class EltType,
          class Extents,
@@ -3599,6 +3603,8 @@ transpose_view(basic_mdspan<EltType, Extents,
 return basic_mdspan<EltType, Extents, Layout, Accessor>(a.data(),
   a.mapping().nested_mapping(), a.accessor());
 ```
+
+* *Remarks:* The elements of the returned `basic_mdspan` are read only.
 
 [*Example:*
 ```c++
@@ -3692,6 +3698,8 @@ conjugate_transpose_view(
 
 * *Effects:* Equivalent to
   `return conjugate_view(transpose_view(a));`.
+
+* *Remarks:* The elements of the returned `basic_mdspan` are read only.
 
 [*Example:*
 ```c++

--- a/D1673/blas_interface.md
+++ b/D1673/blas_interface.md
@@ -5317,8 +5317,7 @@ Unlike the symmetric rank-1 update functions, these functions assume
 that the input matrix -- not the output matrix -- is symmetric. --*end
 note]*
 
-The following requirements apply to all functions in this section,
-unless otherwise specified.
+The following requirements apply to all functions in this section.
 
 * *Requires:*
 
@@ -5327,22 +5326,6 @@ unless otherwise specified.
   * `C.extent(0)` equals `E.extent(0)` (if applicable).
 
   * `C.extent(1)` equals `E.extent(1)` (if applicable).
-
-  * For `symmetric_matrix_left_product`,
-
-     * `A.extent(1)` equals `B.extent(0)`,
-
-     * `A.extent(0)` equals `C.extent(0)`, and
-
-     * `B.extent(1)` equals `C.extent(1)`.
-
-  * For `symmetric_matrix_right_product`,
-
-     * `B.extent(1)` equals `A.extent(0)`,
-
-     * `B.extent(0)` equals `C.extent(0)`, and
-
-     * `A.extent(1)` equals `C.extent(1)`.
 
 * *Constraints:*
 
@@ -5370,37 +5353,59 @@ unless otherwise specified.
     `dynamic_extent`, then `C.static_extent(r)` equals
     `E.static_extent(r)` (if applicable).
 
-  * For `symmetric_matrix_left_product`,
-
-    * if neither `A.static_extent(1)` nor `B.static_extent(0)` equals
-      `dynamic_extent`, then `A.static_extent(1)` equals
-      `B.static_extent(0)`;
-
-    * if neither `A.static_extent(0)` nor `C.static_extent(0)` equals
-      `dynamic_extent`, then `A.static_extent(0)` equals
-      `C.static_extent(0)`; and
-
-    * if neither `B.static_extent(1)` nor `C.static_extent(1)` equals
-      `dynamic_extent`, then `B.static_extent(1)` equals
-      `C.static_extent(1)`.
-
-  * For `symmetric_matrix_right_product`,
-
-    * if neither `B.static_extent(1)` nor `A.static_extent(0)` equals
-      `dynamic_extent`, then `B.static_extent(1)` equals
-      `A.static_extent(0)`;
-
-    * if neither `B.static_extent(0)` nor `C.static_extent(0)` equals
-      `dynamic_extent`, then `B.static_extent(0)` equals
-      `C.static_extent(0)`; and
-
-    * if neither `A.static_extent(1)` nor `C.static_extent(1)` equals
-      `dynamic_extent`, then `A.static_extent(1)` equals
-      `C.static_extent(1)`.
-
 * *Remarks:* The functions will only access the triangle of `A`
   specified by the `Triangle` argument `t`, and will assume for
   indices `i,j` outside that triangle, that `A(j,i)` equals `A(i,j)`.
+
+The following requirements apply to all overloads of
+`symmetric_matrix_left_product`.
+
+* *Requires:*
+
+   * `A.extent(1)` equals `B.extent(0)`,
+
+   * `A.extent(0)` equals `C.extent(0)`, and
+
+   * `B.extent(1)` equals `C.extent(1)`.
+
+* *Mandates:*
+
+  * If neither `A.static_extent(1)` nor `B.static_extent(0)` equals
+    `dynamic_extent`, then `A.static_extent(1)` equals
+    `B.static_extent(0)`;
+
+  * if neither `A.static_extent(0)` nor `C.static_extent(0)` equals
+    `dynamic_extent`, then `A.static_extent(0)` equals
+    `C.static_extent(0)`; and
+
+  * if neither `B.static_extent(1)` nor `C.static_extent(1)` equals
+    `dynamic_extent`, then `B.static_extent(1)` equals
+    `C.static_extent(1)`.
+
+The following requirements apply to all overloads of
+`symmetric_matrix_right_product`.
+
+* *Requires:*
+
+   * `B.extent(1)` equals `A.extent(0)`,
+
+   * `B.extent(0)` equals `C.extent(0)`, and
+
+   * `A.extent(1)` equals `C.extent(1)`.
+
+* *Mandates:*
+
+  * If neither `B.static_extent(1)` nor `A.static_extent(0)` equals
+    `dynamic_extent`, then `B.static_extent(1)` equals
+    `A.static_extent(0)`;
+
+  * if neither `B.static_extent(0)` nor `C.static_extent(0)` equals
+    `dynamic_extent`, then `B.static_extent(0)` equals
+    `C.static_extent(0)`; and
+
+  * if neither `A.static_extent(1)` nor `C.static_extent(1)` equals
+    `dynamic_extent`, then `A.static_extent(1)` equals
+    `C.static_extent(1)`.
 
 ###### Overwriting symmetric matrix-matrix product
 
@@ -5463,12 +5468,10 @@ void symmetric_matrix_right_product(
 * *Effects:*
 
   * `symmetric_matrix_left_product` assigns to the elements of the
-    matrix `C` the product of the matrices `A` and `B`, where the
-    matrix `A` is assumed to be symmetric.
+    matrix `C` the product of the matrices `A` and `B`.
 
   * `symmetric_matrix_right_product` assigns to the elements of the
-    matrix `C` the product of the matrices `B` and `A`, where the
-    matrix `A` is assumed to be symmetric.
+    matrix `C` the product of the matrices `B` and `A`.
 
 ###### Updating symmetric matrix-matrix product
 
@@ -5540,13 +5543,11 @@ void symmetric_matrix_right_product(
 
   * `symmetric_matrix_left_product` assigns to the elements of the
     matrix `C` on output, the elementwise sum of `E` and the product
-    of the matrices `A` and `B`, where the matrix `A` is assumed to be
-    symmetric.
+    of the matrices `A` and `B`.
 
   * `symmetric_matrix_right_product` assigns to the elements of the
     matrix `C` on output, the elementwise sum of `E` and the product
-    of the matrices `B` and `A`, where the matrix `A` is assumed to be
-    symmetric.
+    of the matrices `B` and `A`.
 
 * *Remarks:* `C` and `E` may refer to the same matrix.  If so, then
   they must have the same layout.
@@ -5558,8 +5559,7 @@ Unlike the Hermitian rank-1 update functions, these functions assume
 that the input matrix -- not the output matrix -- is Hermitian. --*end
 note]*
 
-The following requirements apply to all functions in this section,
-unless otherwise specified.
+The following requirements apply to all functions in this section.
 
 * *Requires:*
 
@@ -5568,22 +5568,6 @@ unless otherwise specified.
   * `C.extent(0)` equals `E.extent(0)` (if applicable).
 
   * `C.extent(1)` equals `E.extent(1)` (if applicable).
-
-  * For `hermitian_matrix_left_product`,
-
-     * `A.extent(1)` equals `B.extent(0)`,
-
-     * `A.extent(0)` equals `C.extent(0)`, and
-
-     * `B.extent(1)` equals `C.extent(1)`.
-
-  * For `hermitian_matrix_right_product`,
-
-     * `B.extent(1)` equals `A.extent(0)`,
-
-     * `B.extent(0)` equals `C.extent(0)`, and
-
-     * `A.extent(1)` equals `C.extent(1)`.
 
 * *Constraints:*
 
@@ -5611,38 +5595,60 @@ unless otherwise specified.
     `dynamic_extent`, then `C.static_extent(r)` equals
     `E.static_extent(r)` (if applicable).
 
-  * For `hermitian_matrix_left_product`,
-
-    * if neither `A.static_extent(1)` nor `B.static_extent(0)` equals
-      `dynamic_extent`, then `A.static_extent(1)` equals
-      `B.static_extent(0)`;
-
-    * if neither `A.static_extent(0)` nor `C.static_extent(0)` equals
-      `dynamic_extent`, then `A.static_extent(0)` equals
-      `C.static_extent(0)`; and
-
-    * if neither `B.static_extent(1)` nor `C.static_extent(1)` equals
-      `dynamic_extent`, then `B.static_extent(1)` equals
-      `C.static_extent(1)`.
-
-  * For `hermitian_matrix_right_product`,
-
-    * if neither `B.static_extent(1)` nor `A.static_extent(0)` equals
-      `dynamic_extent`, then `B.static_extent(1)` equals
-      `A.static_extent(0)`;
-
-    * if neither `B.static_extent(0)` nor `C.static_extent(0)` equals
-      `dynamic_extent`, then `B.static_extent(0)` equals
-      `C.static_extent(0)`; and
-
-    * if neither `A.static_extent(1)` nor `C.static_extent(1)` equals
-      `dynamic_extent`, then `A.static_extent(1)` equals
-      `C.static_extent(1)`.
-
 * *Remarks:* The functions will only access the triangle of `A`
   specified by the `Triangle` argument `t`, and will assume for
   indices `i,j` outside that triangle, that `A(j,i)` equals
   `conj(A(i,j))`.
+
+The following requirements apply to all overloads of
+`hermitian_matrix_left_product`.
+
+* *Requires:*
+
+  * `A.extent(1)` equals `B.extent(0)`,
+
+  * `A.extent(0)` equals `C.extent(0)`, and
+
+  * `B.extent(1)` equals `C.extent(1)`.
+
+* *Mandates:*
+
+  * If neither `A.static_extent(1)` nor `B.static_extent(0)` equals
+    `dynamic_extent`, then `A.static_extent(1)` equals
+    `B.static_extent(0)`;
+
+  * if neither `A.static_extent(0)` nor `C.static_extent(0)` equals
+    `dynamic_extent`, then `A.static_extent(0)` equals
+    `C.static_extent(0)`; and
+
+  * if neither `B.static_extent(1)` nor `C.static_extent(1)` equals
+    `dynamic_extent`, then `B.static_extent(1)` equals
+    `C.static_extent(1)`.
+
+The following requirements apply to all overloads of
+`hermitian_matrix_right_product`.
+
+* *Requires:*
+
+  * `B.extent(1)` equals `A.extent(0)`,
+
+  * `B.extent(0)` equals `C.extent(0)`, and
+
+  * `A.extent(1)` equals `C.extent(1)`.
+
+* *Mandates:*
+
+  * If neither `B.static_extent(1)` nor `A.static_extent(0)` equals
+    `dynamic_extent`, then `B.static_extent(1)` equals
+    `A.static_extent(0)`;
+
+  * if neither `B.static_extent(0)` nor `C.static_extent(0)` equals
+    `dynamic_extent`, then `B.static_extent(0)` equals
+    `C.static_extent(0)`; and
+
+  * if neither `A.static_extent(1)` nor `C.static_extent(1)` equals
+    `dynamic_extent`, then `A.static_extent(1)` equals
+    `C.static_extent(1)`.
 
 ###### Overwriting Hermitian matrix-matrix product
 
@@ -5705,12 +5711,10 @@ void hermitian_matrix_right_product(
 * *Effects:*
 
   * `hermitian_matrix_left_product` assigns to the elements of the
-    matrix `C` the product of the matrices `A` and `B`, where the
-    matrix `A` is assumed to be Hermitian.
+    matrix `C` the product of the matrices `A` and `B`.
 
   * `hermitian_matrix_right_product` assigns to the elements of the
-    matrix `C` the product of the matrices `B` and `A`, where the
-    matrix `A` is assumed to be Hermitian.
+    matrix `C` the product of the matrices `B` and `A`.
 
 ###### Updating Hermitian matrix-matrix product
 
@@ -5782,13 +5786,11 @@ void hermitian_matrix_right_product(
 
   * `hermitian_matrix_left_product` assigns to the elements of the
     matrix `C` on output, the elementwise sum of `E` and the product
-    of the matrices `A` and `B`, where the matrix `A` is assumed to be
-    Hermitian.
+    of the matrices `A` and `B`.
 
   * `hermitian_matrix_right_product` assigns to the elements of the
     matrix `C` on output, the elementwise sum of `E` and the product
-    of the matrices `B` and `A`, where the matrix `A` is assumed to be
-    Hermitian.
+    of the matrices `B` and `A`.
 
 * *Remarks:* `C` and `E` may refer to the same matrix.  If so, then
   they must have the same layout.

--- a/D1673/blas_interface.md
+++ b/D1673/blas_interface.md
@@ -2091,46 +2091,96 @@ void hermitian_matrix_right_product(
 
 // [linalg.algs.blas3.trmm],
 // triangular matrix-matrix product
+
 template<class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
-         class Side,
          class in_matrix_2_t,
          class out_matrix_t>
-void triangular_matrix_product(
+void triangular_matrix_left_product(
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
-  Side s,
+  in_matrix_2_t B,
+  out_matrix_t C);
+template<class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void triangular_matrix_right_product(
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_matrix_2_t B,
+  out_matrix_t C);
+
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void triangular_matrix_left_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
   in_matrix_2_t B,
   out_matrix_t C);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
-         class Side,
          class in_matrix_2_t,
          class out_matrix_t>
-void triangular_matrix_product(
+void triangular_matrix_right_product(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
-  Side s,
   in_matrix_2_t B,
+  out_matrix_t C);
+
+template<class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void triangular_matrix_left_product(
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
   out_matrix_t C);
 template<class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
-         class Side,
          class in_matrix_2_t,
          class in_matrix_3_t,
          class out_matrix_t>
-void triangular_matrix_product(
+void triangular_matrix_right_product(
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
-  Side s,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void triangular_matrix_left_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
   in_matrix_2_t B,
   in_matrix_3_t E,
   out_matrix_t C);
@@ -2138,16 +2188,14 @@ template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
-         class Side,
          class in_matrix_2_t,
          class in_matrix_3_t,
          class out_matrix_t>
-void triangular_matrix_product(
+void triangular_matrix_right_product(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
-  Side s,
   in_matrix_2_t B,
   in_matrix_3_t E,
   out_matrix_t C);
@@ -2200,32 +2248,54 @@ void hermitian_matrix_rank_2k_update(
 
 // [linalg.alg.blas3.trsm],
 // solve multiple triangular linear systems
+
 template<class in_matrix_t,
          class Triangle,
          class DiagonalStorage,
-         class Side,
          class in_object_t,
          class out_object_t>
-void triangular_matrix_matrix_solve(
+void triangular_matrix_matrix_left_solve(
   in_matrix_t A,
   Triangle t,
   DiagonalStorage d,
-  Side s,
   in_object_t B,
   out_object_t X);
+template<class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_object_t,
+         class out_object_t>
+void triangular_matrix_matrix_right_solve(
+  in_matrix_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_object_t B,
+  out_object_t X);
+
 template<class ExecutionPolicy,
          class in_matrix_t,
          class Triangle,
          class DiagonalStorage,
-         class Side,
          class in_matrix_t,
          class out_matrix_t>
-void triangular_matrix_matrix_solve(
+void triangular_matrix_matrix_left_solve(
   ExecutionPolicy&& exec,
   in_matrix_t A,
   Triangle t,
   DiagonalStorage d,
-  Side s,
+  in_matrix_t B,
+  out_matrix_t X);
+template<class ExecutionPolicy,
+         class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_t,
+         class out_matrix_t>
+void triangular_matrix_matrix_right_solve(
+  ExecutionPolicy&& exec,
+  in_matrix_t A,
+  Triangle t,
+  DiagonalStorage d,
   in_matrix_t B,
   out_matrix_t X);
 ```
@@ -5810,22 +5880,6 @@ The following requirements apply to all functions in this section.
 
   * `C.extent(1)` equals `E.extent(1)` (if applicable).
 
-  * If `Side` is `left_side_t`, then
-
-     * `A.extent(1)` equals `B.extent(0)`,
-
-     * `A.extent(0)` equals `C.extent(0)`, and
-
-     * `B.extent(1)` equals `C.extent(1)`.
-
-  * Otherwise, if `Side` is `right_side_t`, then
-
-     * `B.extent(1)` equals `A.extent(0)`,
-
-     * `B.extent(0)` equals `C.extent(0)`, and
-
-     * `A.extent(1)` equals `C.extent(1)`.
-
 * *Constraints:*
 
   * `in_matrix_1_t` either has unique layout, or `layout_blas_packed`
@@ -5852,34 +5906,6 @@ The following requirements apply to all functions in this section.
     `dynamic_extent`, then `C.static_extent(r)` equals
     `E.static_extent(r)` (if applicable).
 
-  * If `Side` is `left_side_t`, then
-
-    * if neither `A.static_extent(1)` nor `B.static_extent(0)` equals
-      `dynamic_extent`, then `A.static_extent(1)` equals
-      `B.static_extent(0)`;
-
-    * if neither `A.static_extent(0)` nor `C.static_extent(0)` equals
-      `dynamic_extent`, then `A.static_extent(0)` equals
-      `C.static_extent(0)`; and
-
-    * if neither `B.static_extent(1)` nor `C.static_extent(1)` equals
-      `dynamic_extent`, then `B.static_extent(1)` equals
-      `C.static_extent(1)`.
-
-  * Otherwise, if `Side` is `right_side_t`, then
-
-    * if neither `B.static_extent(1)` nor `A.static_extent(0)` equals
-      `dynamic_extent`, then `B.static_extent(1)` equals
-      `A.static_extent(0)`;
-
-    * if neither `B.static_extent(0)` nor `C.static_extent(0)` equals
-      `dynamic_extent`, then `B.static_extent(0)` equals
-      `C.static_extent(0)`; and
-
-    * if neither `A.static_extent(1)` nor `C.static_extent(1)` equals
-      `dynamic_extent`, then `A.static_extent(1)` equals
-      `C.static_extent(1)`.
-
 * *Remarks:*
 
   * The functions will only access the triangle of `A` specified by
@@ -5892,20 +5918,79 @@ The following requirements apply to all functions in this section.
     function needs to be able to form an `element_type` value equal to
     one. --*end note]
 
+The following requirements apply to all overloads of
+`triangular_matrix_left_product`.
+
+* *Requires:*
+
+  * `A.extent(1)` equals `B.extent(0)`,
+
+  * `A.extent(0)` equals `C.extent(0)`, and
+
+  * `B.extent(1)` equals `C.extent(1)`.
+
+* *Mandates:*
+
+  * If neither `A.static_extent(1)` nor `B.static_extent(0)` equals
+    `dynamic_extent`, then `A.static_extent(1)` equals
+    `B.static_extent(0)`;
+
+  * if neither `A.static_extent(0)` nor `C.static_extent(0)` equals
+    `dynamic_extent`, then `A.static_extent(0)` equals
+    `C.static_extent(0)`; and
+
+  * if neither `B.static_extent(1)` nor `C.static_extent(1)` equals
+    `dynamic_extent`, then `B.static_extent(1)` equals
+    `C.static_extent(1)`.
+
+The following requirements apply to all overloads of
+`triangular_matrix_right_product`.
+
+* *Requires:*
+
+  * `B.extent(1)` equals `A.extent(0)`,
+
+  * `B.extent(0)` equals `C.extent(0)`, and
+
+  * `A.extent(1)` equals `C.extent(1)`.
+
+* *Mandates:*
+
+  * If neither `B.static_extent(1)` nor `A.static_extent(0)` equals
+    `dynamic_extent`, then `B.static_extent(1)` equals
+    `A.static_extent(0)`;
+
+  * if neither `B.static_extent(0)` nor `C.static_extent(0)` equals
+    `dynamic_extent`, then `B.static_extent(0)` equals
+    `C.static_extent(0)`; and
+
+  * if neither `A.static_extent(1)` nor `C.static_extent(1)` equals
+    `dynamic_extent`, then `A.static_extent(1)` equals
+    `C.static_extent(1)`.
+
 ###### Overwriting triangular matrix-matrix product
 
 ```c++
 template<class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
-         class Side,
          class in_matrix_2_t,
          class out_matrix_t>
-void triangular_matrix_product(
+void triangular_matrix_left_product(
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
-  Side s,
+  in_matrix_2_t B,
+  out_matrix_t C);
+template<class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void triangular_matrix_right_product(
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
   in_matrix_2_t B,
   out_matrix_t C);
 
@@ -5913,35 +5998,48 @@ template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
-         class Side,
          class in_matrix_2_t,
          class out_matrix_t>
-void triangular_matrix_product(
+void triangular_matrix_left_product(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
-  Side s,
+  in_matrix_2_t B,
+  out_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void triangular_matrix_right_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
   in_matrix_2_t B,
   out_matrix_t C);
 ```
 
 * *Constraints:*
 
-  * If `Side` is `left_side_t`, then for `i,j` in the domain of `C`,
+  * For `triangular_matrix_left_product`,
+    for `i,j` in the domain of `C`,
     `i,k` in the domain of `A`, and `k,j` in the domain of `B`, the
     expression `C(i,j) += A(i,k)*B(k,j)` is well formed.
 
-  * If `Side` is `right_side_t`, then for `i,j` in the domain of `C`,
+  * For `triangular_matrix_left_product`,
+    for `i,j` in the domain of `C`,
     `i,k` in the domain of `B`, and `k,j` in the domain of `A`, the
     expression `C(i,j) += B(i,k)*A(k,j)` is well formed.
 
 * *Effects:*
 
-  * If `Side` is `left_side_t`, then assigns to the elements of the
+  * `triangular_matrix_left_product` assigns to the elements of the
     matrix `C` the product of the matrices `A` and `B`.
 
-  * If `Side` is `right_side_t`, then assigns to the elements of the
+  * `triangular_matrix_right_product` assigns to the elements of the
     matrix `C` the product of the matrices `B` and `A`.
 
 ###### Updating triangular matrix-matrix product
@@ -5950,15 +6048,26 @@ void triangular_matrix_product(
 template<class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
-         class Side,
          class in_matrix_2_t,
          class in_matrix_3_t,
          class out_matrix_t>
-void triangular_matrix_product(
+void triangular_matrix_left_product(
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
-  Side s,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+template<class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void triangular_matrix_right_product(
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
   in_matrix_2_t B,
   in_matrix_3_t E,
   out_matrix_t C);
@@ -5967,16 +6076,29 @@ template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
-         class Side,
          class in_matrix_2_t,
          class in_matrix_3_t,
          class out_matrix_t>
-void triangular_matrix_product(
+void triangular_matrix_left_product(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
-  Side s,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void triangular_matrix_right_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
   in_matrix_2_t B,
   in_matrix_3_t E,
   out_matrix_t C);
@@ -5984,21 +6106,23 @@ void triangular_matrix_product(
 
 * *Constraints:*
 
-  * If `Side` is `left_side_t`, then for `i,j` in the domain of `C`,
+  * For `triangular_matrix_left_product`,
+    for `i,j` in the domain of `C`,
     `i,k` in the domain of `A`, and `k,j` in the domain of `B`, the
     expression `C(i,j) += E(i,j) + A(i,k)*B(k,j)` is well formed.
 
-  * If `Side` is `right_side_t`, then for `i,j` in the domain of `C`,
+  * For `triangular_matrix_right_product`,
+    for `i,j` in the domain of `C`,
     `i,k` in the domain of `B`, and `k,j` in the domain of `A`, the
     expression `C(i,j) += E(i,j) + B(i,k)*A(k,j)` is well formed.
 
 * *Effects:*
 
-  * If `Side` is `left_side_t`, then assigns to the elements of the
+  * `triangular_matrix_left_product` assigns to the elements of the
     matrix `C` on output, the elementwise sum of `E` and the product of
     the matrices `A` and `B`.
 
-  * If `Side` is `right_side_t`, then assigns to the elements of the
+  * `triangular_matrix_right_product` assigns to the elements of the
     matrix `C` on output, the elementwise sum of `E` and the product of
     the matrices `B` and `A`.
 
@@ -6170,14 +6294,23 @@ void hermitian_matrix_rank_2k_update(
 template<class in_matrix_t,
          class Triangle,
          class DiagonalStorage,
-         class Side,
          class in_object_t,
          class out_object_t>
-void triangular_matrix_matrix_solve(
+void triangular_matrix_matrix_left_solve(
   in_matrix_t A,
   Triangle t,
   DiagonalStorage d,
-  Side s,
+  in_object_t B,
+  out_object_t X);
+template<class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_object_t,
+         class out_object_t>
+void triangular_matrix_matrix_right_solve(
+  in_matrix_t A,
+  Triangle t,
+  DiagonalStorage d,
   in_object_t B,
   out_object_t X);
 
@@ -6185,15 +6318,26 @@ template<class ExecutionPolicy,
          class in_matrix_t,
          class Triangle,
          class DiagonalStorage,
-         class Side,
          class in_matrix_t,
          class out_matrix_t>
-void triangular_matrix_matrix_solve(
+void triangular_matrix_matrix_left_solve(
   ExecutionPolicy&& exec,
   in_matrix_t A,
   Triangle t,
   DiagonalStorage d,
-  Side s,
+  in_matrix_t B,
+  out_matrix_t X);
+template<class ExecutionPolicy,
+         class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_t,
+         class out_matrix_t>
+void triangular_matrix_matrix_right_solve(
+  ExecutionPolicy&& exec,
+  in_matrix_t A,
+  Triangle t,
+  DiagonalStorage d,
   in_matrix_t B,
   out_matrix_t X);
 ```
@@ -6208,10 +6352,10 @@ Reference BLAS does not have a `xTPSM` function. --*end note]*
 
   * `A.extent(0)` equals `A.extent(1)`.
 
-  * If `Side` is `left_side_t`, then
+  * For `triangular_matrix_matrix_left_solve`,
     `A.extent(1)` equals `B.extent(0)`.
 
-  * Otherwise, if `Side` is `right_side_t`, then
+  * For `triangular_matrix_matrix_right_solve`,
     `A.extent(1)` equals `B.extent(1)`.
 
 * *Constraints:*
@@ -6226,13 +6370,13 @@ Reference BLAS does not have a `xTPSM` function. --*end note]*
   * If `r,j` is in the domain of `X` and `B`, then the expression
     `X(r,j) = B(r,j)` is well formed.
 
-  * If `Side` is `left_side_t`, and if `i,j` and `i,k` are in the
-    domain of `X`, then the expression `X(i,j) -= A(i,k) * X(k,j)` is
-    well formed.
+  * For `triangular_matrix_matrix_left_solve`,
+    if `i,j` and `i,k` are in the domain of `X`, then
+    the expression `X(i,j) -= A(i,k) * X(k,j)` is well formed.
 
-  * If `Side` is `right_side_t`, and if `i,j` and `i,k` are in the
-    domain of `X`, then the expression `X(i,j) -= X(i,k) * A(k,j)` is
-    well formed.
+  * For `triangular_matrix_matrix_right_solve`,
+    if `i,j` and `i,k` are in the domain of `X`, then
+    the expression `X(i,j) -= X(i,k) * A(k,j)` is well formed.
 
   * If `DiagonalStorage` is `explicit_diagonal_t`, and `i,j` is in the
     domain of `X`, then the expression `X(i,j) /= A(i,i)` is well
@@ -6249,21 +6393,22 @@ Reference BLAS does not have a `xTPSM` function. --*end note]*
     `dynamic_extent`, then `A.static_extent(0)` equals
     `A.static_extent(1)`.
 
-  * If `Side` is `left_side_t`, then if neither `A.static_extent(1)`
-    nor `B.static_extent(0)` equals `dynamic_extent`, then
+  * For `triangular_matrix_matrix_left_solve`,
+    if neither `A.static_extent(1)` nor `B.static_extent(0)`
+    equals `dynamic_extent`, then
     `A.static_extent(1)` equals `B.static_extent(0)`.
 
-  * Otherwise, if `Side` is `right_side_t`, then if neither
-    `A.static_extent(1)` nor `B.static_extent(1)` equals
-    `dynamic_extent`, then `A.static_extent(1)` equals
-    `B.static_extent(1)`.
+  * For `triangular_matrix_matrix_right_solve`,
+    if neither `A.static_extent(1)` nor `B.static_extent(1)`
+    equals `dynamic_extent`, then
+    `A.static_extent(1)` equals `B.static_extent(1)`.
 
 * *Effects:*
 
-  * If `Side` is `left_side_t`, then assigns to the elements of `X`
+  * `triangular_matrix_matrix_left_solve` assigns to the elements of `X`
     the result of solving the triangular linear system(s) AX=B for X.
 
-  * If `Side` is `right_side_t`, then assigns to the elements of `X`
+  * `triangular_matrix_matrix_right_solve` assigns to the elements of `X`
     the result of solving the triangular linear system(s) XA=B for X.
 
 * *Remarks:*

--- a/D1673/blas_interface.md
+++ b/D1673/blas_interface.md
@@ -3256,6 +3256,8 @@ where
   * else, equivalent to
     `return R(a.data(), a.mapping(), a.accessor());`.
 
+* *Remarks:* The elements of the returned `basic_mdspan` are read only.
+
 *[Note:*
 
 The point of `ReturnAccessor` is to give implementations freedom to

--- a/D1673/blas_interface.md
+++ b/D1673/blas_interface.md
@@ -1272,46 +1272,9 @@ template<class ElementType,
          class Extents,
          class Layout,
          class Accessor>
-basic_mdspan<ElementType, Extents,
-             layout_transpose<Layout>,
-             accessor_conjugate<Accessor>>
+/* see-below */
 conjugate_transpose_view(
-  basic_mdspan<ElementType, Extents,
-               Layout,
-               Accessor> a);
-template<class ElementType,
-         class Extents,
-         class Layout,
-         class Accessor>
-basic_mdspan<ElementType, Extents,
-             Layout,
-             accessor_conjugate<Accessor>>
-conjugate_transpose_view(
-  basic_mdspan<ElementType, Extents,
-               layout_transpose<Layout>,
-               Accessor> a);
-template<class ElementType,
-         class Extents,
-         class Layout,
-         class Accessor>
-basic_mdspan<ElementType, Extents,
-             layout_transpose<Layout>,
-             Accessor>
-conjugate_transpose_view(
-  basic_mdspan<ElementType, Extents,
-               Layout,
-               accessor_conjugate<Accessor>> a);
-template<class ElementType,
-         class Extents,
-         class Layout,
-         class Accessor>
-basic_mdspan<ElementType, Extents,
-             Layout,
-             Accessor>
-conjugate_transpose_view(
-  basic_mdspan<ElementType, Extents,
-               layout_transpose<Layout>,
-               accessor_conjugate<Accessor>> a);
+  basic_mdspan<ElementType, Extents, Layout, Accessor> a);
 
 // [linalg.algs.blas1.givens.lartg], compute Givens rotation
 template<class Real>
@@ -3639,49 +3602,9 @@ template<class ElementType,
          class Extents,
          class Layout,
          class Accessor>
-basic_mdspan<ElementType, Extents,
-             layout_transpose<Layout>,
-             accessor_conjugate<Accessor>>
+/* see-below */
 conjugate_transpose_view(
-  basic_mdspan<ElementType, Extents,
-               Layout,
-               Accessor> a);
-
-template<class ElementType,
-         class Extents,
-         class Layout,
-         class Accessor>
-basic_mdspan<ElementType, Extents,
-             Layout,
-             accessor_conjugate<Accessor>>
-conjugate_transpose_view(
-  basic_mdspan<ElementType, Extents,
-               layout_transpose<Layout>,
-               Accessor> a);
-
-template<class ElementType,
-         class Extents,
-         class Layout,
-         class Accessor>
-basic_mdspan<ElementType, Extents,
-             layout_transpose<Layout>,
-             Accessor>
-conjugate_transpose_view(
-  basic_mdspan<ElementType, Extents,
-               Layout,
-               accessor_conjugate<Accessor>> a);
-
-template<class ElementType,
-         class Extents,
-         class Layout,
-         class Accessor>
-basic_mdspan<ElementType, Extents,
-             Layout,
-             Accessor>
-conjugate_transpose_view(
-  basic_mdspan<ElementType, Extents,
-               layout_transpose<Layout>,
-               accessor_conjugate<Accessor>> a);
+  basic_mdspan<ElementType, Extents, Layout, Accessor> a);
 ```
 
 * *Effects:* Equivalent to

--- a/D1673/blas_interface.md
+++ b/D1673/blas_interface.md
@@ -1709,7 +1709,7 @@ void triangular_matrix_vector_product(ExecutionPolicy&& exec,
                                       in_vector_2_t y,
                                       out_vector_t z);
 
-// [linalg.algs.blas2.tri-solve],
+// [linalg.algs.blas2.trsv],
 // Solve a triangular linear system
 template<class in_matrix_t,
          class Triangle,
@@ -1736,7 +1736,7 @@ void triangular_matrix_vector_solve(
   in_vector_t b,
   out_vector_t x);
 
-// [linalg.algs.blas2.rank1.nonconj],
+// [linalg.algs.blas2.rank1.geru],
 // nonconjugated rank-1 matrix update
 template<class in_vector_1_t,
          class in_vector_2_t,
@@ -1755,7 +1755,7 @@ void matrix_rank_1_update(
   in_vector_2_t y,
   inout_matrix_t A);
 
-// [linalg.algs.blas2.rank1.conj],
+// [linalg.algs.blas2.rank1.gerc],
 // conjugated rank-1 matrix update
 template<class in_vector_1_t,
          class in_vector_2_t,
@@ -1774,7 +1774,7 @@ void matrix_rank_1_update_c(
   in_vector_2_t y,
   inout_matrix_t A);
 
-// [linalg.algs.blas2.rank1.symm],
+// [linalg.algs.blas2.rank1.syr],
 // symmetric rank-1 matrix update
 template<class in_vector_t,
          class inout_matrix_t,
@@ -1793,7 +1793,7 @@ void symmetric_matrix_rank_1_update(
   inout_matrix_t A,
   Triangle t);
 
-// [linalg.algs.blas2.rank1.herm],
+// [linalg.algs.blas2.rank1.her],
 // Hermitian rank-1 matrix update
 template<class in_vector_t,
          class inout_matrix_t,
@@ -1812,7 +1812,7 @@ void hermitian_matrix_rank_1_update(
   inout_matrix_t A,
   Triangle t);
 
-// [linalg.algs.blas2.rank2.symm],
+// [linalg.algs.blas2.rank2.syr2],
 // symmetric rank-2 matrix update
 template<class in_vector_1_t,
          class in_vector_2_t,
@@ -1835,7 +1835,7 @@ void symmetric_matrix_rank_2_update(
   inout_matrix_t A,
   Triangle t);
 
-// [linalg.algs.blas2.rank2.herm],
+// [linalg.algs.blas2.rank2.her2],
 // Hermitian rank-2 matrix update
 template<class in_vector_1_t,
          class in_vector_2_t,
@@ -4850,7 +4850,7 @@ void triangular_matrix_vector_product(ExecutionPolicy&& exec,
 * *Effects:* Assigns to the elements of `z` the elementwise sum of
   `y`, with the product of the matrix `A` with the vector `x`.
 
-##### Solve a triangular linear system [linalg.algs.blas2.tri-solve]
+##### Solve a triangular linear system [linalg.algs.blas2.trsv]
 
 ```c++
 template<class in_matrix_t,
@@ -4945,7 +4945,7 @@ void triangular_matrix_vector_solve(
 
 ##### Rank-1 (outer product) update of a matrix [linalg.algs.blas2.rank1]
 
-###### Nonsymmetric non-conjugated rank-1 update [linalg.algs.blas2.rank1.nonconj]
+###### Nonsymmetric non-conjugated rank-1 update [linalg.algs.blas2.rank1.geru]
 
 ```c++
 template<class in_vector_1_t,
@@ -4968,8 +4968,8 @@ void matrix_rank_1_update(
 ```
 
 *[Note:* This function corresponds to the BLAS functions `xGER` (for
-real element types), `xGERC`, and `xGERU` (for complex element
-types). --*end note]*
+real element types) and `xGERU` (for complex element types). --*end
+note]*
 
 * *Requires:*
 
@@ -5001,7 +5001,7 @@ types). --*end note]*
 as a `conjugate_view`.  Alternately, they can use the shortcut
 `matrix_rank_1_update_c` below. --*end note]*
 
-###### Nonsymmetric conjugated rank-1 update [linalg.algs.blas2.rank1.conj]
+###### Nonsymmetric conjugated rank-1 update [linalg.algs.blas2.rank1.gerc]
 
 ```c++
 template<class in_vector_1_t,
@@ -5023,10 +5023,14 @@ void matrix_rank_1_update_c(
   inout_matrix_t A);
 ```
 
+*[Note:* This function corresponds to the BLAS functions `xGER` (for
+real element types) and `xGERC` (for complex element types). --*end
+note]*
+
 * *Effects:* Equivalent to
   `matrix_rank_1_update(x, conjugate_view(y), A);`.
 
-###### Rank-1 update of a Symmetric matrix [linalg.algs.blas2.rank1.symm]
+###### Rank-1 update of a Symmetric matrix [linalg.algs.blas2.rank1.syr]
 
 ```c++
 template<class in_vector_t,
@@ -5087,7 +5091,7 @@ void symmetric_matrix_rank_1_update(
   specified by the `Triangle` argument `t`, and will assume for
   indices `i,j` outside that triangle, that `A(j,i)` equals `A(i,j)`.
 
-###### Rank-1 update of a Hermitian matrix [linalg.algs.blas2.rank1.herm]
+###### Rank-1 update of a Hermitian matrix [linalg.algs.blas2.rank1.her]
 
 ```c++
 template<class in_vector_t,
@@ -5149,7 +5153,7 @@ void hermitian_matrix_rank_1_update(
   indices `i,j` outside that triangle, that `A(j,i)` equals
   `conj(A(i,j))`.
 
-##### Rank-2 update of a symmetric matrix [linalg.algs.blas2.rank2.symm]
+##### Rank-2 update of a symmetric matrix [linalg.algs.blas2.rank2.syr2]
 
 ```c++
 template<class in_vector_1_t,
@@ -5221,7 +5225,7 @@ void symmetric_matrix_rank_2_update(
   specified by the `Triangle` argument `t`, and will assume for
   indices `i,j` outside that triangle, that `A(j,i)` equals `A(i,j)`.
 
-##### Rank-2 update of a Hermitian matrix [linalg.algs.blas2.rank2.herm]
+##### Rank-2 update of a Hermitian matrix [linalg.algs.blas2.rank2.her2]
 
 ```c++
 template<class in_vector_1_t,

--- a/D1673/blas_interface.md
+++ b/D1673/blas_interface.md
@@ -1896,6 +1896,8 @@ void matrix_product(ExecutionPolicy&& exec,
 // [linalg.algs.blas3.symm],
 // symmetric matrix-matrix product
 
+// [linalg.algs.blas3.symm.ov.left],
+// overwriting symmetric matrix-matrix left product
 template<class in_matrix_1_t,
          class Triangle,
          class in_matrix_2_t,
@@ -1905,16 +1907,6 @@ void symmetric_matrix_left_product(
   Triangle t,
   in_matrix_2_t B,
   out_matrix_t C);
-template<class in_matrix_1_t,
-         class Triangle,
-         class in_matrix_2_t,
-         class out_matrix_t>
-void symmetric_matrix_right_product(
-  in_matrix_1_t A,
-  Triangle t,
-  in_matrix_2_t B,
-  out_matrix_t C);
-
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
@@ -1926,6 +1918,18 @@ void symmetric_matrix_left_product(
   Triangle t,
   in_matrix_2_t B,
   out_matrix_t C);
+
+// [linalg.algs.blas3.symm.ov.right],
+// overwriting symmetric matrix-matrix right product
+template<class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void symmetric_matrix_right_product(
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  out_matrix_t C);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
@@ -1938,6 +1942,8 @@ void symmetric_matrix_right_product(
   in_matrix_2_t B,
   out_matrix_t C);
 
+// [linalg.algs.blas3.symm.up.left],
+// updating symmetric matrix-matrix left product
 template<class in_matrix_1_t,
          class Triangle,
          class in_matrix_2_t,
@@ -1949,18 +1955,6 @@ void symmetric_matrix_left_product(
   in_matrix_2_t B,
   in_matrix_3_t E,
   out_matrix_t C);
-template<class in_matrix_1_t,
-         class Triangle,
-         class in_matrix_2_t,
-         class in_matrix_3_t,
-         class out_matrix_t>
-void symmetric_matrix_right_product(
-  in_matrix_1_t A,
-  Triangle t,
-  in_matrix_2_t B,
-  in_matrix_3_t E,
-  out_matrix_t C);
-
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
@@ -1969,6 +1963,20 @@ template<class ExecutionPolicy,
          class out_matrix_t>
 void symmetric_matrix_left_product(
   ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+
+// [linalg.algs.blas3.symm.up.right],
+// updating symmetric matrix-matrix right product
+template<class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void symmetric_matrix_right_product(
   in_matrix_1_t A,
   Triangle t,
   in_matrix_2_t B,
@@ -5376,10 +5384,14 @@ void matrix_product(ExecutionPolicy&& exec,
 
 ##### Symmetric matrix-matrix product [linalg.algs.blas3.symm]
 
-*[Note:* These functions correspond to the BLAS function `xSYMM`.
+*[Note:*
+
+These functions correspond to the BLAS function `xSYMM`.
+
 Unlike the symmetric rank-1 update functions, these functions assume
-that the input matrix -- not the output matrix -- is symmetric. --*end
-note]*
+that the input matrix -- not the output matrix -- is symmetric.
+
+--*end note]*
 
 The following requirements apply to all functions in this section.
 
@@ -5417,9 +5429,14 @@ The following requirements apply to all functions in this section.
     `dynamic_extent`, then `C.static_extent(r)` equals
     `E.static_extent(r)` (if applicable).
 
-* *Remarks:* The functions will only access the triangle of `A`
-  specified by the `Triangle` argument `t`, and will assume for
-  indices `i,j` outside that triangle, that `A(j,i)` equals `A(i,j)`.
+* *Remarks:*
+
+  * The functions will only access the triangle of `A` specified by
+    the `Triangle` argument `t`, and will assume for indices `i,j`
+    outside that triangle, that `A(j,i)` equals `A(i,j)`.
+
+  * *Remarks:* `C` and `E` (if applicable) may refer to the same
+    matrix.  If so, then they must have the same layout.
 
 The following requirements apply to all overloads of
 `symmetric_matrix_left_product`.
@@ -5471,7 +5488,7 @@ The following requirements apply to all overloads of
     `dynamic_extent`, then `A.static_extent(1)` equals
     `C.static_extent(1)`.
 
-###### Overwriting symmetric matrix-matrix product
+###### Overwriting symmetric matrix-matrix left product [linalg.algs.blas3.symm.ov.left]
 
 ```c++
 template<class in_matrix_1_t,
@@ -5483,16 +5500,6 @@ void symmetric_matrix_left_product(
   Triangle t,
   in_matrix_2_t B,
   out_matrix_t C);
-template<class in_matrix_1_t,
-         class Triangle,
-         class in_matrix_2_t,
-         class out_matrix_t>
-void symmetric_matrix_right_product(
-  in_matrix_1_t A,
-  Triangle t,
-  in_matrix_2_t B,
-  out_matrix_t C);
-
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
@@ -5500,6 +5507,28 @@ template<class ExecutionPolicy,
          class out_matrix_t>
 void symmetric_matrix_left_product(
   ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  out_matrix_t C);
+```
+
+* *Constraints:* For `i,j` in the domain of `C`,
+  `i,k` in the domain of `A`, and
+  `k,j` in the domain of `B`,
+  the expression `C(i,j) += A(i,k)*B(k,j)` is well formed.
+
+* *Effects:* Assigns to the elements of the matrix `C`
+  the product of the matrices `A` and `B`.
+
+###### Overwriting symmetric matrix-matrix right product [linalg.algs.blas3.symm.ov.right]
+
+```c++
+template<class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void symmetric_matrix_right_product(
   in_matrix_1_t A,
   Triangle t,
   in_matrix_2_t B,
@@ -5517,27 +5546,15 @@ void symmetric_matrix_right_product(
   out_matrix_t C);
 ```
 
-* *Constraints:*
+* *Constraints:* For `i,j` in the domain of `C`,
+  `i,k` in the domain of `B`, and
+  `k,j` in the domain of `A`,
+  the expression `C(i,j) += B(i,k)*A(k,j)` is well formed.
 
-  * For `symmetric_matrix_left_product`,
-    for `i,j` in the domain of `C`,
-    `i,k` in the domain of `A`, and `k,j` in the domain of `B`, the
-    expression `C(i,j) += A(i,k)*B(k,j)` is well formed.
+* *Effects:* Assigns to the elements of the matrix `C`
+  the product of the matrices `B` and `A`.
 
-  * For `symmetric_matrix_right_product`,
-    for for `i,j` in the domain of `C`,
-    `i,k` in the domain of `B`, and `k,j` in the domain of `A`, the
-    expression `C(i,j) += B(i,k)*A(k,j)` is well formed.
-
-* *Effects:*
-
-  * `symmetric_matrix_left_product` assigns to the elements of the
-    matrix `C` the product of the matrices `A` and `B`.
-
-  * `symmetric_matrix_right_product` assigns to the elements of the
-    matrix `C` the product of the matrices `B` and `A`.
-
-###### Updating symmetric matrix-matrix product
+###### Updating symmetric matrix-matrix left product [linalg.algs.blas3.symm.up.left]
 
 ```c++
 template<class in_matrix_1_t,
@@ -5551,18 +5568,6 @@ void symmetric_matrix_left_product(
   in_matrix_2_t B,
   in_matrix_3_t E,
   out_matrix_t C);
-template<class in_matrix_1_t,
-         class Triangle,
-         class in_matrix_2_t,
-         class in_matrix_3_t,
-         class out_matrix_t>
-void symmetric_matrix_right_product(
-  in_matrix_1_t A,
-  Triangle t,
-  in_matrix_2_t B,
-  in_matrix_3_t E,
-  out_matrix_t C);
-
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
@@ -5571,6 +5576,30 @@ template<class ExecutionPolicy,
          class out_matrix_t>
 void symmetric_matrix_left_product(
   ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+```
+
+* *Constraints:* For `i,j` in the domain of `C`,
+  `i,k` in the domain of `A`, and
+  `k,j` in the domain of `B`,
+  the expression `C(i,j) += E(i,j) + A(i,k)*B(k,j)` is well formed.
+
+* *Effects:* assigns to the elements of the matrix `C` on output, the
+  elementwise sum of `E` and the product of the matrices `A` and `B`.
+
+###### Updating symmetric matrix-matrix right product [linalg.algs.blas3.symm.up.right]
+
+```c++
+template<class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void symmetric_matrix_right_product(
   in_matrix_1_t A,
   Triangle t,
   in_matrix_2_t B,
@@ -5591,30 +5620,13 @@ void symmetric_matrix_right_product(
   out_matrix_t C);
 ```
 
-* *Constraints:*
+* *Constraints:* For `i,j` in the domain of `C`,
+  `i,k` in the domain of `B`, and
+  `k,j` in the domain of `A`,
+  the expression `C(i,j) += E(i,j) + B(i,k)*A(k,j)` is well formed.
 
-  * For `symmetric_matrix_left_product`,
-    for `i,j` in the domain of `C`,
-    `i,k` in the domain of `A`, and `k,j` in the domain of `B`, the
-    expression `C(i,j) += E(i,j) + A(i,k)*B(k,j)` is well formed.
-
-  * For `symmetric_matrix_right_product`,
-    for `i,j` in the domain of `C`,
-    `i,k` in the domain of `B`, and `k,j` in the domain of `A`, the
-    expression `C(i,j) += E(i,j) + B(i,k)*A(k,j)` is well formed.
-
-* *Effects:*
-
-  * `symmetric_matrix_left_product` assigns to the elements of the
-    matrix `C` on output, the elementwise sum of `E` and the product
-    of the matrices `A` and `B`.
-
-  * `symmetric_matrix_right_product` assigns to the elements of the
-    matrix `C` on output, the elementwise sum of `E` and the product
-    of the matrices `B` and `A`.
-
-* *Remarks:* `C` and `E` may refer to the same matrix.  If so, then
-  they must have the same layout.
+* *Effects:* assigns to the elements of the matrix `C` on output, the
+  elementwise sum of `E` and the product of the matrices `B` and `A`.
 
 ##### Hermitian matrix-matrix product [linalg.algs.blas3.hemm]
 

--- a/D1673/blas_interface.md
+++ b/D1673/blas_interface.md
@@ -4094,6 +4094,12 @@ void linalg_add(ExecutionPolicy&& exec,
 
 ###### Nonconjugated dot product of two vectors [linalg.algs.blas1.dot.dotu]
 
+*[Note:* The functions in this section correspond to the BLAS
+functions `xDOT` (for real element types) and `xDOTU` (for complex
+element types).  --*end note]*
+
+Nonconjugated dot product with specified result type
+
 ```c++
 template<class in_vector_1_t,
          class in_vector_2_t,
@@ -4110,10 +4116,6 @@ T dot(ExecutionPolicy&& exec,
       in_vector_2_t v2,
       T init);
 ```
-
-*[Note:* These functions correspond to the BLAS functions `xDOT` (for
-real element types) and `xDOTU` (for complex element types).
---*end note]*
 
 * *Requires:*
 
@@ -4152,7 +4154,7 @@ for specific `ExecutionPolicy` types. --*end note]*
 as a `conjugate_view`.  Alternately, they can use the shortcut `dotc`
 below. --*end note]*
 
-###### Nonconjugated dot product with default result type
+Nonconjugated dot product with default result type
 
 ```c++
 template<class in_vector_1_t,
@@ -4173,6 +4175,18 @@ auto dot(ExecutionPolicy&& exec,
 
 ###### Conjugated dot product of two vectors [linalg.algs.blas1.dot.dotc]
 
+*[Note:*
+
+The functions in this section correspond to the BLAS functions `xDOT`
+(for real element types) and `xDOTC` (for complex element types).
+
+`dotc` exists to give users reasonable default inner product behavior
+for both real and complex element types.
+
+--*end note]*
+
+Conjugated dot product with specified result type
+
 ```c++
 template<class in_vector_1_t,
          class in_vector_2_t,
@@ -4190,22 +4204,12 @@ T dotc(ExecutionPolicy&& exec,
        T init);
 ```
 
-*[Note:*
-
-These functions correspond to the BLAS functions `xDOT` (for real
-element types) and `xDOTC` (for complex element types).
-
-`dotc` exists to give users reasonable default inner product behavior
-for both real and complex element types.
-
---*end note]*
-
 * *Effects:* The three-argument overload is equivalent to
   `dot(v1, conjugate_view(v2), init);`.
   The four-argument overload is equivalent to
   `dot(exec, v1, conjugate_view(v2), init);`.
 
-###### Conjugated dot product with default result type
+Conjugated dot product with default result type
 
 ```c++
 template<class in_vector_1_t,

--- a/D1673/blas_interface.md
+++ b/D1673/blas_interface.md
@@ -1262,17 +1262,9 @@ template<class ElementType,
          class Extents,
          class Layout,
          class Accessor>
-basic_mdspan<ElementType, transpose_extents_t<Extents>,
-             layout_transpose<Layout>, Accessor>
+/* see-below */
 transpose_view(
   basic_mdspan<ElementType, Extents, Layout, Accessor> a);
-template<class EltType,
-         class Extents,
-         class Layout,
-         class Accessor>
-basic_mdspan<EltType, Extents, Layout, Accessor>
-transpose_view(basic_mdspan<EltType, Extents,
-               layout_transpose<Layout>, Accessor> a);
 
 // [linalg.conj_transp],
 // conjugated transposed in-place transformation
@@ -3243,7 +3235,10 @@ where
        for some `NestedAccessor`, then
        either `NestedAccessor` or `accessor_conjugate<Accessor>`,
 
-     * else `Accessor`.
+     * else if `ElementType` is `complex<U>` or `const complex<U>` for
+       some `U`, then `accessor_conjugate<Accessor>`,
+
+     * else either `accessor_conjugate<Accessor>` or `Accessor`.
 
 * *Effects:*
 
@@ -3565,44 +3560,37 @@ template<class ElementType,
          class Extents,
          class Layout,
          class Accessor>
-basic_mdspan<ElementType, transpose_extents_t<Extents>,
-             layout_transpose<Layout>, Accessor>
+/* see-below */
 transpose_view(
   basic_mdspan<ElementType, Extents, Layout, Accessor> a);
 ```
 
-* *Effects:* Equivalent to
+Let `ReturnExtents` name the type `transpose_extents_t<Extents>`.
+Let `R` name the type
+`basic_mdspan<ReturnElementType, ReturnExtents, ReturnLayout, Accessor>`,
+where
 
-```c++
-return basic_mdspan<ElementType,
-                    transpose_extents_t<Extents>,
-                    layout_transpose<Layout>,
-                    Accessor>(
-  a.data(),
-  typename layout_transpose<Layout>::
-    template mapping<transpose_extents_t<Extents>>(
-      a.mapping());
-  a.accessor());
-```
+  * `ReturnElementType` is either `ElementType` or
+    `const ElementType`; and
 
-* *Remarks:* The elements of the returned `basic_mdspan` are read only.
+  * `ReturnLayout` is:
 
-```c++
-template<class EltType,
-         class Extents,
-         class Layout,
-         class Accessor>
-basic_mdspan<EltType, Extents, Layout, Accessor>
-transpose_view(basic_mdspan<EltType, Extents,
-               layout_transpose<Layout>, Accessor> a);
-```
+     * if `Layout` is `layout_transpose<NestedLayout>`
+       for some `NestedLayout`, then
+       either `NestedLayout` or `layout_transpose<Layout>`,
 
-* *Effects:* Equivalent to
+     * else `layout_transpose<Layout>`.
 
-```c++
-return basic_mdspan<EltType, Extents, Layout, Accessor>(a.data(),
-  a.mapping().nested_mapping(), a.accessor());
-```
+* *Effects:*
+
+  * If `Layout` is `layout_transpose<NestedLayout>` and
+    `ReturnLayout` is `NestedLayout`, then equivalent to
+    `return R(a.data(), a.mapping().nested_mapping(), a.accessor());`;
+
+  * else, equivalent to
+    `return R(a.data(), ReturnMapping(a.mapping()), a.accessor);`,
+    where `ReturnMapping` names the type
+    `typename layout_transpose<Layout>::template mapping<ReturnExtents>`.
 
 * *Remarks:* The elements of the returned `basic_mdspan` are read only.
 

--- a/D1673/blas_interface.md
+++ b/D1673/blas_interface.md
@@ -1531,7 +1531,7 @@ template<class ExecutionPolicy,
 ptrdiff_t idx_abs_max(ExecutionPolicy&& exec,
                       in_vector_t v);
 
-// [linalg.algs.blas2.general-matvec],
+// [linalg.algs.blas2.gemv],
 // general matrix-vector product
 template<class in_vector_t,
          class in_matrix_t,
@@ -1566,7 +1566,7 @@ void matrix_vector_product(ExecutionPolicy&& exec,
                            in_vector_2_t y,
                            out_vector_t z);
 
-// [linalg.algs.blas2.symm-matvec],
+// [linalg.algs.blas2.symv],
 // symmetric matrix-vector product
 template<class in_matrix_t,
          class Triangle,
@@ -1612,7 +1612,7 @@ void symmetric_matrix_vector_product(
   in_vector_2_t y,
   out_vector_t z);
 
-// [linalg.algs.blas2.herm-matvec],
+// [linalg.algs.blas2.hemv],
 // Hermitian matrix-vector product
 template<class in_matrix_t,
          class Triangle,
@@ -1656,7 +1656,7 @@ void hermitian_matrix_vector_product(ExecutionPolicy&& exec,
                                      in_vector_2_t y,
                                      out_vector_t z);
 
-// [linalg.algs.blas2.tri-matvec],
+// [linalg.algs.blas2.trmv],
 // Triangular matrix-vector product
 template<class in_matrix_t,
          class Triangle,
@@ -4358,7 +4358,7 @@ ptrdiff_t idx_abs_max(ExecutionPolicy&& exec,
 
 #### BLAS 2 functions [linalg.algs.blas2]
 
-##### General matrix-vector product [linalg.algs.blas2.general-matvec]
+##### General matrix-vector product [linalg.algs.blas2.gemv]
 
 *[Note:* These functions correspond to the BLAS function
 `xGEMV`. --*end note]*
@@ -4482,7 +4482,7 @@ void matrix_vector_product(ExecutionPolicy&& exec,
 * *Effects:* Assigns to the elements of `z` the elementwise sum of
   `y`, and the product of the matrix `A` with the vector `x`.
 
-##### Symmetric matrix-vector product [linalg.algs.blas2.symm-matvec],
+##### Symmetric matrix-vector product [linalg.algs.blas2.symv]
 
 *[Note:* These functions correspond to the BLAS functions `xSYMV` and
 `xSPMV`. --*end note]*
@@ -4599,7 +4599,7 @@ void symmetric_matrix_vector_product(
 * *Effects:* Assigns to the elements of `z` the elementwise sum of
   `y`, with the product of the matrix `A` with the vector `x`.
 
-##### Hermitian matrix-vector product [linalg.algs.blas2.herm-matvec],
+##### Hermitian matrix-vector product [linalg.algs.blas2.hemv]
 
 *[Note:* These functions correspond to the BLAS functions `xHEMV` and
 `xHPMV`. --*end note]*
@@ -4717,7 +4717,7 @@ void hermitian_matrix_vector_product(ExecutionPolicy&& exec,
 * *Effects:* Assigns to the elements of `z` the elementwise sum of
   `y`, and the product of the matrix `A` with the vector `x`.
 
-##### Triangular matrix-vector product [linalg.algs.blas2.tri-matvec]
+##### Triangular matrix-vector product [linalg.algs.blas2.trmv]
 
 *[Note:* These functions correspond to the BLAS functions `xTRMV` and
 `xTPMV`. --*end note]*

--- a/D1673/blas_interface.md
+++ b/D1673/blas_interface.md
@@ -1999,6 +1999,8 @@ void symmetric_matrix_right_product(
 // [linalg.algs.blas3.hemm],
 // Hermitian matrix-matrix product
 
+// [linalg.algs.blas3.hemm.ov.left],
+// overwriting Hermitian matrix-matrix left product
 template<class in_matrix_1_t,
          class Triangle,
          class in_matrix_2_t,
@@ -2008,16 +2010,6 @@ void hermitian_matrix_left_product(
   Triangle t,
   in_matrix_2_t B,
   out_matrix_t C);
-template<class in_matrix_1_t,
-         class Triangle,
-         class in_matrix_2_t,
-         class out_matrix_t>
-void hermitian_matrix_right_product(
-  in_matrix_1_t A,
-  Triangle t,
-  in_matrix_2_t B,
-  out_matrix_t C);
-
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
@@ -2029,6 +2021,18 @@ void hermitian_matrix_left_product(
   Triangle t,
   in_matrix_2_t B,
   out_matrix_t C);
+
+// [linalg.algs.blas3.hemm.ov.right],
+// overwriting Hermitian matrix-matrix right product
+template<class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void hermitian_matrix_right_product(
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  out_matrix_t C);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
@@ -2041,6 +2045,8 @@ void hermitian_matrix_right_product(
   in_matrix_2_t B,
   out_matrix_t C);
 
+// [linalg.algs.blas3.hemm.up.left],
+// updating Hermitian matrix-matrix left product
 template<class in_matrix_1_t,
          class Triangle,
          class in_matrix_2_t,
@@ -2052,18 +2058,6 @@ void hermitian_matrix_left_product(
   in_matrix_2_t B,
   in_matrix_3_t E,
   out_matrix_t C);
-template<class in_matrix_1_t,
-         class Triangle,
-         class in_matrix_2_t,
-         class in_matrix_3_t,
-         class out_matrix_t>
-void hermitian_matrix_right_product(
-  in_matrix_1_t A,
-  Triangle t,
-  in_matrix_2_t B,
-  in_matrix_3_t E,
-  out_matrix_t C);
-
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
@@ -2072,6 +2066,20 @@ template<class ExecutionPolicy,
          class out_matrix_t>
 void hermitian_matrix_left_product(
   ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+
+// [linalg.algs.blas3.hemm.up.right],
+// updating Hermitian matrix-matrix right product
+template<class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void hermitian_matrix_right_product(
   in_matrix_1_t A,
   Triangle t,
   in_matrix_2_t B,
@@ -5630,10 +5638,14 @@ void symmetric_matrix_right_product(
 
 ##### Hermitian matrix-matrix product [linalg.algs.blas3.hemm]
 
-*[Note:* These functions correspond to the BLAS function `xHEMM`.
+*[Note:*
+
+These functions correspond to the BLAS function `xHEMM`.
+
 Unlike the Hermitian rank-1 update functions, these functions assume
-that the input matrix -- not the output matrix -- is Hermitian. --*end
-note]*
+that the input matrix -- not the output matrix -- is Hermitian.
+
+--*end note]*
 
 The following requirements apply to all functions in this section.
 
@@ -5671,10 +5683,14 @@ The following requirements apply to all functions in this section.
     `dynamic_extent`, then `C.static_extent(r)` equals
     `E.static_extent(r)` (if applicable).
 
-* *Remarks:* The functions will only access the triangle of `A`
-  specified by the `Triangle` argument `t`, and will assume for
-  indices `i,j` outside that triangle, that `A(j,i)` equals
-  `conj(A(i,j))`.
+* *Remarks:*
+
+  * The functions will only access the triangle of `A` specified by
+    the `Triangle` argument `t`, and will assume for indices `i,j`
+    outside that triangle, that `A(j,i)` equals `conj(A(i,j))`.
+
+  * *Remarks:* `C` and `E` (if applicable) may refer to the same
+    matrix.  If so, then they must have the same layout.
 
 The following requirements apply to all overloads of
 `hermitian_matrix_left_product`.
@@ -5726,7 +5742,7 @@ The following requirements apply to all overloads of
     `dynamic_extent`, then `A.static_extent(1)` equals
     `C.static_extent(1)`.
 
-###### Overwriting Hermitian matrix-matrix product
+###### Overwriting Hermitian matrix-matrix left product [linalg.algs.blas3.hemm.ov.left]
 
 ```c++
 template<class in_matrix_1_t,
@@ -5738,16 +5754,6 @@ void hermitian_matrix_left_product(
   Triangle t,
   in_matrix_2_t B,
   out_matrix_t C);
-template<class in_matrix_1_t,
-         class Triangle,
-         class in_matrix_2_t,
-         class out_matrix_t>
-void hermitian_matrix_right_product(
-  in_matrix_1_t A,
-  Triangle t,
-  in_matrix_2_t B,
-  out_matrix_t C);
-
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
@@ -5755,6 +5761,28 @@ template<class ExecutionPolicy,
          class out_matrix_t>
 void hermitian_matrix_left_product(
   ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  out_matrix_t C);
+```
+
+* *Constraints:* For `i,j` in the domain of `C`,
+  `i,k` in the domain of `A`, and
+  `k,j` in the domain of `B`,
+  the expression `C(i,j) += A(i,k)*B(k,j)` is well formed.
+
+* *Effects:* Assigns to the elements of the matrix `C` the product of
+  the matrices `A` and `B`.
+
+###### Overwriting Hermitian matrix-matrix right product [linalg.algs.blas3.hemm.ov.right]
+
+```c++
+template<class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void hermitian_matrix_right_product(
   in_matrix_1_t A,
   Triangle t,
   in_matrix_2_t B,
@@ -5772,27 +5800,15 @@ void hermitian_matrix_right_product(
   out_matrix_t C);
 ```
 
-* *Constraints:*
+* *Constraints:* For `i,j` in the domain of `C`,
+  `i,k` in the domain of `B`, and
+  `k,j` in the domain of `A`,
+  the expression `C(i,j) += B(i,k)*A(k,j)` is well formed.
 
-  * For `hermitian_matrix_left_product`,
-    for `i,j` in the domain of `C`,
-    `i,k` in the domain of `A`, and `k,j` in the domain of `B`, the
-    expression `C(i,j) += A(i,k)*B(k,j)` is well formed.
+* *Effects:* Assigns to the elements of the matrix `C` the product of
+  the matrices `B` and `A`.
 
-  * For `hermitian_matrix_right_product`,
-    for for `i,j` in the domain of `C`,
-    `i,k` in the domain of `B`, and `k,j` in the domain of `A`, the
-    expression `C(i,j) += B(i,k)*A(k,j)` is well formed.
-
-* *Effects:*
-
-  * `hermitian_matrix_left_product` assigns to the elements of the
-    matrix `C` the product of the matrices `A` and `B`.
-
-  * `hermitian_matrix_right_product` assigns to the elements of the
-    matrix `C` the product of the matrices `B` and `A`.
-
-###### Updating Hermitian matrix-matrix product
+###### Updating Hermitian matrix-matrix left product [linalg.algs.blas3.hemm.up.left]
 
 ```c++
 template<class in_matrix_1_t,
@@ -5806,18 +5822,6 @@ void hermitian_matrix_left_product(
   in_matrix_2_t B,
   in_matrix_3_t E,
   out_matrix_t C);
-template<class in_matrix_1_t,
-         class Triangle,
-         class in_matrix_2_t,
-         class in_matrix_3_t,
-         class out_matrix_t>
-void hermitian_matrix_right_product(
-  in_matrix_1_t A,
-  Triangle t,
-  in_matrix_2_t B,
-  in_matrix_3_t E,
-  out_matrix_t C);
-
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
@@ -5826,6 +5830,30 @@ template<class ExecutionPolicy,
          class out_matrix_t>
 void hermitian_matrix_left_product(
   ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+```
+
+* *Constraints:* For `i,j` in the domain of `C`,
+  `i,k` in the domain of `A`, and
+  `k,j` in the domain of `B`,
+  the expression `C(i,j) += E(i,j) + A(i,k)*B(k,j)` is well formed.
+
+* *Effects:* Assigns to the elements of the matrix `C` on output, the
+  elementwise sum of `E` and the product of the matrices `A` and `B`.
+
+###### Updating Hermitian matrix-matrix right product [linalg.algs.blas3.hemm.up.right]
+
+```c++
+template<class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void hermitian_matrix_right_product(
   in_matrix_1_t A,
   Triangle t,
   in_matrix_2_t B,
@@ -5846,30 +5874,13 @@ void hermitian_matrix_right_product(
   out_matrix_t C);
 ```
 
-* *Constraints:*
+* *Constraints:* For `i,j` in the domain of `C`,
+  `i,k` in the domain of `B`, and
+  `k,j` in the domain of `A`,
+  the expression `C(i,j) += E(i,j) + B(i,k)*A(k,j)` is well formed.
 
-  * For `hermitian_matrix_left_product`,
-    for `i,j` in the domain of `C`,
-    `i,k` in the domain of `A`, and `k,j` in the domain of `B`, the
-    expression `C(i,j) += E(i,j) + A(i,k)*B(k,j)` is well formed.
-
-  * For `hermitian_matrix_right_product`,
-    for for `i,j` in the domain of `C`,
-    `i,k` in the domain of `B`, and `k,j` in the domain of `A`, the
-    expression `C(i,j) += E(i,j) + B(i,k)*A(k,j)` is well formed.
-
-* *Effects:*
-
-  * `hermitian_matrix_left_product` assigns to the elements of the
-    matrix `C` on output, the elementwise sum of `E` and the product
-    of the matrices `A` and `B`.
-
-  * `hermitian_matrix_right_product` assigns to the elements of the
-    matrix `C` on output, the elementwise sum of `E` and the product
-    of the matrices `B` and `A`.
-
-* *Remarks:* `C` and `E` may refer to the same matrix.  If so, then
-  they must have the same layout.
+* *Effects:* Assigns to the elements of the matrix `C` on output, the
+  elementwise sum of `E` and the product of the matrices `B` and `A`.
 
 ##### Triangular matrix-matrix product [linalg.algs.blas3.trmm]
 

--- a/D1673/blas_interface.md
+++ b/D1673/blas_interface.md
@@ -22,7 +22,7 @@
 * Srinath Vadlamani (Srinath.Vadlamani@arm.com) (ARM)
 * Rene Vanoostrum (Rene.Vanoostrum@amd.com) (AMD)
 
-## Date: 2020-01-07
+## Date: 2020-01-09
 
 ## Revision history
 
@@ -1901,110 +1901,190 @@ void matrix_product(ExecutionPolicy&& exec,
 
 // [linalg.algs.blas3.symm],
 // symmetric matrix-matrix product
+
 template<class in_matrix_1_t,
          class Triangle,
-         class Side,
          class in_matrix_2_t,
          class out_matrix_t>
-void symmetric_matrix_product(
+void symmetric_matrix_left_product(
   in_matrix_1_t A,
   Triangle t,
-  Side s,
+  in_matrix_2_t B,
+  out_matrix_t C);
+template<class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void symmetric_matrix_right_product(
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  out_matrix_t C);
+
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void symmetric_matrix_left_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
   in_matrix_2_t B,
   out_matrix_t C);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
-         class Side,
          class in_matrix_2_t,
          class out_matrix_t>
-void symmetric_matrix_product(
+void symmetric_matrix_right_product(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
-  Side s,
   in_matrix_2_t B,
   out_matrix_t C);
+
 template<class in_matrix_1_t,
          class Triangle,
-         class Side,
          class in_matrix_2_t,
          class in_matrix_3_t,
          class out_matrix_t>
-void symmetric_matrix_product(
+void symmetric_matrix_left_product(
   in_matrix_1_t A,
   Triangle t,
-  Side s,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+template<class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void symmetric_matrix_right_product(
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void symmetric_matrix_left_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
   in_matrix_2_t B,
   in_matrix_3_t E,
   out_matrix_t C);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
-         class Side,
          class in_matrix_2_t,
          class in_matrix_3_t,
          class out_matrix_t>
-void symmetric_matrix_product(
+void symmetric_matrix_right_product(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
-  Side s,
   in_matrix_2_t B,
   in_matrix_3_t E,
   out_matrix_t C);
 
 // [linalg.algs.blas3.hemm],
 // Hermitian matrix-matrix product
+
 template<class in_matrix_1_t,
          class Triangle,
-         class Side,
          class in_matrix_2_t,
          class out_matrix_t>
-void hermitian_matrix_product(
+void hermitian_matrix_left_product(
   in_matrix_1_t A,
   Triangle t,
-  Side s,
+  in_matrix_2_t B,
+  out_matrix_t C);
+template<class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void hermitian_matrix_right_product(
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  out_matrix_t C);
+
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void hermitian_matrix_left_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
   in_matrix_2_t B,
   out_matrix_t C);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
-         class Side,
          class in_matrix_2_t,
          class out_matrix_t>
-void hermitian_matrix_product(
+void hermitian_matrix_right_product(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
-  Side s,
   in_matrix_2_t B,
   out_matrix_t C);
+
 template<class in_matrix_1_t,
          class Triangle,
-         class Side,
          class in_matrix_2_t,
          class in_matrix_3_t,
          class out_matrix_t>
-void hermitian_matrix_product(
+void hermitian_matrix_left_product(
   in_matrix_1_t A,
   Triangle t,
-  Side s,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+template<class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void hermitian_matrix_right_product(
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void hermitian_matrix_left_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
   in_matrix_2_t B,
   in_matrix_3_t E,
   out_matrix_t C);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
-         class Side,
          class in_matrix_2_t,
          class in_matrix_3_t,
          class out_matrix_t>
-void hermitian_matrix_product(
+void hermitian_matrix_right_product(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
-  Side s,
   in_matrix_2_t B,
   in_matrix_3_t E,
   out_matrix_t C);
@@ -2222,25 +2302,6 @@ The `implicit_unit_diagonal_t` tag indicates two things:
 
 The tag `explicit_diagonal_t` indicates that algorithms and other
 users of the viewer may access the matrix's diagonal entries directly.
-
-#### Side tags [linalg.tags.side]
-
-Some linear algebra algorithms distinguish between applying some
-operator to the left side of an object, or the right side of an
-object.  *[Note:* Matrix-matrix product and triangular solve with a
-matrix generally do not commute. --*end note]*
-
-```c++
-struct left_side_t { };
-inline constexpr left_side_t left_side = { };
-
-struct right_side_t { };
-inline constexpr right_side_t right_side = { };
-```
-
-These tag classes specify whether algorithms should apply some
-operator to the left side (`left_side_t`) or right side
-(`right_side_t`) of an object.
 
 ### Layouts for general and packed matrix types [linalg.layouts]
 
@@ -3610,8 +3671,6 @@ or other things as appropriate.
 
 * `DiagonalStorage` is either `implicit_unit_diagonal_t` or
   `explicit_diagonal_t`.
-
-* `Side` is either `left_side_t` or `right_side_t`.
 
 * `in_*_t` template parameters may deduce a `const` lvalue reference
    or a (non-`const`) rvalue reference to a `basic_mdspan`.
@@ -5258,7 +5317,8 @@ Unlike the symmetric rank-1 update functions, these functions assume
 that the input matrix -- not the output matrix -- is symmetric. --*end
 note]*
 
-The following requirements apply to all functions in this section.
+The following requirements apply to all functions in this section,
+unless otherwise specified.
 
 * *Requires:*
 
@@ -5268,7 +5328,7 @@ The following requirements apply to all functions in this section.
 
   * `C.extent(1)` equals `E.extent(1)` (if applicable).
 
-  * If `Side` is `left_side_t`, then
+  * For `symmetric_matrix_left_product`,
 
      * `A.extent(1)` equals `B.extent(0)`,
 
@@ -5276,7 +5336,7 @@ The following requirements apply to all functions in this section.
 
      * `B.extent(1)` equals `C.extent(1)`.
 
-  * Otherwise, if `Side` is `right_side_t`, then
+  * For `symmetric_matrix_right_product`,
 
      * `B.extent(1)` equals `A.extent(0)`,
 
@@ -5310,7 +5370,7 @@ The following requirements apply to all functions in this section.
     `dynamic_extent`, then `C.static_extent(r)` equals
     `E.static_extent(r)` (if applicable).
 
-  * If `Side` is `left_side_t`, then
+  * For `symmetric_matrix_left_product`,
 
     * if neither `A.static_extent(1)` nor `B.static_extent(0)` equals
       `dynamic_extent`, then `A.static_extent(1)` equals
@@ -5324,7 +5384,7 @@ The following requirements apply to all functions in this section.
       `dynamic_extent`, then `B.static_extent(1)` equals
       `C.static_extent(1)`.
 
-  * Otherwise, if `Side` is `right_side_t`, then
+  * For `symmetric_matrix_right_product`,
 
     * if neither `B.static_extent(1)` nor `A.static_extent(0)` equals
       `dynamic_extent`, then `B.static_extent(1)` equals
@@ -5347,62 +5407,91 @@ The following requirements apply to all functions in this section.
 ```c++
 template<class in_matrix_1_t,
          class Triangle,
-         class Side,
          class in_matrix_2_t,
          class out_matrix_t>
-void symmetric_matrix_product(
+void symmetric_matrix_left_product(
   in_matrix_1_t A,
   Triangle t,
-  Side s,
+  in_matrix_2_t B,
+  out_matrix_t C);
+template<class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void symmetric_matrix_right_product(
+  in_matrix_1_t A,
+  Triangle t,
   in_matrix_2_t B,
   out_matrix_t C);
 
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
-         class Side,
          class in_matrix_2_t,
          class out_matrix_t>
-void symmetric_matrix_product(
+void symmetric_matrix_left_product(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
-  Side s,
+  in_matrix_2_t B,
+  out_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void symmetric_matrix_right_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
   in_matrix_2_t B,
   out_matrix_t C);
 ```
 
 * *Constraints:*
 
-  * If `Side` is `left_side_t`, then for `i,j` in the domain of `C`,
+  * For `symmetric_matrix_left_product`,
+    for `i,j` in the domain of `C`,
     `i,k` in the domain of `A`, and `k,j` in the domain of `B`, the
     expression `C(i,j) += A(i,k)*B(k,j)` is well formed.
 
-  * If `Side` is `right_side_t`, then for `i,j` in the domain of `C`,
+  * For `symmetric_matrix_right_product`,
+    for for `i,j` in the domain of `C`,
     `i,k` in the domain of `B`, and `k,j` in the domain of `A`, the
     expression `C(i,j) += B(i,k)*A(k,j)` is well formed.
 
 * *Effects:*
 
-  * If `Side` is `left_side_t`, then assigns to the elements of the
-    matrix `C` the product of the matrices `A` and `B`.
+  * `symmetric_matrix_left_product` assigns to the elements of the
+    matrix `C` the product of the matrices `A` and `B`, where the
+    matrix `A` is assumed to be symmetric.
 
-  * If `Side` is `right_side_t`, then assigns to the elements of the
-    matrix `C` the product of the matrices `B` and `A`.
+  * `symmetric_matrix_right_product` assigns to the elements of the
+    matrix `C` the product of the matrices `B` and `A`, where the
+    matrix `A` is assumed to be symmetric.
 
 ###### Updating symmetric matrix-matrix product
 
 ```c++
 template<class in_matrix_1_t,
          class Triangle,
-         class Side,
          class in_matrix_2_t,
          class in_matrix_3_t,
          class out_matrix_t>
-void symmetric_matrix_product(
+void symmetric_matrix_left_product(
   in_matrix_1_t A,
   Triangle t,
-  Side s,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+template<class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void symmetric_matrix_right_product(
+  in_matrix_1_t A,
+  Triangle t,
   in_matrix_2_t B,
   in_matrix_3_t E,
   out_matrix_t C);
@@ -5410,15 +5499,26 @@ void symmetric_matrix_product(
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
-         class Side,
          class in_matrix_2_t,
          class in_matrix_3_t,
          class out_matrix_t>
-void symmetric_matrix_product(
+void symmetric_matrix_left_product(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
-  Side s,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void symmetric_matrix_right_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
   in_matrix_2_t B,
   in_matrix_3_t E,
   out_matrix_t C);
@@ -5426,23 +5526,27 @@ void symmetric_matrix_product(
 
 * *Constraints:*
 
-  * If `Side` is `left_side_t`, then for `i,j` in the domain of `C`,
+  * For `symmetric_matrix_left_product`,
+    for `i,j` in the domain of `C`,
     `i,k` in the domain of `A`, and `k,j` in the domain of `B`, the
     expression `C(i,j) += E(i,j) + A(i,k)*B(k,j)` is well formed.
 
-  * If `Side` is `right_side_t`, then for `i,j` in the domain of `C`,
+  * For `symmetric_matrix_right_product`,
+    for `i,j` in the domain of `C`,
     `i,k` in the domain of `B`, and `k,j` in the domain of `A`, the
     expression `C(i,j) += E(i,j) + B(i,k)*A(k,j)` is well formed.
 
 * *Effects:*
 
-  * If `Side` is `left_side_t`, then assigns to the elements of the
-    matrix `C` on output, the elementwise sum of `E` and the product of
-    the matrices `A` and `B`.
+  * `symmetric_matrix_left_product` assigns to the elements of the
+    matrix `C` on output, the elementwise sum of `E` and the product
+    of the matrices `A` and `B`, where the matrix `A` is assumed to be
+    symmetric.
 
-  * If `Side` is `right_side_t`, then assigns to the elements of the
-    matrix `C` on output, the elementwise sum of `E` and the product of
-    the matrices `B` and `A`.
+  * `symmetric_matrix_right_product` assigns to the elements of the
+    matrix `C` on output, the elementwise sum of `E` and the product
+    of the matrices `B` and `A`, where the matrix `A` is assumed to be
+    symmetric.
 
 * *Remarks:* `C` and `E` may refer to the same matrix.  If so, then
   they must have the same layout.
@@ -5454,7 +5558,8 @@ Unlike the Hermitian rank-1 update functions, these functions assume
 that the input matrix -- not the output matrix -- is Hermitian. --*end
 note]*
 
-The following requirements apply to all functions in this section.
+The following requirements apply to all functions in this section,
+unless otherwise specified.
 
 * *Requires:*
 
@@ -5464,7 +5569,7 @@ The following requirements apply to all functions in this section.
 
   * `C.extent(1)` equals `E.extent(1)` (if applicable).
 
-  * If `Side` is `left_side_t`, then
+  * For `hermitian_matrix_left_product`,
 
      * `A.extent(1)` equals `B.extent(0)`,
 
@@ -5472,7 +5577,7 @@ The following requirements apply to all functions in this section.
 
      * `B.extent(1)` equals `C.extent(1)`.
 
-  * Otherwise, if `Side` is `right_side_t`, then
+  * For `hermitian_matrix_right_product`,
 
      * `B.extent(1)` equals `A.extent(0)`,
 
@@ -5506,7 +5611,7 @@ The following requirements apply to all functions in this section.
     `dynamic_extent`, then `C.static_extent(r)` equals
     `E.static_extent(r)` (if applicable).
 
-  * If `Side` is `left_side_t`, then
+  * For `hermitian_matrix_left_product`,
 
     * if neither `A.static_extent(1)` nor `B.static_extent(0)` equals
       `dynamic_extent`, then `A.static_extent(1)` equals
@@ -5520,7 +5625,7 @@ The following requirements apply to all functions in this section.
       `dynamic_extent`, then `B.static_extent(1)` equals
       `C.static_extent(1)`.
 
-  * Otherwise, if `Side` is `right_side_t`, then
+  * For `hermitian_matrix_right_product`,
 
     * if neither `B.static_extent(1)` nor `A.static_extent(0)` equals
       `dynamic_extent`, then `B.static_extent(1)` equals
@@ -5544,62 +5649,91 @@ The following requirements apply to all functions in this section.
 ```c++
 template<class in_matrix_1_t,
          class Triangle,
-         class Side,
          class in_matrix_2_t,
          class out_matrix_t>
-void hermitian_matrix_product(
+void hermitian_matrix_left_product(
   in_matrix_1_t A,
   Triangle t,
-  Side s,
+  in_matrix_2_t B,
+  out_matrix_t C);
+template<class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void hermitian_matrix_right_product(
+  in_matrix_1_t A,
+  Triangle t,
   in_matrix_2_t B,
   out_matrix_t C);
 
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
-         class Side,
          class in_matrix_2_t,
          class out_matrix_t>
-void hermitian_matrix_product(
+void hermitian_matrix_left_product(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
-  Side s,
+  in_matrix_2_t B,
+  out_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void hermitian_matrix_right_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
   in_matrix_2_t B,
   out_matrix_t C);
 ```
 
 * *Constraints:*
 
-  * If `Side` is `left_side_t`, then for `i,j` in the domain of `C`,
+  * For `hermitian_matrix_left_product`,
+    for `i,j` in the domain of `C`,
     `i,k` in the domain of `A`, and `k,j` in the domain of `B`, the
     expression `C(i,j) += A(i,k)*B(k,j)` is well formed.
 
-  * If `Side` is `right_side_t`, then for `i,j` in the domain of `C`,
+  * For `hermitian_matrix_right_product`,
+    for for `i,j` in the domain of `C`,
     `i,k` in the domain of `B`, and `k,j` in the domain of `A`, the
     expression `C(i,j) += B(i,k)*A(k,j)` is well formed.
 
 * *Effects:*
 
-  * If `Side` is `left_side_t`, then assigns to the elements of the
-    matrix `C` the product of the matrices `A` and `B`.
+  * `hermitian_matrix_left_product` assigns to the elements of the
+    matrix `C` the product of the matrices `A` and `B`, where the
+    matrix `A` is assumed to be Hermitian.
 
-  * If `Side` is `right_side_t`, then assigns to the elements of the
-    matrix `C` the product of the matrices `B` and `A`.
+  * `hermitian_matrix_right_product` assigns to the elements of the
+    matrix `C` the product of the matrices `B` and `A`, where the
+    matrix `A` is assumed to be Hermitian.
 
 ###### Updating Hermitian matrix-matrix product
 
 ```c++
 template<class in_matrix_1_t,
          class Triangle,
-         class Side,
          class in_matrix_2_t,
          class in_matrix_3_t,
          class out_matrix_t>
-void hermitian_matrix_product(
+void hermitian_matrix_left_product(
   in_matrix_1_t A,
   Triangle t,
-  Side s,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+template<class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void hermitian_matrix_right_product(
+  in_matrix_1_t A,
+  Triangle t,
   in_matrix_2_t B,
   in_matrix_3_t E,
   out_matrix_t C);
@@ -5607,15 +5741,26 @@ void hermitian_matrix_product(
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
-         class Side,
          class in_matrix_2_t,
          class in_matrix_3_t,
          class out_matrix_t>
-void hermitian_matrix_product(
+void hermitian_matrix_left_product(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
-  Side s,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void hermitian_matrix_right_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
   in_matrix_2_t B,
   in_matrix_3_t E,
   out_matrix_t C);
@@ -5623,23 +5768,27 @@ void hermitian_matrix_product(
 
 * *Constraints:*
 
-  * If `Side` is `left_side_t`, then for `i,j` in the domain of `C`,
+  * For `hermitian_matrix_left_product`,
+    for `i,j` in the domain of `C`,
     `i,k` in the domain of `A`, and `k,j` in the domain of `B`, the
     expression `C(i,j) += E(i,j) + A(i,k)*B(k,j)` is well formed.
 
-  * If `Side` is `right_side_t`, then for `i,j` in the domain of `C`,
+  * For `hermitian_matrix_right_product`,
+    for for `i,j` in the domain of `C`,
     `i,k` in the domain of `B`, and `k,j` in the domain of `A`, the
     expression `C(i,j) += E(i,j) + B(i,k)*A(k,j)` is well formed.
 
 * *Effects:*
 
-  * If `Side` is `left_side_t`, then assigns to the elements of the
-    matrix `C` on output, the elementwise sum of `E` and the product of
-    the matrices `A` and `B`.
+  * `hermitian_matrix_left_product` assigns to the elements of the
+    matrix `C` on output, the elementwise sum of `E` and the product
+    of the matrices `A` and `B`, where the matrix `A` is assumed to be
+    Hermitian.
 
-  * If `Side` is `right_side_t`, then assigns to the elements of the
-    matrix `C` on output, the elementwise sum of `E` and the product of
-    the matrices `B` and `A`.
+  * `hermitian_matrix_right_product` assigns to the elements of the
+    matrix `C` on output, the elementwise sum of `E` and the product
+    of the matrices `B` and `A`, where the matrix `A` is assumed to be
+    Hermitian.
 
 * *Remarks:* `C` and `E` may refer to the same matrix.  If so, then
   they must have the same layout.

--- a/D1673/blas_interface.md
+++ b/D1673/blas_interface.md
@@ -2267,6 +2267,9 @@ void hermitian_matrix_rank_2k_update(
 // [linalg.alg.blas3.trsm],
 // solve multiple triangular linear systems
 
+// [linalg.alg.blas3.trsm.left],
+// solve multiple triangular linear systems
+// with triangular matrix on the left
 template<class in_matrix_t,
          class Triangle,
          class DiagonalStorage,
@@ -2278,18 +2281,6 @@ void triangular_matrix_matrix_left_solve(
   DiagonalStorage d,
   in_object_t B,
   out_object_t X);
-template<class in_matrix_t,
-         class Triangle,
-         class DiagonalStorage,
-         class in_object_t,
-         class out_object_t>
-void triangular_matrix_matrix_right_solve(
-  in_matrix_t A,
-  Triangle t,
-  DiagonalStorage d,
-  in_object_t B,
-  out_object_t X);
-
 template<class ExecutionPolicy,
          class in_matrix_t,
          class Triangle,
@@ -2303,6 +2294,21 @@ void triangular_matrix_matrix_left_solve(
   DiagonalStorage d,
   in_matrix_t B,
   out_matrix_t X);
+
+// [linalg.alg.blas3.trsm.right],
+// solve multiple triangular linear systems
+// with triangular matrix on the right
+template<class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_object_t,
+         class out_object_t>
+void triangular_matrix_matrix_right_solve(
+  in_matrix_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_object_t B,
+  out_object_t X);
 template<class ExecutionPolicy,
          class in_matrix_t,
          class Triangle,
@@ -6313,60 +6319,10 @@ void hermitian_matrix_rank_2k_update(
 
 ##### Solve multiple triangular linear systems [linalg.alg.blas3.trsm]
 
-```c++
-template<class in_matrix_t,
-         class Triangle,
-         class DiagonalStorage,
-         class in_object_t,
-         class out_object_t>
-void triangular_matrix_matrix_left_solve(
-  in_matrix_t A,
-  Triangle t,
-  DiagonalStorage d,
-  in_object_t B,
-  out_object_t X);
-template<class in_matrix_t,
-         class Triangle,
-         class DiagonalStorage,
-         class in_object_t,
-         class out_object_t>
-void triangular_matrix_matrix_right_solve(
-  in_matrix_t A,
-  Triangle t,
-  DiagonalStorage d,
-  in_object_t B,
-  out_object_t X);
-
-template<class ExecutionPolicy,
-         class in_matrix_t,
-         class Triangle,
-         class DiagonalStorage,
-         class in_matrix_t,
-         class out_matrix_t>
-void triangular_matrix_matrix_left_solve(
-  ExecutionPolicy&& exec,
-  in_matrix_t A,
-  Triangle t,
-  DiagonalStorage d,
-  in_matrix_t B,
-  out_matrix_t X);
-template<class ExecutionPolicy,
-         class in_matrix_t,
-         class Triangle,
-         class DiagonalStorage,
-         class in_matrix_t,
-         class out_matrix_t>
-void triangular_matrix_matrix_right_solve(
-  ExecutionPolicy&& exec,
-  in_matrix_t A,
-  Triangle t,
-  DiagonalStorage d,
-  in_matrix_t B,
-  out_matrix_t X);
-```
-
 *[Note:* These functions correspond to the BLAS function `xTRSM`.  The
 Reference BLAS does not have a `xTPSM` function. --*end note]*
+
+The following requirements apply to all functions in this section.
 
 * *Requires:*
 
@@ -6374,12 +6330,6 @@ Reference BLAS does not have a `xTPSM` function. --*end note]*
     `X.extent(r)` equals `B.extent(r)`.
 
   * `A.extent(0)` equals `A.extent(1)`.
-
-  * For `triangular_matrix_matrix_left_solve`,
-    `A.extent(1)` equals `B.extent(0)`.
-
-  * For `triangular_matrix_matrix_right_solve`,
-    `A.extent(1)` equals `B.extent(1)`.
 
 * *Constraints:*
 
@@ -6392,14 +6342,6 @@ Reference BLAS does not have a `xTPSM` function. --*end note]*
 
   * If `r,j` is in the domain of `X` and `B`, then the expression
     `X(r,j) = B(r,j)` is well formed.
-
-  * For `triangular_matrix_matrix_left_solve`,
-    if `i,j` and `i,k` are in the domain of `X`, then
-    the expression `X(i,j) -= A(i,k) * X(k,j)` is well formed.
-
-  * For `triangular_matrix_matrix_right_solve`,
-    if `i,j` and `i,k` are in the domain of `X`, then
-    the expression `X(i,j) -= X(i,k) * A(k,j)` is well formed.
 
   * If `DiagonalStorage` is `explicit_diagonal_t`, and `i,j` is in the
     domain of `X`, then the expression `X(i,j) /= A(i,i)` is well
@@ -6416,24 +6358,6 @@ Reference BLAS does not have a `xTPSM` function. --*end note]*
     `dynamic_extent`, then `A.static_extent(0)` equals
     `A.static_extent(1)`.
 
-  * For `triangular_matrix_matrix_left_solve`,
-    if neither `A.static_extent(1)` nor `B.static_extent(0)`
-    equals `dynamic_extent`, then
-    `A.static_extent(1)` equals `B.static_extent(0)`.
-
-  * For `triangular_matrix_matrix_right_solve`,
-    if neither `A.static_extent(1)` nor `B.static_extent(1)`
-    equals `dynamic_extent`, then
-    `A.static_extent(1)` equals `B.static_extent(1)`.
-
-* *Effects:*
-
-  * `triangular_matrix_matrix_left_solve` assigns to the elements of `X`
-    the result of solving the triangular linear system(s) AX=B for X.
-
-  * `triangular_matrix_matrix_right_solve` assigns to the elements of `X`
-    the result of solving the triangular linear system(s) XA=B for X.
-
 * *Remarks:*
 
   * The functions will only access the triangle of `A` specified by
@@ -6445,3 +6369,85 @@ Reference BLAS does not have a `xTPSM` function. --*end note]*
     of `A` all equal one. *[Note:* This does not imply that the
     function needs to be able to form an `element_type` value equal to
     one. --*end note]
+
+###### Solve multiple triangular linear systems with triangular matrix on the left [linalg.alg.blas3.trsm.left]
+
+```c++
+template<class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_object_t,
+         class out_object_t>
+void triangular_matrix_matrix_left_solve(
+  in_matrix_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_object_t B,
+  out_object_t X);
+template<class ExecutionPolicy,
+         class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_t,
+         class out_matrix_t>
+void triangular_matrix_matrix_left_solve(
+  ExecutionPolicy&& exec,
+  in_matrix_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_matrix_t B,
+  out_matrix_t X);
+```
+
+* *Requires:* `A.extent(1)` equals `B.extent(0)`.
+
+* *Constraints:* If `i,j` and `i,k` are in the domain of `X`, then
+  the expression `X(i,j) -= A(i,k) * X(k,j)` is well formed.
+
+* *Mandates:* If neither `A.static_extent(1)` nor `B.static_extent(0)`
+  equals `dynamic_extent`, then
+  `A.static_extent(1)` equals `B.static_extent(0)`.
+
+* *Effects:* Assigns to the elements of `X`
+  the result of solving the triangular linear system(s) AX=B for X.
+
+###### Solve multiple triangular linear systems with triangular matrix on the right [linalg.alg.blas3.trsm.right]
+
+```c++
+template<class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_object_t,
+         class out_object_t>
+void triangular_matrix_matrix_right_solve(
+  in_matrix_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_object_t B,
+  out_object_t X);
+template<class ExecutionPolicy,
+         class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_t,
+         class out_matrix_t>
+void triangular_matrix_matrix_right_solve(
+  ExecutionPolicy&& exec,
+  in_matrix_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_matrix_t B,
+  out_matrix_t X);
+```
+
+* *Requires:* `A.extent(1)` equals `B.extent(1)`.
+
+* *Constraints:* If `i,j` and `i,k` are in the domain of `X`, then
+  the expression `X(i,j) -= X(i,k) * A(k,j)` is well formed.
+
+* *Mandates:* If neither `A.static_extent(1)` nor `B.static_extent(1)`
+  equals `dynamic_extent`, then
+  `A.static_extent(1)` equals `B.static_extent(1)`.
+
+* *Effects:* Assigns to the elements of `X`
+  the result of solving the triangular linear system(s) XA=B for X.

--- a/D1673/blas_interface.md
+++ b/D1673/blas_interface.md
@@ -2218,7 +2218,7 @@ void triangular_matrix_right_product(
   in_matrix_3_t E,
   out_matrix_t C);
 
-// [linalg.alg.blas3.rank2k.symm],
+// [linalg.alg.blas3.syr2k],
 // rank-2k symmetric matrix update
 template<class in_matrix_1_t,
          class in_matrix_2_t,
@@ -2241,7 +2241,7 @@ void symmetric_matrix_rank_2k_update(
   inout_matrix_t C,
   Triangle t);
 
-// [linalg.alg.blas3.rank2k.herm],
+// [linalg.alg.blas3.her2k],
 // rank-2k Hermitian matrix update
 template<class in_matrix_1_t,
          class in_matrix_2_t,
@@ -6164,7 +6164,7 @@ void triangular_matrix_right_product(
 BLAS functions, by making `C` a `transpose_view` or
 `conjugate_transpose_view`. --*end note]*
 
-###### Rank-2k symmetric matrix update [linalg.alg.blas3.rank2k.symm]
+###### Rank-2k symmetric matrix update [linalg.alg.blas3.syr2k]
 
 ```c++
 template<class in_matrix_1_t,
@@ -6240,7 +6240,7 @@ The BLAS "quick reference" has a typo; the "ALPHA" argument of
   specified by the `Triangle` argument `t`, and will assume for
   indices `i,j` outside that triangle, that `C(j,i)` equals `C(i,j)`.
 
-###### Rank-2k Hermitian matrix update [linalg.alg.blas3.rank2k.herm]
+###### Rank-2k Hermitian matrix update [linalg.alg.blas3.her2k]
 
 ```c++
 template<class in_matrix_1_t,

--- a/D1673/blas_interface.md
+++ b/D1673/blas_interface.md
@@ -2102,6 +2102,8 @@ void hermitian_matrix_right_product(
 // [linalg.algs.blas3.trmm],
 // triangular matrix-matrix product
 
+// [linalg.algs.blas3.trmm.ov.left],
+// overwriting triangular matrix-matrix left product
 template<class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
@@ -2113,18 +2115,6 @@ void triangular_matrix_left_product(
   DiagonalStorage d,
   in_matrix_2_t B,
   out_matrix_t C);
-template<class in_matrix_1_t,
-         class Triangle,
-         class DiagonalStorage,
-         class in_matrix_2_t,
-         class out_matrix_t>
-void triangular_matrix_right_product(
-  in_matrix_1_t A,
-  Triangle t,
-  DiagonalStorage d,
-  in_matrix_2_t B,
-  out_matrix_t C);
-
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
@@ -2138,6 +2128,20 @@ void triangular_matrix_left_product(
   DiagonalStorage d,
   in_matrix_2_t B,
   out_matrix_t C);
+
+// [linalg.algs.blas3.trmm.ov.right],
+// overwriting triangular matrix-matrix right product
+template<class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void triangular_matrix_right_product(
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_matrix_2_t B,
+  out_matrix_t C);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
@@ -2152,6 +2156,8 @@ void triangular_matrix_right_product(
   in_matrix_2_t B,
   out_matrix_t C);
 
+// [linalg.algs.blas3.trmm.up.left],
+// updating triangular matrix-matrix left product
 template<class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
@@ -2165,20 +2171,6 @@ void triangular_matrix_left_product(
   in_matrix_2_t B,
   in_matrix_3_t E,
   out_matrix_t C);
-template<class in_matrix_1_t,
-         class Triangle,
-         class DiagonalStorage,
-         class in_matrix_2_t,
-         class in_matrix_3_t,
-         class out_matrix_t>
-void triangular_matrix_right_product(
-  in_matrix_1_t A,
-  Triangle t,
-  DiagonalStorage d,
-  in_matrix_2_t B,
-  in_matrix_3_t E,
-  out_matrix_t C);
-
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
@@ -2188,6 +2180,22 @@ template<class ExecutionPolicy,
          class out_matrix_t>
 void triangular_matrix_left_product(
   ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+
+// [linalg.algs.blas3.trmm.up.right],
+// updating triangular matrix-matrix right product
+template<class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void triangular_matrix_right_product(
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
@@ -5935,6 +5943,9 @@ The following requirements apply to all functions in this section.
     function needs to be able to form an `element_type` value equal to
     one. --*end note]
 
+  * `C` and `E` (if applicable) may refer to the same matrix.
+    If so, then they must have the same layout.
+
 The following requirements apply to all overloads of
 `triangular_matrix_left_product`.
 
@@ -5985,7 +5996,7 @@ The following requirements apply to all overloads of
     `dynamic_extent`, then `A.static_extent(1)` equals
     `C.static_extent(1)`.
 
-###### Overwriting triangular matrix-matrix product
+###### Overwriting triangular matrix-matrix left product [linalg.algs.blas3.trmm.ov.left]
 
 ```c++
 template<class in_matrix_1_t,
@@ -5999,18 +6010,6 @@ void triangular_matrix_left_product(
   DiagonalStorage d,
   in_matrix_2_t B,
   out_matrix_t C);
-template<class in_matrix_1_t,
-         class Triangle,
-         class DiagonalStorage,
-         class in_matrix_2_t,
-         class out_matrix_t>
-void triangular_matrix_right_product(
-  in_matrix_1_t A,
-  Triangle t,
-  DiagonalStorage d,
-  in_matrix_2_t B,
-  out_matrix_t C);
-
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
@@ -6019,6 +6018,30 @@ template<class ExecutionPolicy,
          class out_matrix_t>
 void triangular_matrix_left_product(
   ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_matrix_2_t B,
+  out_matrix_t C);
+```
+
+* *Constraints:* For `i,j` in the domain of `C`,
+  `i,k` in the domain of `A`, and
+  `k,j` in the domain of `B`,
+  the expression `C(i,j) += A(i,k)*B(k,j)` is well formed.
+
+* *Effects:* Assigns to the elements of the matrix `C`
+  the product of the matrices `A` and `B`.
+
+###### Overwriting triangular matrix-matrix right product [linalg.algs.blas3.trmm.ov.right]
+
+```c++
+template<class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void triangular_matrix_right_product(
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
@@ -6039,27 +6062,15 @@ void triangular_matrix_right_product(
   out_matrix_t C);
 ```
 
-* *Constraints:*
+* *Constraints:* For `i,j` in the domain of `C`,
+  `i,k` in the domain of `B`, and
+  `k,j` in the domain of `A`,
+  the expression `C(i,j) += B(i,k)*A(k,j)` is well formed.
 
-  * For `triangular_matrix_left_product`,
-    for `i,j` in the domain of `C`,
-    `i,k` in the domain of `A`, and `k,j` in the domain of `B`, the
-    expression `C(i,j) += A(i,k)*B(k,j)` is well formed.
+* *Effects:* Assigns to the elements of the matrix `C`
+  the product of the matrices `B` and `A`.
 
-  * For `triangular_matrix_left_product`,
-    for `i,j` in the domain of `C`,
-    `i,k` in the domain of `B`, and `k,j` in the domain of `A`, the
-    expression `C(i,j) += B(i,k)*A(k,j)` is well formed.
-
-* *Effects:*
-
-  * `triangular_matrix_left_product` assigns to the elements of the
-    matrix `C` the product of the matrices `A` and `B`.
-
-  * `triangular_matrix_right_product` assigns to the elements of the
-    matrix `C` the product of the matrices `B` and `A`.
-
-###### Updating triangular matrix-matrix product
+###### Updating triangular matrix-matrix left product [linalg.algs.blas3.trmm.up.left]
 
 ```c++
 template<class in_matrix_1_t,
@@ -6075,20 +6086,6 @@ void triangular_matrix_left_product(
   in_matrix_2_t B,
   in_matrix_3_t E,
   out_matrix_t C);
-template<class in_matrix_1_t,
-         class Triangle,
-         class DiagonalStorage,
-         class in_matrix_2_t,
-         class in_matrix_3_t,
-         class out_matrix_t>
-void triangular_matrix_right_product(
-  in_matrix_1_t A,
-  Triangle t,
-  DiagonalStorage d,
-  in_matrix_2_t B,
-  in_matrix_3_t E,
-  out_matrix_t C);
-
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
@@ -6098,6 +6095,32 @@ template<class ExecutionPolicy,
          class out_matrix_t>
 void triangular_matrix_left_product(
   ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+```
+
+* *Constraints:* For `i,j` in the domain of `C`,
+  `i,k` in the domain of `A`, and
+  `k,j` in the domain of `B`,
+  the expression `C(i,j) += E(i,j) + A(i,k)*B(k,j)` is well formed.
+
+* *Effects:* Assigns to the elements of the matrix `C` on output, the
+  elementwise sum of `E` and the product of the matrices `A` and `B`.
+
+###### Updating triangular matrix-matrix right product [linalg.algs.blas3.trmm.up.right]
+
+```c++
+template<class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void triangular_matrix_right_product(
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
@@ -6121,30 +6144,13 @@ void triangular_matrix_right_product(
   out_matrix_t C);
 ```
 
-* *Constraints:*
+* *Constraints:* For `i,j` in the domain of `C`,
+  `i,k` in the domain of `B`, and
+  `k,j` in the domain of `A`,
+  the expression `C(i,j) += E(i,j) + B(i,k)*A(k,j)` is well formed.
 
-  * For `triangular_matrix_left_product`,
-    for `i,j` in the domain of `C`,
-    `i,k` in the domain of `A`, and `k,j` in the domain of `B`, the
-    expression `C(i,j) += E(i,j) + A(i,k)*B(k,j)` is well formed.
-
-  * For `triangular_matrix_right_product`,
-    for `i,j` in the domain of `C`,
-    `i,k` in the domain of `B`, and `k,j` in the domain of `A`, the
-    expression `C(i,j) += E(i,j) + B(i,k)*A(k,j)` is well formed.
-
-* *Effects:*
-
-  * `triangular_matrix_left_product` assigns to the elements of the
-    matrix `C` on output, the elementwise sum of `E` and the product of
-    the matrices `A` and `B`.
-
-  * `triangular_matrix_right_product` assigns to the elements of the
-    matrix `C` on output, the elementwise sum of `E` and the product of
-    the matrices `B` and `A`.
-
-* *Remarks:* `C` and `E` may refer to the same matrix.  If so, then
-  they must have the same layout.
+* *Effects:* Assigns to the elements of the matrix `C` on output, the
+  elementwise sum of `E` and the product of the matrices `B` and `A`.
 
 ##### Rank-2k update of a symmetric or Hermitian matrix [linalg.alg.blas3.rank2k]
 

--- a/D1673/blas_interface.md
+++ b/D1673/blas_interface.md
@@ -2218,7 +2218,7 @@ void triangular_matrix_right_product(
   in_matrix_3_t E,
   out_matrix_t C);
 
-// [linalg.alg.blas3.syr2k],
+// [linalg.alg.blas3.rank2k.syr2k],
 // rank-2k symmetric matrix update
 template<class in_matrix_1_t,
          class in_matrix_2_t,
@@ -2241,7 +2241,7 @@ void symmetric_matrix_rank_2k_update(
   inout_matrix_t C,
   Triangle t);
 
-// [linalg.alg.blas3.her2k],
+// [linalg.alg.blas3.rank2k.her2k],
 // rank-2k Hermitian matrix update
 template<class in_matrix_1_t,
          class in_matrix_2_t,
@@ -6164,7 +6164,7 @@ void triangular_matrix_right_product(
 BLAS functions, by making `C` a `transpose_view` or
 `conjugate_transpose_view`. --*end note]*
 
-###### Rank-2k symmetric matrix update [linalg.alg.blas3.syr2k]
+###### Rank-2k symmetric matrix update [linalg.alg.blas3.rank2k.syr2k]
 
 ```c++
 template<class in_matrix_1_t,
@@ -6240,7 +6240,7 @@ The BLAS "quick reference" has a typo; the "ALPHA" argument of
   specified by the `Triangle` argument `t`, and will assume for
   indices `i,j` outside that triangle, that `C(j,i)` equals `C(i,j)`.
 
-###### Rank-2k Hermitian matrix update [linalg.alg.blas3.her2k]
+###### Rank-2k Hermitian matrix update [linalg.alg.blas3.rank2k.her2k]
 
 ```c++
 template<class in_matrix_1_t,


### PR DESCRIPTION
@crtrott @dhollman @dalg24 @dsunder and friends :-)

The most important change is that the return type of `*_view` is now "see-below".  Implementations have freedom to optimize multiple applications of `layout_transpose`, `accessor_scaled`, `accessor_conjugate`, etc., but are not required to.  I added some Notes to explain this.