### PR TITLE
P0009: Remove noexcept from mdspan

### DIFF
--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -709,89 +709,200 @@ properties will work.
 
 # Description
 
-The proposed polymorphic multidimensional array reference (`mdspan`)
-defines types and functions for mapping multidimensional indices
-in its *domain*, a
-multidimensional index space, to the `mdspan`'s *codomain*,
-elements of a contiguous span of objects.
-A *multidimensional index space* of *rank* <math>R</math>
+## What we propose to add
+
+This paper proposes adding to the C++ Standard Library
+a multidimensional array view, `mdspan`,
+along with classes, class templates, and constants
+for describing and creating multidimensional array views.
+It also proposes adding the `submdspan` function that "slices"
+(returns an `mdspan` that views a subset of) an existing mdspan`.
+
+The `mdspan` class template can represent arbitrary mixes
+of compile-time or run-time extents.
+Its element type can be any complete object type
+that is neither an abstract class type nor an array type.
+It has two customization opportunities for users:
+the *layout mapping* and the *accessor*.
+The layout mapping specifies the formula, and properties of the formula,
+for mapping a multidimensional index to an element of the array.
+The accessor governs how elements are read and written.
+
+## Definitions
+
+A *multidimensional array view* views a multidimensional array,
+just as a `span` views a one-dimensional `array` or `vector`.
+
+A *multidimensional array* of *rank* <math>R</math>
+maps from a tuple of <math>R</math> indices to a single offset index.
+Each of the <math>R</math> indices in the tuple
+is in a bounded range whose inclusive lower bound is zero,
+and whose nonnegative exclusive upper bound is that index's *extent*.
+The array thus has <math>R</math> extents.
+The offset index ranges over a subset of a bounded contiguous index range
+whose lower bound is zero,
+and whose upper bound is the product of the <math>R</math> extents.
+
+More formally, a multidimensional array of rank <math>R</math>
+maps from its *domain*, a multidimensional index space of rank <math>R</math>,
+to its *codomain*, elements of a contiguous span of objects.
+A *multidimensional index space* of rank <math>R</math>
 is the Cartesian product
 <math>[0, N<sub>0</sub>) &#10799; [0, N<sub>1</sub>) &#10799; ... &#10799; [0, N<sub>R-1</sub>)</math>
-of half-open integer intervals.
+of half-open integer intervals,
+where the <math>N<sub>k</sub></math> for <math>k = 0</math>, ..., <math>R-1</math>
+are the array's extents.
 A *multidimensional index*
 is a element of a multidimensional index space.
-An `mdspan` has two policies: the *layout mapping*
-and the *accessor*. The layout mapping specifies the formula, and
-properties of the formula, for mapping a multidimensional index from the domain to
-an element in the codomain. The accessor is an extension point that
-allows modification of how elements are accessed. For example,
-\[P0367](http://wg21.link/p0367)
-proposed a rich set of potential access properties.
 
-<b>The need for multidimensional arrays</b>
-Multidimensional arrays are fundamental data structures in numerous fields, 
-including graphics, mathematics, engineering and general science.
-As a consequence they are a primary language concept in many general purpose 
-(e.g. Python/NumPy, Fortran) and special purpose languages (e.g. Matlab, Julia).
-In fact Fortran had multidimensional arrays as part of its language definition since version I.
-Lately they also have been integral to the newly prominent fields of AI and Machine Learning processing. 
-In fact, one of the predominant Machine Learning libraries is called TensorFlow - and tensors are the quintessiental multidimensional arrays. 
+## Why do we need multidimensional arrays?
 
-<b>A multidimensional array is not an array-of-array-of-array-of...</b>
+Multidimensional arrays are fundamental concepts in many fields,
+including graphics, mathematics, statistics, engineering, and the sciences.
+Many programming languages thus come with multidimensional array data structures
+either as a core language feature,
+or as a tightly integrated standard library.
+Example languages include
+Ada, ANSI Common Lisp, APL, C#, Fortran, Julia, Matlab, Mathematica,
+Pascal, Python (via NumPy), and Visual Basic.
+The original version of the Fortran language for the IBM 704
+featured arrays with one, two, or three extents (Backus 1956, pp. 10-11).
 
-The multidimensional array abstraction has been fundamental to numerical
-computations for over five decades. However, the C/C++ language provides
-only a one-dimensional array abstraction which can be composed into
-array-of-array-of-array-of... types. While such types have some similarity
-to multidimensional arrays, they do not provide adequate multidimensional
-array functionality of this proposal. Two critical functionality
-differences are (1) multiple dynamic extents and (2) polymorphic mapping
-of multidimensional indices to element objects.
+Multidimensional arrays have long been useful
+for representing large amounts of data,
+describing points in physical space,
+or expressing approximations of functions.
+They are a natural way to represent mathematical objects like matrices and tensors.
+This makes multidimensional arrays a critical data structure for many computations
+at the heart of modern machine learning.
+In fact, one of the predominant machine learning frameworks
+is called [TensorFlow](https://www.tensorflow.org/).
 
-<b>Why propose array view before container</b>
+## Why are existing C++ data structures not enough?
 
-One commonality of the above mentioned fields is, that they all rely heavily on 
-parallel programming, where threads access common data.
-Thus view-like semantics express the data ownership semantics - or the lack thereof - better.
-Furthermore, often it is necessary to view pre-existing data as multidimensional views, 
-sometimes with different shapes depending on the operation.
-Last but not least, it is very common in the above use cases to require language interoperability, 
-with parts of the application written in one language and others in a different language. 
-In those cases data is handed over via simple pointers, with the appropriate shaping as 
-multidimensional arrays being superimposed. 
+C++ currently has the following approaches
+that could be used to represent multidimensional arrays:
 
-<b>Mixing Compile-Time and Run-Time Dimensions </b>
+1. "native" arrays where all the extents are compile-time constants,
+  like `int[3][4][5]`;
 
-The fundamental reason to allow for compile time dimensions is performance.
-Knowing an extent at compile time enables a number of compiler optimizations,
-such as unrolling and pre-computing of offsets, which can significantly 
-improve the generated code.
-Furthermore in a number of areas some dimensions are more naturally expressed via 
-compile time extents. 
-For example in many physics and engineering algorithms some dimensions are dictated 
-by fundamental properties of the physical world or the discretization scheme.
-The position of a particle in space requries a vector of extents three, since 
-physical space is three-dimensional.
-At the same time other extents are only known at runtime, such as the number of 
-particles in a simulation. 
-Similarly in Graphics, some of the most fundamental objects are 2x2 or 3x3 matrices. 
-Not carrying around the extents as members is important to conserve register and stack space.
+2. pointer-of-pointers(-of-pointers...), like `int***`,
+  set up as a data structure to view multidimensional data;
 
-<b>Customizable Layout Mappings</b>
+3. arrays-of-arrays(-of-arrays...) data structures,
+  like `vector<vector<array<int, N>>>`; or
 
-One important aspect of allowing customizable layouts is language interoperability.
-C++ arrays have a prescribed layout in memory, with the rightmost index providing stride-1 access
-to the underlying memory. Fortran arrays also have a prescribed layout, however its leftmost
-dimension is providing stride-1 access in memory, the opposite of the C layout.
-Python's NumPy arrays have a configurable layout, to provide compatibility with both C and Fortran.
+4. `gslice`, which selects a subset of indices of a `valarray`
+  and can be used to impose a multidimensional array layout
+  on the `valarray`, in a way analogous to `layout_stride`.
 
-Beyond language interoperability controling the layout can also be used to enable performant memory
-access patterns which may depend on the hardware. Consider the following small code which performs a
-matrix-vector product using parallel algorithms:
+If a multidimensional array has any extents
+that are not known at compile time, Approach (1) does not work.
+
+Approach (2) does not suffice as a stand-alone data structure,
+because a pointer-of-pointers does not carry along
+the array's run-time extents.
+Users thus end up building some subset of `mdspan`'s functionality
+to represent a multidimensional array view.
+Every run-time extent other than the rightmost
+requires a separate memory allocation for an array of pointers.
+A pointer-of-pointers also loses information
+about any dimensions known at compile time.
+Users cannot arbitrarily mix compile-time and run-time extents.
+
+Approach (3) can mix `vector` and `array` to represent extents
+known at run time resp. compile time.
+However, any use of `vector` at any position other than the outermost
+results in the data structure no longer having
+a contiguous memory allocation (or a subset thereof) for the elements.
+This makes the data structure incompatible with many libraries
+that expect a subset of a contiguous allocation.
+Also, every run-time extent other than the rightmost
+requires a separate memory allocation for an array of arrays.
+In addition, each element access requires reading
+multiple memory locations ("pointer chasing").
+Finally, the inlining depth for an element access
+is proportional to the array's rank.
+
+Approach (4) is meant for addressing many elements of a `valarray` all at once.
+Even though `valarray` itself is a one-dimensional array,
+one can use `gslice` to make the `valarray` represent multidimensional data.
+Giving a `gslice` to `valarray::operator[]` returns something that references
+a subset of elements of the original `valarray`.
+However, the result (a `gslice_array` in the nonconst case,
+some type that might be an expression template in the const case)
+is not guaranteed to have an `operator[]`.
+Thus, it's not a view, whereas our proposed `submdspan` function
+always takes and returns a view.
+In the const case, the result might even be a (deep) copy of the input.
+Finally, `gslice` offers no efficient way to address a single element.
+The `gslice` constructor takes strides and lengths as `valarray`s
+and is meant for array-based computation.
+Accessing a single element requires accessing
+the memory of three `valarray`s.
+
+## Mixing compile-time and run-time extents
+
+The fundamental reason to allow expressing extents at compile time is performance.
+Knowing an extent at compile time enables many compiler optimizations,
+such as unrolling and precomputing of offsets.
+These can significantly improve the generated code.
+Not storing extents at run time
+may help conserve registers and stack space.
+
+In many fields, some extents are naturally known at compile time.
+For many physics and engineering algorithms,
+some extents are dictated by fundamental properties of the physical world
+or the discretization scheme.
+For example, the position of a particle in space
+requires a rank-3 array, since physical space has three dimensions.
+At the same time, other extents are only known at run time,
+such as the number of particles in a simulation.
+A natural data structure for storing a list of particles
+would thus be a rank-2 array,
+where the one run-time extent is the number of particles
+and the one compile-time extent is three.
+In graphics, some of the most fundamental objects are square matrices
+with 2, 3, or 4 rows and columns.
+The number of matrices with which one would like to compute
+might only be known at run time.
+This would make a rank-3 array with two compile-time extents
+a natural data structure for the matrices.
+
+## Why custom memory layouts?
+
+Our `mdspan` class template permits custom layouts.
+Our proposal comes with three memory layouts:
+
+* `layout_right`: C or C++ style, row major,
+  where the rightmost index gives stride-1 access to the underlying memory;
+
+* `layout_left`: Fortran or Matlab style, column major,
+  where the leftmost index gives stride-1 access to the underlying memory;
+
+* `layout_stride`: a generalization of the two layouts above,
+  which stores a separate stride (possibly not one) for each extent.
+
+"Custom" layouts besides these could include space-filling curves or "tiled" layouts.
+
+An important reason we allow different layouts is language interoperability.
+For example, C++ and Fortran have different "native" layouts.
+Python's NumPy arrays have a configurable layout,
+to provide compatibility with both languages.
+
+Control of the layout can also be used to write code
+that performs well on different computer architectures
+when only changing a template argument.
+Consider the following implementation of a parallel dense matrix-vector product.
+
+
+
 ```c++
