### PR TITLE
P0009: Add operator[]; remove reference to "span"

### DIFF
--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -1051,7 +1051,7 @@ Language interoperability is key to the success
 of the various Python-based data analysis frameworks
 built up around NumPy.
 
-## Options for the array access operator
+## Use multiple-parameter operator[] for array access
 
 We welcome multiple-parameter `operator[]`
 as the preferred multidimensional array access operator.
@@ -1061,84 +1061,17 @@ by deprecating comma expressions inside `operator[]` invocations.
 [P2128R6](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2128r6.pdf),
 which proposed changing `operator[]` to accept multiple parameters,
 was approved at the October 2021 WG21 Plenary meeting.
+Please refer to P2128 for an extensive discussion.
 
-C++ libraries implementing multidimensional arrays
-have used several different work-arounds over the years
-for the lack of multiple-parameter `operator[]`.
-P2128 discusses these extensively.
-Previous versions of our `mdspan` proposal used the function call operator
-(parentheses, instead of square brackets) for multidimensional array access,
+Many existing libraries use the function call `operator()`
+for multidimensional array access,
 with `operator[]` available for rank-1 (single-dimensional) `mdspan`.
-Using `operator()` as a work-around was a popular choice
-among multidimensional array libraries, as P2128 explains.
-In fact, it was such a popular choice that it leaves us
-with a decision:
-
-1. do we adopt `operator[]` and remove `operator()`, or
-
-2. do we adopt `operator[]` and keep `operator()`
-   for backwards compatibility with existing code?
-
-Note that no coauthors considered *not* adopting `operator[]`.
-All of us have welcomed `operator[]` without reservations.
-The only question for us is,
-"Do we want to remove or keep `operator()`
-as an array access operator for `mdspan`?"
-We will summarize the arguments for both sides.
-
-### Remove operator()
-
-[P2128R6](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2128r6.pdf),
-specifically the "Function call operator" section (p. 4),
-argues that `mdspan` should not use `operator()` at all.
-This section reprises some of the arguments there.
-
-First, using `operator[]` and not `operator()`
-helps the compiler catch errors at compile time
-due to mixing up the order of invocables and multidimensional arrays.
-The resulting error messages can be easier to understand.
-C++ libraries (and even the language itself, with coroutines)
-increasingly offer users interfaces for
-asynchronous (or at least deferred) computation.
-The resulting separation of the actual computation from the call site
-makes it even more important to detect errors at compile time
-as much as possible.
-
-For example, consider an asynchronous function `combine(f, A, B, C)`
-that is templated on all four parameters.
-It applies the binary function `f` elementwise
-to the rank-2 arrays `A` and `B`,
-assigning the results to the elements of the rank-2 arrays `C`.
-If multidimensional array access can only use `operator[]`,
-then the "inner loop" of `combine` would look like this:
-`C[i,j] = f(A[i,j], B[i,j])`.
-In this case, the typo `combine(A, f, B, C)` would not compile,
-and the error message would explain that `A` has no `operator()`.
-However, if `mdspan` permits `operator()`,
-then the implementer of `combine` could get away with
-`C(i,j) = f(A(i,j), B(i,j))`.
-In that case, depending on the element types of `A` and `B`,
-the typo `combine(A, f, B, C)` might compile.
-If it does, the resulting run-time errors would likely be hard to debug.
-Even if not, the compilation errors would be harder to understand.
-
-Second, retaining `operator()` would confuse users.
-One anecdote we gathered, is that it puzzles novice C++ programmers
-to see what appears to be a function call
-on the left-hand side of an assignment, as in `a(x,y,z) = 42`.
-One imagines information flowing out of function calls, not into them.
-The distinct syntax `a[x,y,z] = 42` avoids this confusion.
-
-Third, it's straightforward to adapt existing code
-that uses `operator()` for multidimensional array access.
-A subclass or wrapper of `mdspan` can provide an `operator()`
+P2128 gives examples.
+It's straightforward to adapt these libraries to transition to `mdspan`.
+For example, a subclass or wrapper of `mdspan` can provide an `operator()`
 that simply forwards to `mdspan::operator[]`.
 The subclass or wrapper can then deprecate `operator()`
 to help developers find and change all the code that uses it.
-
-### Keep operator()
-
-TODO
 
 ## Reference Implementation
 

--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -2693,9 +2693,7 @@ delete [] ptr;
 Next Steps
 ==========
 
-We would like LEWG to poll on sending P0009 ('mdspan') to LWG for C++23 instead of
-C++ Library Fundamentals Technical Specification version 3, classified as an addition
-(P0592R4 bucket 3 item).
+We would like LEWG to poll on sending P0009 ('mdspan') to LWG for C++23.
 
 
 Implementation
