### PR TITLE
Fix required_span_size for degenerated mdspan and rank-0 mdspan

### DIFF
--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -79,6 +79,8 @@ Attendance: 25; Number of authors: 1 [presumably for P2299, as P0009 coauthors w
 - Minor formatting corrections
 - Added design discussion as requested by LEWG
 - Remove unconditional `noexcept` from `mdspan`
+- Fix layout `required_span_size` for rank-0 mdspan.
+- Fix `layout_stride::required_span_size` for mdspans with at least one extent being zero
 
 ## P0009r12: post 2021-05 Mailing
 - Fixed definition of `static_extent`
@@ -1643,7 +1645,7 @@ template<class OtherExtents>
 constexpr size_type required_span_size() const noexcept;
 ```
 
-* [5]{.pnum} *Returns:* The product of `extents().extent(r)` for all `r` in the range $[0,$ `Extents::rank()` $)$.
+* [5]{.pnum} *Returns:* If `Extents::rank() > 0` is true, returns the product of `extents().extent(r)` for all `r` in the range $[0,$ `Extents::rank()` $)$. Otherwise, returns 1.
 
 
 ```c++
@@ -1784,7 +1786,7 @@ template<class OtherExtents>
 size_type required_span_size() const noexcept;
 ```
 
-* [5]{.pnum} *Returns:* The product of `extents().extent(r)` for all `r` in the range $[0,$ `Extents::rank()` $)$.
+* [5]{.pnum} *Returns:* If `Extents::rank() > 0` is true, returns the product of `extents().extent(r)` for all `r` in the range $[0,$ `Extents::rank()` $)$. Otherwise, returns 1.
 
 ```c++
 template<class... Indices> 
@@ -1944,7 +1946,7 @@ template<class OtherExtents>
 ```c++
 constexpr size_type required_span_size() const noexcept;
 ```
-* [7]{.pnum} *Returns:* The maximum of `extents().extent(r) * stride(r)` for all `r` in the range $[0,$ `Extents::rank()` $)$.
+* [7]{.pnum} *Returns:* If `(extents().extent(r) > 0) && (Extents::rank() > 0)` is true for all `r` in the range $[0,$ `Extents::rank()`, returns the maximum of `extents().extent(r) * stride(r)` for all `r` in the range $[0,$ `Extents::rank()` $)$. Otherwise, returns `Extents::rank() == 0 ? 1 : 0`.
 
 
 ```c++

--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -1946,7 +1946,7 @@ template<class OtherExtents>
 ```c++
 constexpr size_type required_span_size() const noexcept;
 ```
-* [7]{.pnum} *Returns:* If `(extents().extent(r) > 0) && (Extents::rank() > 0)` is true for all `r` in the range $[0,$ `Extents::rank()`, the maximum of `extents().extent(r) * stride(r)` for all `r` in the range $[0,$ `Extents::rank()` $)$. Otherwise, `Extents::rank() == 0 ? 1 : 0`.
+* [7]{.pnum} *Returns:* If `(Extents::rank() > 0)` is true and `(extents().extent(r) > 0)` is true for all `r` in the range $[0,$ `Extents::rank()` $)$, the maximum of `extents().extent(r) * stride(r)` for all `r` in the range $[0,$ `Extents::rank()` $)$. Otherwise, `Extents::rank() == 0 ? 1 : 0`.
 
 
 ```c++

--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -1309,9 +1309,9 @@ The $r^{th}$ interval of an `extents` is as follows:
 constexpr size_t dynamic_index(size_t i) noexcept; // @_exposition only_@
 ```
 
-* [5]{.pnum} *Returns*: If `i <= sizeof...(Extents)` is `true`, returns the number of arguments 
+* [5]{.pnum} *Returns*: If `i <= sizeof...(Extents)` is `true`, the number of arguments 
 before the `i`_th_ template parameter in the template parameter pack `Extents` 
-equivalent to `dynamic_extent`.  Otherwise, returns `rank_dynamic()`.
+equivalent to `dynamic_extent`.  Otherwise, `rank_dynamic()`.
 
 
 <b>22.7.�.3 Constructors and assignment [mdspan.extents.cons]</b>
@@ -1645,7 +1645,7 @@ template<class OtherExtents>
 constexpr size_type required_span_size() const noexcept;
 ```
 
-* [5]{.pnum} *Returns:* If `Extents::rank() > 0` is true, returns the product of `extents().extent(r)` for all `r` in the range $[0,$ `Extents::rank()` $)$. Otherwise, returns 1.
+* [5]{.pnum} *Returns:* If `Extents::rank() > 0` is true, the product of `extents().extent(r)` for all `r` in the range $[0,$ `Extents::rank()` $)$. Otherwise, 1.
 
 
 ```c++
@@ -1786,7 +1786,7 @@ template<class OtherExtents>
 size_type required_span_size() const noexcept;
 ```
 
-* [5]{.pnum} *Returns:* If `Extents::rank() > 0` is true, returns the product of `extents().extent(r)` for all `r` in the range $[0,$ `Extents::rank()` $)$. Otherwise, returns 1.
+* [5]{.pnum} *Returns:* If `Extents::rank() > 0` is true, the product of `extents().extent(r)` for all `r` in the range $[0,$ `Extents::rank()` $)$. Otherwise, 1.
 
 ```c++
 template<class... Indices> 
@@ -1946,7 +1946,7 @@ template<class OtherExtents>
 ```c++
 constexpr size_type required_span_size() const noexcept;
 ```
-* [7]{.pnum} *Returns:* If `(extents().extent(r) > 0) && (Extents::rank() > 0)` is true for all `r` in the range $[0,$ `Extents::rank()`, returns the maximum of `extents().extent(r) * stride(r)` for all `r` in the range $[0,$ `Extents::rank()` $)$. Otherwise, returns `Extents::rank() == 0 ? 1 : 0`.
+* [7]{.pnum} *Returns:* If `(extents().extent(r) > 0) && (Extents::rank() > 0)` is true for all `r` in the range $[0,$ `Extents::rank()`, the maximum of `extents().extent(r) * stride(r)` for all `r` in the range $[0,$ `Extents::rank()` $)$. Otherwise, `Extents::rank() == 0 ? 1 : 0`.
 
 
 ```c++


### PR DESCRIPTION
The wording didn't take into account a situation where one of the extents is 0.
It also didn't take into account rank-0 mdspan.