### PR TITLE
P0009: Make layout wording style consistent

### DIFF
--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -1744,7 +1744,7 @@ template<class OtherExtents>
 
 [2]{.pnum} `layout_right` is a trivially copyable type.  `layout_right::mapping<Extents>` is a trivially copyable type.
 
-[3]{.pnum} The layout mapping property `layout_right` gives a layout mapping where the right-most extent is stride one and strides increase right-to-left as the product of extents.
+[3]{.pnum} `layout_right` gives a layout mapping where the right-most extent is stride one and strides increase right-to-left as the product of extents.
 
 [4]{.pnum} If `Extents` is not a (possibly cv-qualified) specialization of `extents`, then the program is ill-formed.
 


### PR DESCRIPTION
Make `layout_left` and `layout_right` wording have consistent style, per @brycelelbach 's request.