@@ -2707,18 +2705,9 @@ There is an mdspan implementation available at [https://github.com/kokkos/mdspan
 Related Work
 ============
 
-[LEWG issue](https://issues.isocpp.org/show_bug.cgi?id=80)
-
-<b>Previous paper:</b>
-
--   [[N4355]]
-
-<b>P0860 : Access Policy Generating Proxy Reference</b>
-
-The `reference` type may be a proxy for accessing an `element_type`
-object. For example, the *atomic* `AccessorPolicy` in <b>P0860</b> defines
-`AccessorPolicy::template accessor_type<T>::reference` to be `atomic_ref<T>` from
-<b>P0019</b>.
+The original version of this paper,
+[N4355](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4355.pdf),
+predates the "P" naming for papers.
 
 <b>Related papers:</b>
 

--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -79,8 +79,13 @@ Attendance: 25; Number of authors: 1 [presumably for P2299, as P0009 coauthors w
 - Minor formatting corrections
 - Added design discussion as requested by LEWG
 - Remove unconditional `noexcept` from `mdspan`
-- Fix layout `required_span_size` for rank-0 mdspan.
+- Fix layout `required_span_size` for rank-0 mdspan
 - Fix `layout_stride::required_span_size` for mdspans with at least one extent being zero
+- Use `operator[]` in `mdspan` for multidimensional array access,
+  and add explanation to Discussion section
+- Remove reference to `span` in the `mdspan` wording,
+  since `mdspan` does not necessarily require a backing `span`
+  (because `pointer` need not be `ElementType*`)
 
 ## P0009r12: post 2021-05 Mailing
 - Fixed definition of `static_extent`
@@ -913,8 +918,10 @@ std::for_each(std::execution::par_unseq,
   std::ranges::begin(range), std::ranges::end(range),
   [=](int i) {
      double sum = 0.0;
-     for(int j=0; j<M; j++) sum += A(i,j) * x(j);
-     y(i) = sum;
+     for(int j = 0; j < M; ++j) {
+       sum += A[i, j] * x[j];
+     }
+     y[i] = sum;
   });
 
 ```
@@ -948,7 +955,7 @@ Another design goal for our custom layouts is to permit nonunique layouts.
 A *nonunique* layout lets multiple index tuples refer to the same element.
 This can save memory for data structures that have natural symmetry.
 For example, if `A` is a symmetric matrix,
-then `A(i,j)` and `A(j,i)` refer to the same element,
+then `A[i,j]` and `A[j,i]` refer to the same element,
 so the element can and should only be stored once.
 
 ## Why custom accessors?
@@ -1044,6 +1051,95 @@ Language interoperability is key to the success
 of the various Python-based data analysis frameworks
 built up around NumPy.
 
+## Options for the array access operator
+
+We welcome multiple-parameter `operator[]`
+as the preferred multidimensional array access operator.
+[P1161R3](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1161r3.html),
+now part of C++20, prepared the way for this
+by deprecating comma expressions inside `operator[]` invocations.
+[P2128R6](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2128r6.pdf),
+which proposed changing `operator[]` to accept multiple parameters,
+was approved at the October 2021 WG21 Plenary meeting.
+
+C++ libraries implementing multidimensional arrays
+have used several different work-arounds over the years
+for the lack of multiple-parameter `operator[]`.
+P2128 discusses these extensively.
+Previous versions of our `mdspan` proposal used the function call operator
+(parentheses, instead of square brackets) for multidimensional array access,
+with `operator[]` available for rank-1 (single-dimensional) `mdspan`.
+Using `operator()` as a work-around was a popular choice
+among multidimensional array libraries, as P2128 explains.
+In fact, it was such a popular choice that it leaves us
+with a decision:
+
+1. do we adopt `operator[]` and remove `operator()`, or
+
+2. do we adopt `operator[]` and keep `operator()`
+   for backwards compatibility with existing code?
+
+Note that no coauthors considered *not* adopting `operator[]`.
+All of us have welcomed `operator[]` without reservations.
+The only question for us is,
+"Do we want to remove or keep `operator()`
+as an array access operator for `mdspan`?"
+We will summarize the arguments for both sides.
+
+### Remove operator()
+
+[P2128R6](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2128r6.pdf),
+specifically the "Function call operator" section (p. 4),
+argues that `mdspan` should not use `operator()` at all.
+This section reprises some of the arguments there.
+
+First, using `operator[]` and not `operator()`
+helps the compiler catch errors at compile time
+due to mixing up the order of invocables and multidimensional arrays.
+The resulting error messages can be easier to understand.
+C++ libraries (and even the language itself, with coroutines)
+increasingly offer users interfaces for
+asynchronous (or at least deferred) computation.
+The resulting separation of the actual computation from the call site
+makes it even more important to detect errors at compile time
+as much as possible.
+
+For example, consider an asynchronous function `combine(f, A, B, C)`
+that is templated on all four parameters.
+It applies the binary function `f` elementwise
+to the rank-2 arrays `A` and `B`,
+assigning the results to the elements of the rank-2 arrays `C`.
+If multidimensional array access can only use `operator[]`,
+then the "inner loop" of `combine` would look like this:
+`C[i,j] = f(A[i,j], B[i,j])`.
+In this case, the typo `combine(A, f, B, C)` would not compile,
+and the error message would explain that `A` has no `operator()`.
+However, if `mdspan` permits `operator()`,
+then the implementer of `combine` could get away with
+`C(i,j) = f(A(i,j), B(i,j))`.
+In that case, depending on the element types of `A` and `B`,
+the typo `combine(A, f, B, C)` might compile.
+If it does, the resulting run-time errors would likely be hard to debug.
+Even if not, the compilation errors would be harder to understand.
+
+Second, retaining `operator()` would confuse users.
+One anecdote we gathered, is that it puzzles novice C++ programmers
+to see what appears to be a function call
+on the left-hand side of an assignment, as in `a(x,y,z) = 42`.
+One imagines information flowing out of function calls, not into them.
+The distinct syntax `a[x,y,z] = 42` avoids this confusion.
+
+Third, it's straightforward to adapt existing code
+that uses `operator()` for multidimensional array access.
+A subclass or wrapper of `mdspan` can provide an `operator()`
+that simply forwards to `mdspan::operator[]`.
+The subclass or wrapper can then deprecate `operator()`
+to help developers find and change all the code that uses it.
+
+### Keep operator()
+
+TODO
+
 ## Reference Implementation
 
 A reference implementation of this proposal under BSD license is available at:
@@ -1136,7 +1232,7 @@ Y88b  d88P Y88b 888 888  888 Y88..88P 888 d88P      X88 888      X88
 <br/>
 <b>22.7.� Header `<mdspan>` synopsis [mdspan.syn]</b>
 
-```cpp
+```c++
 namespace std {
   // [mdspan.extents], class template extents
   template<size_t... Extents>
@@ -1241,7 +1337,7 @@ Y8b.     .d8""8b. Y88b. Y8b.     888  888 Y88b.       X88
 
 
 
-```cpp
+```c++
 namespace std {
 
 template<size_t... Extents>
@@ -1305,7 +1401,7 @@ The $r^{th}$ interval of an `extents` is as follows:
 
 ---
 
-```cpp
+```c++
 constexpr size_t dynamic_index(size_t i) noexcept; // @_exposition only_@
 ```
 
@@ -1562,7 +1658,7 @@ Table � — Layout mapping policy and layout mapping requirements
 
 [4]{.pnum} If `Extents` is not a (possibly cv-qualified) specialization of `extents`, then the program is ill-formed.
 
-```cpp
+```c++
 namespace std {
 
 struct layout_left {
@@ -1700,7 +1796,7 @@ template<class OtherExtents>
 
 [4]{.pnum} If `Extents` is not a (possibly cv-qualified) specialization of `extents`, then the program is ill-formed.
 
-```cpp
+```c++
 namespace std {
 
 struct layout_right {
@@ -1848,7 +1944,7 @@ layout_stride
 
 [4]{.pnum} If `Extents` is not a (possibly cv-qualified) specialization of `extents`, then the program is ill-formed.
 
-```cpp
+```c++
 namespace std {
 
 struct layout_stride {
@@ -2187,11 +2283,11 @@ constexpr reference access(pointer p, size_t i) const noexcept;
 
 [2]{.pnum} The *domain* of an `mdspan` object is a multidimensional index space defined by an `extents`.
 
-[3]{.pnum} The *codomain* of an `mdspan` object is a `span` of elements.
+[3]{.pnum} The *codomain* of an `mdspan` object is a contiguous span of elements.
 
-[4]{.pnum} As with `span`, the storage of the objects in the codomain `span` of an `mdspan` is owned by some other object.
+[4]{.pnum} As with `span`, the storage of the objects in the codomain of an `mdspan` is owned by some other object.
 
-```cpp
+```c++
 namespace std {
 
 template<class ElementType, class Extents, class LayoutPolicy, class AccessorPolicy>
@@ -2234,11 +2330,10 @@ public:
       const mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessorPolicy>& other);
 
   // [mdspan.basic.mapping], mdspan mapping domain multidimensional index to access codomain element
-  constexpr reference operator[](size_type) const;
   template<class... SizeTypes>
-    constexpr reference operator()(SizeTypes... indices) const;
+    constexpr reference operator[](SizeTypes... indices) const;
   template<class SizeType, size_t N>
-    constexpr reference operator()(const array<SizeType, N>& indices) const;
+    constexpr reference operator[](const array<SizeType, N>& indices) const;
 
   constexpr accessor_type accessor() const { return acc_; }
 
@@ -2488,7 +2583,7 @@ constexpr reference operator[](size_type i) const;
 
 ```c++
 template<class... SizeTypes>
-  constexpr reference operator()(SizeTypes... indices) const;
+  constexpr reference operator[](SizeTypes... indices) const;
 ```
 
 * [4]{.pnum} *Constraints:*
@@ -2505,7 +2600,7 @@ template<class... SizeTypes>
 
 ```c++
 template<class SizeType, size_t N>
-  constexpr reference operator()(const array<SizeType, N>& indices) const;
+  constexpr reference operator[](const array<SizeType, N>& indices) const;
 ```
 
 * [8]{.pnum} *Constraints:*
@@ -2559,7 +2654,7 @@ submdspan
    and the corresponding value(s) of the arguments of `submdspan` after `src`
    determine the subset of `src` that the `mdspan` returned by `submdspan` views.
 
-```cpp
+```c++
 namespace std {
 
   // [mdspan.submdspan], submdspan creation
@@ -2645,10 +2740,10 @@ int* ptr = new int[3*8*10];
 mdspan<int, Extents3D, layout_right> a(ptr, map_right);
 
 // Initialize the span
-for(int i0=0; i0<a.extent(0); i0++) {
-  for(int i1=0; i1<a.extent(1); i1++) {
-    for(int i2=0; i2<a.extent(2); i2++) {
-      a(i0,i1,i2) = 10000*i0 + 100*i1 + i2;
+for(int i0 = 0; i0 < a.extent(0); ++i0) {
+  for(int i1 = 0; i1 < a.extent(1); ++i1) {
+    for(int i2 = 0; i2 < a.extent(2); ++i2) {
+      a[i0, i1, i2] = 10000*i0 + 100*i1 + i2;
     }
   }
 }
@@ -2657,12 +2752,13 @@ for(int i0=0; i0<a.extent(0); i0++) {
 auto a_sub = submdspan(a, 1, pair{4,6}, pair{1,6});
 
 // Print values of submdspan
-for(int i0=0; i0<a_sub.extent(0); i0++) {
-  for(int i1=0; i1<a_sub.extent(1); i1++) {
-    cout << a_sub(i0,i1) << " ";
+for(int i0 = 0; i0 < a_sub.extent(0); ++i0) {
+  for(int i1 = 0; i1 < a_sub.extent(1); ++i1) {
+    cout << a_sub[i0, i1] << " ";
   }
   cout << endl;
 }
+delete [] ptr;
 
 /* Output
 10401 10402 10403 10404 10405
@@ -2679,9 +2775,6 @@ Next Steps
 We would like LEWG to poll on sending P0009 ('mdspan') to LWG for C++23 instead of
 C++ Library Fundamentals Technical Specification version 3, classified as an addition
 (P0592R4 bucket 3 item).
-
-If [P2128 Multidimensional subscript operator](https://wg21.link/P2128/) is also adopted into C++23, we will
-propose that `mdspan::operator()` be replaced with `mdspan::operator[]` for C++23.
 
 
 Implementation

--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -2570,18 +2570,6 @@ template<class OtherElementType, class OtherExtents, class OtherLayoutPolicy, cl
 <b>22.7.�.2 `mdspan` members [mdspan.basic.members]</b>
 
 ```c++
-constexpr reference operator[](size_type i) const;
-```
-
-* [1]{.pnum} *Constraints:* `rank() == 1` is `true`.
-
-* [2]{.pnum} *Preconditions:* `acc_.access(ptr_, map_(i))` shall be valid.
-
-* [3]{.pnum} *Effects:* Equivalent to: `return (*this)(i);`.
-
-<br/>
-
-```c++
 template<class... SizeTypes>
   constexpr reference operator[](SizeTypes... indices) const;
 ```


### PR DESCRIPTION
@crtrott @nliber @dalg24 

* Use `operator[]` in `mdspan` for multidimensional array access,
  add explanation to Discussion section, and fix all the examples

* Remove reference to `span` in the `mdspan` wording,
  since `mdspan` does not necessarily require a backing `span`
  (because `pointer` need not be `ElementType*`)