-std::mdspan<double,std::extents<N,M>,layout> A = ...;
-std::mdspan<double,std::extents<N>> y = ...;
-std::mdspan<double,std::extents<M>> x = ...;
+using layout = /* see-below */;
+
+std::mdspan<double, std::extents<N, M>, layout> A = ...;
+std::mdspan<double, std::extents<N>> y = ...;
+std::mdspan<double, std::extents<M>> x = ...;
 
 std::ranges::iota_view range{0, N};
 
@@ -805,66 +916,158 @@ std::for_each(std::execution::par_unseq,
 
 ```
 
-On CPU like architecture this code performs well with a C layout. However
-when offloading the `for_each` to GPUs (which NVIDIA's nvc++ compiler for example does)
-a Fortran-like layout performs much better, since it will enable coalesced data access
-on `A`.
+On conventional CPU architectures,
+this code performs well with `layout = layout_right`,
+the native C++ row-major layout.
+However, when offloading the `for_each` to NVIDIA GPUs
+(which NVIDIA's `nvc++` compiler can do),
+`layout = layout_left` (Fortran's column-major layout) performs much better,
+since it enables coalesced data access on the matrix `A`.
 
-However, it is not enough to have just C-like and Fortran-like memory mappings.
-For example viewing a column of a matrix in C-layout, requires a mapping which expresses
-the stride between elements of the column. The same is true for viewing a sub-tensor of a higher dimensional tensor.
-Furthermore, sometimes there are significant performance benefits to be gained by having 
-even more complex layouts.
-One such index mapping is using tiling to improve data locality for common stencil data access patterns.
-Another reason for tiled layouts is to improve vectorization. For example, Intel's Math Kernel Library
-introduced the Vectorized Compact Routines which provide batched matrix operations, where a number
-of matrices are interleaved, such that vectorized memory access can be performed optimally.
-Another design goal for the customizable layouts is to allow for non-unique layouts.
-This allows multiple index tuples to point to the same memory location. One of its uses is
-to express symmetric data structures, for example symmetric matrices where the value of 
-`A(i,j)` must be the same as `A(j,i)`.
+However, it is not enough to have just C++ and Fortran memory mappings.
+For instance, one way to compute tensor products is to decompose them
+into many matrix-matrix multiplications.
+The resulting decomposition may involve matrices with non-unit strides in both extents.
+This means that they have neither a row-major nor a column-major layout.
 
-<b>Why Customizable Accessors</b>
+More complex layouts can improve performance significantly for some algorithms.
+For instance, tiling (a "matrix of small matrices" layout)
+can improve data locality for many computations
+relevant to linear algebra and the discretization of partial differential equations.
+Tiled layouts can also improve vectorization.
+For example, Intel's Math Kernel Library introduced the Vectorized Compact Routines.
+These provide "batched" matrix operations that increase available parallelism
+by operating on many matrices at once.
+The Vectorized Compact Routines accept matrices in an "interleaved" layout
+that optimizes vectorized memory access.
 
-The accessor concept proposed here, serves as a customization point to provide more
-information to the compiler, or allow the injection of special data access modes. 
-Today most hardware implementations provide more instructions to access data than 
-a simple read and write.
-These include for example instructions which affect caching behavior - such as 
-non-temporal, or even non-coherent loads and stores. 
-Other instructions exist to do hardware provided atomic accesses.
-An important information conveyed to compilers is whether data arrays alias each
-other in some context. Thus C introduced the restrict qualifier in its C99 standard.
-The volatile keyword is yet another qualifier which in C restricts what kind of 
-compiler optimizations can be done, and thus is often used in parallel programming, 
-to ensure (eventual) visbility of memory operations to other threads.
+Another design goal for our custom layouts is to permit nonunique layouts.
+A *nonunique* layout lets multiple index tuples refer to the same element.
+This can save memory for data structures that have natural symmetry.
+For example, if `A` is a symmetric matrix,
+then `A(i,j)` and `A(j,i)` refer to the same element,
+so the element can and should only be stored once.
 
-Another concern accessors can address is the emergence of various memory spaces
-in modern machines. For example custom accessors can convey accessibility by
-host or GPU threads in a typesafe manner, in todays common heterogeneous machines. 
-While we don't propose such accessors here, it is a customization point third party
-libraries could directly use, and is available for eventual extensions of the C++ 
-standard to support such heterogeneous memory.
+## Why custom accessors?
 
-<b> Subspan Support </b>
+Custom accessors can provide information to the compiler,
+or permit the injection of special ways of doing data access.
+Most hardware today has more ways to access data than simple reads and writes.
+For example, some instructions affect caching behavior,
+by making loads and/or stores nontemporal (not cached at some level)
+or even noncoherent.
+Other instructions implement atomic access.
+This is why several of us proposed `atomic_ref`,
+as the heart of an "atomic accessor" for `mdspan`.
+C's `restrict` qualifier conveys whether an array is assumed
+never to alias another array in some context.
+The `volatile` keyword is yet another qualifier
+which limits compiler optimizations around data access.
+Custom `mdspan` accessors can apply `restrict`
+(if the C++ implementation supports this extension)
+or `volatile` to array accesses.
 
-Another aspect of this proposal is the capability to get multi dimensional subspans.
-This includes subspans which maintain the rank of the original array and ones which 
-reduce the rank. 
-It is worth noting that all the above mentioned languages with multidimensional array
-support also provide subspan capabilities.
-One important reason for this is that subspans enable code reuse.
-For example the inner loop in the above described matrix-vector product actually 
-represents a *dot product* - an inner product of two vectors.
-If one already has a function for such an inner product, then using it by obtaining 
-each row of the matrix as a subspan allows its reuse.
+Custom accessors also address concerns relating to heterogeneous memory.
+Standard C++ does not have the idea of
+"memory spaces that normal code cannot access,"
+but many extensions to C++ do have this idea.
+For example, a custom accessor could convey accessibility by CPU or GPU threads,
+so that the compiler would prevent users from accessing GPU memory
+while running on the CPU, or vice versa.
+Multiple memory spaces occur in programming models other than for GPUs.
+For example, "partitioned global address space" models
+have a "global shared memory" that requires special operations to access.
+C++ libraries like [Kokkos](https://github.com/kokkos/kokkos)
+expose access to such memory using an analog of a custom accessor.
+Other accessors could expose an array interface
+to a persistent storage device that is not directly byte addressable.
+We do not propose such accessors here,
+but this is a customization point third-party libraries could directly use,
+and is available for any future extensions of the C++ standard
+for supporting heterogeneous memory.
 
-<b> Reference Implementation </b>
+For a discussion of the idea of accessors and several examples,
+please see (Keryell and Falcou 2016).
 
-A reference implementation under BSD license is available at:
+## Subspan Support
+
+A critical feature of this proposal is `submdspan`,
+the subspan or "slicing" function
+that returns a view of a subset of an existing `mdspan`.
+The result may have any rank up to and including the rank of the input.
+All of the aforementioned languages with multidimensional array support
+provide subspan capabilities.
+Subspans are important because they enable code reuse.
+For example, the inner loop in the dense matrix-vector product described above
+actually represents a *dot product* -- an inner product of two vectors.
+If one already has a function for such an inner product,
+then a natural implementation would simply reuse that function.
+The LAPACK linear algebra library depends on subspan reuse
+for the performance of its one-sided "blocked" matrix factorizations
+(Cholesky, LU, and QR).
+These factorizations reuse textbook non-blocked algorithms
+by calling them on groups of contiguous columns at a time.
+This lets LAPACK spend as much time in dense matrix-matrix multiply
+(or algorithms with analogous performance) as possible.
+
+## Why propose a multidimensional array view before a container?
+
+Factoring views from containers generally makes sense.
+For example, one often sees functions that take `vector` by reference
+when they only need to access the `vector`'s elements or call `.size()` on it.
+This is one reason for `span`.
+Some of us have proposed a multidimensional array container,
+`mdarray` [P1684](wg21.link/p1684),
+but we have focused on `mdspan` because we consider views more fundamental.
+
+Many fields that compute with multidimensional arrays
+rely heavily on shared-memory parallel programming,
+where multiple processing units (threads, vector units, etc.)
+access different elements of the same array in parallel.
+Memory allocation and deallocation are "synchronization points"
+for parallel processing units, and thus hinder parallelization.
+This makes just *viewing* a multidimensional array,
+rather than managing its ownership,
+the most fundamental way for parallel computations
+to express how they access an array.
+
+It is often necessary to view previously allocated memory as a multidimensional array.
+An important special case is when C++ code is calling or being called
+from another programming language, such as C, Fortran, or Python.
+This use case matters enough to Python that its C API
+defines a [Buffer Protocol](https://docs.python.org/3/c-api/buffer.html)
+for viewing multidimensional arrays across languages.
+Language interoperability is key to the success
+of the various Python-based data analysis frameworks
+built up around NumPy.
+
+## Reference Implementation
+
+A reference implementation of this proposal under BSD license is available at:
 [mdspan](https://github.com/kokkos/mdspan).
 This implementation is also available on godbolt for experimentation:
 [godbolt](https://godbolt.org/z/ehErvsTce).
+
+## References
+
+* J. W. Backus et al.
+  "Programmer's Reference Manual: Fortran Automatic Coding System for the IBM 704."
+  Applied Science Division and Programming Research Department,
+  International Business Machines Corporation, Oct. 15, 1956.
+  [Available online](https://archive.computerhistory.org/resources/text/Fortran/102649787.05.01.acc.pdf)
+  (last accessed Oct. 10, 2021).
+
+* D. Hollman, C. Trott, M. Hoemmen, and D. Sunderland.
+  "`mdarray`: An Owning Multidimensional Array Analog of `mdspan`."
+  P1684r0, May 28, 2019.
+  [Available online](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1684r0.pdf)
+  (last accessed Oct. 10, 2021).
+
+* R. Keryell and J. Falcou.
+  "Accessors: A C++ standard library class to qualify data accesses."
+  P0367r0, May 29, 2016.
+  [Available online](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0367r0.pdf)
+  (last accessed Oct. 10, 2021).
 
 Editing Notes
 =============

--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -2208,34 +2208,73 @@ public:
   using reference = typename accessor_type::reference;
 
   // [mdspan.basic.cons], mdspan constructors, assignment, and destructor
-  constexpr mdspan() noexcept = default;
-  constexpr mdspan(const mdspan&) noexcept = default;
-  constexpr mdspan(mdspan&&) noexcept = default;
+  constexpr mdspan() noexcept(
+      noexcept(accessor_type{}) &&
+      noexcept(mapping_type{}) &&
+      noexcept(pointer_type{})) = default;
+  constexpr mdspan(const mdspan& rhs) noexcept(
+      noexcept(accessor_type{rhs.acc_}) &&
+      noexcept(mapping_type{rhs.map_}) &&
+      noexcept(pointer_type{rhs.ptr_})) = default;
+  constexpr mdspan(mdspan&& rhs) noexcept(
+      noexcept(accessor_type{rhs.acc_}) &&
+      noexcept(mapping_type{rhs.map_}) &&
+      noexcept(pointer_type{rhs.ptr_})) = default;
 
   template<class... SizeTypes>
-    explicit constexpr mdspan(pointer p, SizeTypes... dynamic_extents);
+    explicit constexpr mdspan(pointer ptr, SizeTypes... dynamic_extents) noexcept(
+      noexcept(pointer_type{ptr}) &&
+      noexcept(mapping_type(dynamic_extents...)));
+
   template<class SizeType, size_t N>
-    explicit constexpr mdspan(pointer p, const array<SizeType, N>& dynamic_extents);
-  constexpr mdspan(pointer p, const mapping_type& m);
-  constexpr mdspan(pointer p, const mapping_type& m, const accessor_type& a);
+    explicit constexpr mdspan(pointer p, const array<SizeType, N>& dynamic_extents)
+      noexcept(noexcept(apply(
+        [&p](auto tuple_extents) { return mdspan(p, tuple_extents); },
+        []<size_t... ArrayIndices> (index_sequence<ArrayIndices...>) {
+          return make_tuple(dynamic_extents[ArrayIndices]...);
+        } (make_index_sequence<N>()))));
+  constexpr mdspan(pointer p, const mapping_type& m) noexcept(
+    noexcept(accessor_type{}) &&
+    noexcept(mapping_type{m}) &&
+    noexcept(pointer_type{p})) = default;
+
+  constexpr mdspan(pointer p, const mapping_type& m, const accessor_type& a) noexcept(
+    noexcept(accessor_type{a}) &&
+    noexcept(mapping_type{m})) &&
+    noexcept(pointer_type{p}));
   template<class OtherElementType, class OtherExtents, class OtherLayoutPolicy, class OtherAccessorPolicy>
     constexpr mdspan(
-      const mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessorPolicy>& other);
+      const mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessorPolicy>& other) noexcept(
+    noexcept(accessor_type{other.acc_}) &&
+    noexcept(mapping_type{other.map_})) &&
+    noexcept(pointer_type{other.ptr_}));
 
-  constexpr mdspan& operator=(const mdspan&) noexcept = default;
-  constexpr mdspan& operator=(mdspan&&) noexcept = default;
+  constexpr mdspan& operator=(const mdspan& rhs) noexcept(
+    noexcept(declval<accessor_type>() = rhs.acc_) &&
+    noexcept(declval<mapping_type>() = rhs.map_) &&
+    noexcept(declval<pointer_type>() = rhs.ptr_)) = default;
+  constexpr mdspan& operator=(mdspan&& rhs) noexcept(
+    noexcept(declval<accessor_type>() = rhs.acc_) &&
+    noexcept(declval<mapping_type>() = rhs.map_) &&
+    noexcept(declval<pointer_type>() = rhs.ptr_)) = default;
   template<class OtherElementType, class OtherExtents, class OtherLayoutPolicy, class OtherAccessorPolicy>
     constexpr mdspan& operator=(
-      const mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessorPolicy>& other);
+      const mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessorPolicy>& other) noexcept(
+    noexcept(declval<accessor_type>() = other.acc_) &&
+    noexcept(declval<mapping_type>() = other.map_) &&
+    noexcept(declval<pointer_type>() = other.ptr_));
 
   // [mdspan.basic.mapping], mdspan mapping domain multidimensional index to access codomain element
-  constexpr reference operator[](size_type) const noexcept;
+  constexpr reference operator[](size_type) const noexcept(noexcept(acc_.access(ptr_, map_(i))));
   template<class... SizeTypes>
-    constexpr reference operator()(SizeTypes... indices) const noexcept;
+    constexpr reference operator()(SizeTypes... indices) const
+      noexcept(acc_.access(ptr_, map_(indices...)));
   template<class SizeType, size_t N>
-    constexpr reference operator()(const array<SizeType, N>& indices) const noexcept;
+    constexpr reference operator()(const array<SizeType, N>& indices) const
+      noexcept(apply(*this, indices));
 
-  constexpr accessor_type accessor() const { return acc_; }
+  constexpr accessor_type accessor() const
+    noexcept(noexcept(accessor_type{acc_})) { return acc_; }
 
   static constexpr int rank() noexcept { return Extents::rank(); }
   static constexpr int rank_dynamic() noexcept { return Extents::rank_dynamic(); }
@@ -2247,17 +2286,34 @@ public:
   constexpr size_type unique_size() const noexcept;
 
   // [mdspan.basic.codomain], mdspan observers of the codomain
-  constexpr pointer data() const noexcept { return ptr_; }
+  constexpr pointer data() const
+    noexcept(noexcept(pointer{ptr_})) { return ptr_; }
 
-  static constexpr bool is_always_unique() noexcept { return mapping_type::is_always_unique(); }
-  static constexpr bool is_always_contiguous() noexcept { return mapping_type::is_always_contiguous(); }
-  static constexpr bool is_always_strided() noexcept { return mapping_type::is_always_strided(); }
+  static constexpr bool is_always_unique()
+    noexcept(noexcept(mapping_type::is_always_unique())) {
+    return mapping_type::is_always_unique();
+  }
+  static constexpr bool is_always_contiguous()
+    noexcept(noexcept(mapping_type::is_always_contiguous())) {
+    return mapping_type::is_always_contiguous();
+  }
+  static constexpr bool is_always_strided()
+    noexcept(noexcept(mapping_type::is_always_strided())) {
+    return mapping_type::is_always_strided();
+  }
 
-  constexpr mapping_type mapping() const noexcept { return map_; }
-  constexpr bool is_unique() const noexcept { return map_.is_unique(); }
-  constexpr bool is_contiguous() const noexcept { return map_.is_contiguous(); } 
-  constexpr bool is_strided() const noexcept { return map_.is_strided(); }
-  constexpr size_type stride(size_t r) const { return map_.stride(r); }
+  constexpr mapping_type mapping() const
+    noexcept(noexcept(mapping_type{map_})) { return map_; }
+  constexpr bool is_unique() const
+    noexcept(noexcept(map_.is_unique())) { return map_.is_unique(); }
+  constexpr bool is_contiguous() const
+    noexcept(noexcept(map_.is_contiguous())) {
+    return map_.is_contiguous();
+  }
+  constexpr bool is_strided() const
+    noexcept(noexcept(map_.is_strided())) { return map_.is_strided(); }
+  constexpr size_type stride(size_t r) const
+    noexcept(noexcept(map_.stride(r))) { return map_.stride(r); }
 
 private:
   accessor_type acc_{}; // @_exposition only_@
@@ -2302,7 +2358,9 @@ private:
 
 ```c++
 template<class... SizeTypes>
-  explicit constexpr mdspan(pointer ptr, SizeTypes... dynamic_extents);
+  explicit constexpr mdspan(pointer ptr, SizeTypes... dynamic_extents) noexcept(
+      noexcept(pointer_type{ptr}) &&
+      noexcept(mapping_type(dynamic_extents...)));
 ```
 
 * [1]{.pnum} *Constraints:*
@@ -2326,7 +2384,12 @@ template<class... SizeTypes>
 
 ```c++
 template<class SizeType, size_t N>
-  explicit constexpr mdspan(pointer p, const array<SizeType, N>& dynamic_extents);
+  explicit constexpr mdspan(pointer p, const array<SizeType, N>& dynamic_extents)
+    noexcept(noexcept(apply(
+      [&p](auto tuple_extents) { return mdspan(p, tuple_extents); },
+      []<size_t... ArrayIndices> (index_sequence<ArrayIndices...>) {
+        return make_tuple(dynamic_extents[ArrayIndices]...);
+      } (make_index_sequence<N>()))));
 ```
 
 * [4]{.pnum} *Constraints:*
@@ -2345,7 +2408,10 @@ template<class SizeType, size_t N>
 
 
 ```c++
-constexpr mdspan(pointer p, const mapping_type& m);
+constexpr mdspan(pointer p, const mapping_type& m) noexcept(
+    noexcept(accessor_type{}) &&
+    noexcept(mapping_type{m})) &&
+    noexcept(pointer_type{p}));
 ```
 
 * [7]{.pnum} *Constraints:* `is_default_constructible_v<accessor_type>` is `true`.
@@ -2360,7 +2426,10 @@ constexpr mdspan(pointer p, const mapping_type& m);
 
 
 ```c++
-constexpr mdspan(pointer p, const mapping_type& m, const accessor_type& a);
+constexpr mdspan(pointer p, const mapping_type& m, const accessor_type& a) noexcept(
+    noexcept(accessor_type{a}) &&
+    noexcept(mapping_type{m})) &&
+    noexcept(pointer_type{p}));
 ```
 
 * [10]{.pnum}*Effects:*
@@ -2376,7 +2445,10 @@ constexpr mdspan(pointer p, const mapping_type& m, const accessor_type& a);
 
 ```c++
 template<class OtherElementType, class OtherExtents, class OtherLayoutPolicy, class OtherAccessor>
-  constexpr mdspan(const mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessor>& other);
+  constexpr mdspan(const mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessor>& other) noexcept(
+    noexcept(accessor_type{other.acc_}) &&
+    noexcept(mapping_type{other.map_})) &&
+    noexcept(pointer_type{other.ptr_}));
 ```
 
 * [12]{.pnum} *Constraints:*
@@ -2410,7 +2482,10 @@ template<class OtherElementType, class OtherExtents, class OtherLayoutPolicy, cl
 ```c++
 template<class OtherElementType, class OtherExtents, class OtherLayoutPolicy, class OtherAccessor>
   constexpr mdspan& operator=(
-    const mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessor>& other);
+    const mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessor>& other) noexcept(
+    noexcept(declval<accessor_type>() = other.acc_) &&
+    noexcept(declval<mapping_type>() = other.map_) &&
+    noexcept(declval<pointer_type>() = other.ptr_));
 ```
 
 <!-- NOTE is_assignable_v<T, U> means T is assignable from U -->
@@ -2456,7 +2531,8 @@ template<class OtherElementType, class OtherExtents, class OtherLayoutPolicy, cl
 <b>22.7.�.2 `mdspan` members [mdspan.basic.members]</b>
 
 ```c++
-constexpr reference operator[](size_type i) const;
+constexpr reference operator[](size_type i) const
+  noexcept(noexcept(acc_.access(ptr_, map_(i))));
 ```
 
 * [1]{.pnum} *Constraints:* `rank() == 1` is `true`.
@@ -2469,7 +2545,7 @@ constexpr reference operator[](size_type i) const;
 
 ```c++
 template<class... SizeTypes>
-  constexpr reference operator()(SizeTypes... indices) const;
+  constexpr reference operator()(SizeTypes... indices) const noexcept(acc_.access(ptr_, map_(indices...)));
 ```
 
 * [4]{.pnum} *Constraints:*
@@ -2486,7 +2562,7 @@ template<class... SizeTypes>
 
 ```c++
 template<class SizeType, size_t N>
-  constexpr reference operator()(const array<SizeType, N>& indices) const;
+  constexpr reference operator()(const array<SizeType, N>& indices) const noexcept(apply(*this, indices));
 ```
 
 * [8]{.pnum} *Constraints:*

--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -1191,9 +1191,9 @@ namespace std {
   // [mdspan.submdspan]
   template<class ElementType, class Extents, class LayoutPolicy,
            class AccessorPolicy, class... SliceSpecifiers>
-    constexpr mdspan<@_see below_@> submdspan(const mdspan<ElementType,
-                                        Extents, LayoutPolicy, AccessorPolicy>&,
-                                        SliceSpecifiers ...) noexcept;
+    constexpr mdspan<@_see below_@> submdspan(
+      const mdspan<ElementType, Extents, LayoutPolicy, AccessorPolicy>&,
+      SliceSpecifiers ...);
 
   // tag supporting submdspan
   struct full_extent_t { explicit full_extent_t() = default; };
@@ -2213,92 +2213,67 @@ public:
   constexpr mdspan(mdspan&& rhs) = default;
 
   template<class... SizeTypes>
-    explicit constexpr mdspan(pointer ptr, SizeTypes... dynamic_extents) noexcept(
-      noexcept(is_nothrow_default_constructible_v<pointer>) &&
-      noexcept(is_nothrow_constructible_v<mapping_type, SizeTypes...>));
+    explicit constexpr mdspan(pointer ptr, SizeTypes... dynamic_extents);
 
   template<class SizeType, size_t N>
-    explicit constexpr mdspan(pointer p, const array<SizeType, N>& dynamic_extents)
-      noexcept(noexcept(
-        is_nothrow_constructible_v<
-          mdspan<ElementType, Extents, LayoutPolicy, AccessorPolicy>,
-          pointer,
-          extents_type>))
-  constexpr mdspan(pointer p, const mapping_type& m) noexcept(
-    noexcept(accessor_type{}) &&
-    noexcept(mapping_type{m}) &&
-    noexcept(pointer_type{p}));
+    explicit constexpr mdspan(pointer p, const array<SizeType, N>& dynamic_extents);
+  constexpr mdspan(pointer p, const mapping_type& m);
 
-  constexpr mdspan(pointer p, const mapping_type& m, const accessor_type& a) noexcept(
-    noexcept(accessor_type{a}) &&
-    noexcept(mapping_type{m})) &&
-    noexcept(pointer_type{p}));
+  constexpr mdspan(pointer p, const mapping_type& m, const accessor_type& a);
   template<class OtherElementType, class OtherExtents, class OtherLayoutPolicy, class OtherAccessorPolicy>
     constexpr mdspan(
-      const mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessorPolicy>& other) noexcept(
-    noexcept(accessor_type{other.acc_}) &&
-    noexcept(mapping_type{other.map_})) &&
-    noexcept(pointer_type{other.ptr_}));
+      const mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessorPolicy>& other);
 
   constexpr mdspan& operator=(const mdspan& rhs) = default;
   constexpr mdspan& operator=(mdspan&& rhs) = default;
   template<class OtherElementType, class OtherExtents, class OtherLayoutPolicy, class OtherAccessorPolicy>
     constexpr mdspan& operator=(
-      const mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessorPolicy>& other) noexcept(
-    noexcept(declval<accessor_type>() = other.acc_) &&
-    noexcept(declval<mapping_type>() = other.map_) &&
-    noexcept(declval<pointer_type>() = other.ptr_));
+      const mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessorPolicy>& other);
 
   // [mdspan.basic.mapping], mdspan mapping domain multidimensional index to access codomain element
-  constexpr reference operator[](size_type) const noexcept(noexcept(acc_.access(ptr_, map_(i))));
+  constexpr reference operator[](size_type) const;
   template<class... SizeTypes>
-    constexpr reference operator()(SizeTypes... indices) const
-      noexcept(acc_.access(ptr_, map_(indices...)));
+    constexpr reference operator()(SizeTypes... indices) const;
   template<class SizeType, size_t N>
-    constexpr reference operator()(const array<SizeType, N>& indices) const
-      noexcept(apply(*this, indices));
+    constexpr reference operator()(const array<SizeType, N>& indices) const;
 
-  constexpr accessor_type accessor() const
-    noexcept(noexcept(accessor_type{acc_})) { return acc_; }
+  constexpr accessor_type accessor() const { return acc_; }
 
-  static constexpr int rank() noexcept { return Extents::rank(); }
-  static constexpr int rank_dynamic() noexcept { return Extents::rank_dynamic(); }
-  static constexpr size_type static_extent(size_t r) noexcept { return Extents::static_extent(r); }
+  static constexpr int rank() { return Extents::rank(); }
+  static constexpr int rank_dynamic() { return Extents::rank_dynamic(); }
+  static constexpr size_type static_extent(size_t r) { return Extents::static_extent(r); }
 
-  constexpr Extents extents() const noexcept { return map_.extents(); }
-  constexpr size_type extent(size_t r) const noexcept { return extents().extent(r); }
-  constexpr size_type size() const noexcept;
-  constexpr size_type unique_size() const noexcept;
+  constexpr Extents extents() const { return map_.extents(); }
+  constexpr size_type extent(size_t r) const { return extents().extent(r); }
+  constexpr size_type size() const;
+  constexpr size_type unique_size() const;
 
   // [mdspan.basic.codomain], mdspan observers of the codomain
-  constexpr pointer data() const
-    noexcept(noexcept(pointer{ptr_})) { return ptr_; }
+  constexpr pointer data() const { return ptr_; }
 
-  static constexpr bool is_always_unique()
-    noexcept(noexcept(mapping_type::is_always_unique())) {
+  static constexpr bool is_always_unique() {
     return mapping_type::is_always_unique();
   }
-  static constexpr bool is_always_contiguous()
-    noexcept(noexcept(mapping_type::is_always_contiguous())) {
+  static constexpr bool is_always_contiguous() {
     return mapping_type::is_always_contiguous();
   }
-  static constexpr bool is_always_strided()
-    noexcept(noexcept(mapping_type::is_always_strided())) {
+  static constexpr bool is_always_strided() {
     return mapping_type::is_always_strided();
   }
 
-  constexpr mapping_type mapping() const
-    noexcept(noexcept(mapping_type{map_})) { return map_; }
-  constexpr bool is_unique() const
-    noexcept(noexcept(map_.is_unique())) { return map_.is_unique(); }
-  constexpr bool is_contiguous() const
-    noexcept(noexcept(map_.is_contiguous())) {
+  constexpr mapping_type mapping() const { return map_; }
+  constexpr bool is_unique() const {
+    return map_.is_unique();
+  }
+  constexpr bool is_contiguous() const {
     return map_.is_contiguous();
   }
-  constexpr bool is_strided() const
-    noexcept(noexcept(map_.is_strided())) { return map_.is_strided(); }
-  constexpr size_type stride(size_t r) const
-    noexcept(noexcept(map_.stride(r))) { return map_.stride(r); }
+  constexpr bool is_strided() const {
+    return map_.is_strided();
+  }
+  constexpr size_type stride(size_t r) const {
+    return map_.stride(r);
+  }
 
 private:
   accessor_type acc_{}; // @_exposition only_@
@@ -2343,9 +2318,7 @@ private:
 
 ```c++
 template<class... SizeTypes>
-  explicit constexpr mdspan(pointer ptr, SizeTypes... dynamic_extents) noexcept(
-      noexcept(pointer_type{ptr}) &&
-      noexcept(mapping_type(dynamic_extents...)));
+  explicit constexpr mdspan(pointer ptr, SizeTypes... dynamic_extents);
 ```
 
 * [1]{.pnum} *Constraints:*
@@ -2369,12 +2342,7 @@ template<class... SizeTypes>
 
 ```c++
 template<class SizeType, size_t N>
-  explicit constexpr mdspan(pointer p, const array<SizeType, N>& dynamic_extents)
-    noexcept(noexcept(apply(
-      [&p](auto tuple_extents) { return mdspan(p, tuple_extents); },
-      []<size_t... ArrayIndices> (index_sequence<ArrayIndices...>) {
-        return make_tuple(dynamic_extents[ArrayIndices]...);
-      } (make_index_sequence<N>()))));
+  explicit constexpr mdspan(pointer p, const array<SizeType, N>& dynamic_extents);
 ```
 
 * [4]{.pnum} *Constraints:*
@@ -2393,10 +2361,7 @@ template<class SizeType, size_t N>
 
 
 ```c++
-constexpr mdspan(pointer p, const mapping_type& m) noexcept(
-    noexcept(accessor_type{}) &&
-    noexcept(mapping_type{m})) &&
-    noexcept(pointer_type{p}));
+constexpr mdspan(pointer p, const mapping_type& m);
 ```
 
 * [7]{.pnum} *Constraints:* `is_default_constructible_v<accessor_type>` is `true`.
@@ -2411,10 +2376,7 @@ constexpr mdspan(pointer p, const mapping_type& m) noexcept(
 
 
 ```c++
-constexpr mdspan(pointer p, const mapping_type& m, const accessor_type& a) noexcept(
-    noexcept(accessor_type{a}) &&
-    noexcept(mapping_type{m})) &&
-    noexcept(pointer_type{p}));
+constexpr mdspan(pointer p, const mapping_type& m, const accessor_type& a);
 ```
 
 * [10]{.pnum}*Effects:*
@@ -2430,10 +2392,7 @@ constexpr mdspan(pointer p, const mapping_type& m, const accessor_type& a) noexc
 
 ```c++
 template<class OtherElementType, class OtherExtents, class OtherLayoutPolicy, class OtherAccessor>
-  constexpr mdspan(const mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessor>& other) noexcept(
-    noexcept(accessor_type{other.acc_}) &&
-    noexcept(mapping_type{other.map_})) &&
-    noexcept(pointer_type{other.ptr_}));
+  constexpr mdspan(const mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessor>& other);
 ```
 
 * [12]{.pnum} *Constraints:*
@@ -2467,10 +2426,7 @@ template<class OtherElementType, class OtherExtents, class OtherLayoutPolicy, cl
 ```c++
 template<class OtherElementType, class OtherExtents, class OtherLayoutPolicy, class OtherAccessor>
   constexpr mdspan& operator=(
-    const mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessor>& other) noexcept(
-    noexcept(declval<accessor_type>() = other.acc_) &&
-    noexcept(declval<mapping_type>() = other.map_) &&
-    noexcept(declval<pointer_type>() = other.ptr_));
+    const mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessor>& other);
 ```
 
 <!-- NOTE is_assignable_v<T, U> means T is assignable from U -->
@@ -2516,8 +2472,7 @@ template<class OtherElementType, class OtherExtents, class OtherLayoutPolicy, cl
 <b>22.7.�.2 `mdspan` members [mdspan.basic.members]</b>
 
 ```c++
-constexpr reference operator[](size_type i) const
-  noexcept(noexcept(acc_.access(ptr_, map_(i))));
+constexpr reference operator[](size_type i) const;
 ```
 
 * [1]{.pnum} *Constraints:* `rank() == 1` is `true`.
@@ -2530,7 +2485,7 @@ constexpr reference operator[](size_type i) const
 
 ```c++
 template<class... SizeTypes>
-  constexpr reference operator()(SizeTypes... indices) const noexcept(acc_.access(ptr_, map_(indices...)));
+  constexpr reference operator()(SizeTypes... indices) const;
 ```
 
 * [4]{.pnum} *Constraints:*
@@ -2547,7 +2502,7 @@ template<class... SizeTypes>
 
 ```c++
 template<class SizeType, size_t N>
-  constexpr reference operator()(const array<SizeType, N>& indices) const noexcept(apply(*this, indices));
+  constexpr reference operator()(const array<SizeType, N>& indices) const;
 ```
 
 * [8]{.pnum} *Constraints:*
@@ -2563,13 +2518,13 @@ template<class SizeType, size_t N>
 
 
 ```c++
-constexpr size_type size() const noexcept;
+constexpr size_type size() const;
 ```
 
 * [11]{.pnum} *Returns:* Product of `extent(r)` for all `r` in the range `[0, Extents::rank())`.
 
 ```c++
-constexpr size_type unique_size() const noexcept;
+constexpr size_type unique_size() const;
 ```
 
 * [12]{.pnum} *Returns:* The number of unique elements in the codomain.
@@ -2609,7 +2564,7 @@ namespace std {
            class AccessorPolicy, class... SliceSpecifiers>
       constexpr mdspan<@_see below_@>
       submdspan(const mdspan<ElementType, Extents, LayoutPolicy,
-                             AccessorPolicy>& src, SliceSpecifiers... slices) noexcept;
+                             AccessorPolicy>& src, SliceSpecifiers... slices);
 }
 ```
 

--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -78,6 +78,7 @@ Attendance: 25; Number of authors: 1 [presumably for P2299, as P0009 coauthors w
 - Adapted new LWG wording guidelines by replacing "Expects" with "Preconditions"
 - Minor formatting corrections
 - Added design discussion as requested by LEWG
+- Remove unconditional `noexcept` from `mdspan`
 
 ## P0009r12: post 2021-05 Mailing
 - Fixed definition of `static_extent`

--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -2208,35 +2208,26 @@ public:
   using reference = typename accessor_type::reference;
 
   // [mdspan.basic.cons], mdspan constructors, assignment, and destructor
-  constexpr mdspan() noexcept(
-      noexcept(accessor_type{}) &&
-      noexcept(mapping_type{}) &&
-      noexcept(pointer_type{})) = default;
-  constexpr mdspan(const mdspan& rhs) noexcept(
-      noexcept(accessor_type{rhs.acc_}) &&
-      noexcept(mapping_type{rhs.map_}) &&
-      noexcept(pointer_type{rhs.ptr_})) = default;
-  constexpr mdspan(mdspan&& rhs) noexcept(
-      noexcept(accessor_type{rhs.acc_}) &&
-      noexcept(mapping_type{rhs.map_}) &&
-      noexcept(pointer_type{rhs.ptr_})) = default;
+  constexpr mdspan() = default;
+  constexpr mdspan(const mdspan& rhs) = default;
+  constexpr mdspan(mdspan&& rhs) = default;
 
   template<class... SizeTypes>
     explicit constexpr mdspan(pointer ptr, SizeTypes... dynamic_extents) noexcept(
-      noexcept(pointer_type{ptr}) &&
-      noexcept(mapping_type(dynamic_extents...)));
+      noexcept(is_nothrow_default_constructible_v<pointer>) &&
+      noexcept(is_nothrow_constructible_v<mapping_type, SizeTypes...>));
 
   template<class SizeType, size_t N>
     explicit constexpr mdspan(pointer p, const array<SizeType, N>& dynamic_extents)
-      noexcept(noexcept(apply(
-        [&p](auto tuple_extents) { return mdspan(p, tuple_extents); },
-        []<size_t... ArrayIndices> (index_sequence<ArrayIndices...>) {
-          return make_tuple(dynamic_extents[ArrayIndices]...);
-        } (make_index_sequence<N>()))));
+      noexcept(noexcept(
+        is_nothrow_constructible_v<
+          mdspan<ElementType, Extents, LayoutPolicy, AccessorPolicy>,
+          pointer,
+          extents_type>))
   constexpr mdspan(pointer p, const mapping_type& m) noexcept(
     noexcept(accessor_type{}) &&
     noexcept(mapping_type{m}) &&
-    noexcept(pointer_type{p})) = default;
+    noexcept(pointer_type{p}));
 
   constexpr mdspan(pointer p, const mapping_type& m, const accessor_type& a) noexcept(
     noexcept(accessor_type{a}) &&
@@ -2249,14 +2240,8 @@ public:
     noexcept(mapping_type{other.map_})) &&
     noexcept(pointer_type{other.ptr_}));
 
-  constexpr mdspan& operator=(const mdspan& rhs) noexcept(
-    noexcept(declval<accessor_type>() = rhs.acc_) &&
-    noexcept(declval<mapping_type>() = rhs.map_) &&
-    noexcept(declval<pointer_type>() = rhs.ptr_)) = default;
-  constexpr mdspan& operator=(mdspan&& rhs) noexcept(
-    noexcept(declval<accessor_type>() = rhs.acc_) &&
-    noexcept(declval<mapping_type>() = rhs.map_) &&
-    noexcept(declval<pointer_type>() = rhs.ptr_)) = default;
+  constexpr mdspan& operator=(const mdspan& rhs) = default;
+  constexpr mdspan& operator=(mdspan&& rhs) = default;
   template<class OtherElementType, class OtherExtents, class OtherLayoutPolicy, class OtherAccessorPolicy>
     constexpr mdspan& operator=(
       const mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessorPolicy>& other) noexcept(


### PR DESCRIPTION
@crtrott @dalg24 @nliber @brycelelbach 

Edited: Remove all `noexcept` from `mdspan`, per current library wording guidance.  Please see, e.g., [P0884r0](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0884r0.pdf).  Leave noexcept everywhere else without changes.

~Make all of `mdspan`'s public methods conditionally `noexcept`.  This is based on PR #155 (please merge that first; thanks!).~

~This does not yet have the `operator[]` changes due to P2128.  That should make the uncertainty about how to `noexcept`-ify single-index `operator[]` go away (since single-index `operator[]` will go away).~

