### PR TITLE
Make constructor conditionally explicit

### DIFF
--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -1304,7 +1304,7 @@ public:
   constexpr extents& operator=(extents&&) noexcept = default;
 
   template<size_t... OtherExtents>
-    explicit((((Extents!=dynamic_extent) && (OtherExtents==dynamic_extent)) || ... ))
+    explicit(@_see below_@)
     constexpr extents(const extents<OtherExtents...>&) noexcept;
   template<class... SizeTypes>
     explicit constexpr extents(SizeTypes...) noexcept;
@@ -1366,7 +1366,7 @@ equivalent to `dynamic_extent`.  Otherwise, `rank_dynamic()`.
 
 ```c++
 template<size_t... OtherExtents>
-  explicit((((Extents!=dynamic_extent) && (OtherExtents==dynamic_extent)) || ... ))
+  explicit(@_see below_@)
   constexpr extents(const extents<OtherExtents...>& other) noexcept;
 ```
 
@@ -1385,6 +1385,8 @@ template<size_t... OtherExtents>
 * [3]{.pnum} *Effects:* For each `r` where `static_extent(r) == dynamic_extent` is `true`,
              assigns `other.extent(r)` to `dynamic_extent[dynamic_index(r)]`.
 
+* [4]{.pnum} *Remarks:* The expression inside `explicit` is equivalent to:
+             `(((Extents!=dynamic_extent) && (OtherExtents==dynamic_extent)) || ... )`
 <br/>
 
 ```c++
@@ -2314,12 +2316,7 @@ public:
   constexpr mdspan(pointer p, const mapping_type& m, const accessor_type& a);
 
   template<class OtherElementType, class OtherExtents, class OtherLayoutPolicy, class OtherAccessorPolicy>
-    explicit(!std::is_convertible_v<OtherElementType, ElementType> ||
-             !std::is_convertible_v<OtherExtents, Extents> ||
-             !std::is_convertible_v<OtherLayoutPolicy, LayoutPolicy> ||
-             !std::is_convertible_v<OtherAccessorPolicy, AccessorPolicy> ||
-             !std::is_convertible_v<typename OtherAccessorPolicy::pointer, pointer>
-            )
+    explicit(@_see below_@)
     constexpr mdspan(
       const mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessorPolicy>& other);
 
@@ -2491,12 +2488,7 @@ constexpr mdspan(pointer p, const mapping_type& m, const accessor_type& a);
 
 ```c++
 template<class OtherElementType, class OtherExtents, class OtherLayoutPolicy, class OtherAccessor>
-  explicit(!std::is_convertible_v<OtherElementType, ElementType> ||
-           !std::is_convertible_v<OtherExtents, Extents> ||
-           !std::is_convertible_v<OtherLayoutPolicy, LayoutPolicy> ||
-           !std::is_convertible_v<OtherAccessorPolicy, AccessorPolicy> ||
-           !std::is_convertible_v<typename OtherAccessorPolicy::pointer, pointer>
-          )
+  explicit(@_see below_@)
   constexpr mdspan(const mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessor>& other);
 ```
 
@@ -2508,7 +2500,7 @@ template<class OtherElementType, class OtherExtents, class OtherLayoutPolicy, cl
 
     + [10.3]{.pnum} `is_constructible_v<pointer, OtherAccessor::pointer>` is `true`;
 
-    + [10.4]{.pnum} `is_constructible_v<extents_type, OtherExtents>` is `true`; and
+    + [10.4]{.pnum} `OtherExtents::rank() == rank()` is `true`; and
 
     + [10.5]{.pnum} For all `r` in the range `[0, rank())`,
        if `other.static_extent(r) != dynamic_extent && static_extent(r) != dynamic_extent` is `true`, 
@@ -2525,6 +2517,11 @@ template<class OtherElementType, class OtherExtents, class OtherLayoutPolicy, cl
     + [12.2]{.pnum} initializes `map_` with `other.map_`, and
 
     + [12.3]{.pnum} initializes `acc_` with `other.acc_`.
+
+* [13]{.pnum} *Remarks:* The expression inside `explicit` is equivalent to:
+             !std::is_convertible_v<typename OtherLayoutPolicy::mapping_type, mapping_type> ||
+             !std::is_convertible_v<OtherAccessorPolicy, AccessorPolicy> ||
+             !std::is_convertible_v<typename OtherAccessorPolicy::pointer, pointer>`
 
 ```c++
 template<class OtherElementType, class OtherExtents, class OtherLayoutPolicy, class OtherAccessor>

--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -1639,7 +1639,7 @@ struct layout_left {
     constexpr mapping(mapping&&) noexcept = default;
     constexpr mapping(const Extents&) noexcept;
     template<class OtherExtents>
-      explicit(!std::is_convertible_v(OtherExtents,Extents>)
+      explicit(!std::is_convertible_v<OtherExtents,Extents>)
       constexpr mapping(const mapping<OtherExtents>&) noexcept;
 
     constexpr mapping& operator=(const mapping&) noexcept = default;
@@ -1684,11 +1684,11 @@ constexpr mapping(const Extents& e) noexcept;
 
 ```c++
 template<class OtherExtents>
-  explicit(!std::is_convertible_v(OtherExtents,Extents>)
+  explicit(!std::is_convertible_v<OtherExtents,Extents>)
   constexpr mapping(const mapping<OtherExtents>& other) noexcept;
 ```
 
-* [2]{.pnum} *Constraints:* `is_constructible_v<OtherExtents,Extents>` is `true`.
+* [2]{.pnum} *Constraints:* `is_constructible_v<Extents,OtherExtents>` is `true`.
 
 * [3]{.pnum} *Effects:* Initializes `extents_` with `other.extents()`.
 
@@ -1779,7 +1779,7 @@ struct layout_right {
     constexpr mapping(const Extents&) noexcept;
     constexpr mapping(mapping&&) noexcept = default;
     template<class OtherExtents>
-      explicit(!std::is_convertible_v(OtherExtents,Extents>)
+      explicit(!std::is_convertible_v<OtherExtents,Extents>)
       constexpr mapping(const mapping<OtherExtents>&) noexcept;
 
     constexpr mapping& operator=(const mapping&) noexcept = default;
@@ -1827,11 +1827,11 @@ constexpr mapping(const Extents& e) noexcept;
 
 ```c++
 template<class OtherExtents>
-  explicit(!std::is_convertible_v(OtherExtents,Extents>)
+  explicit(!std::is_convertible_v<OtherExtents,Extents>)
   constexpr mapping(const mapping<OtherExtents>& other) noexcept;
 ```
 
-* [2]{.pnum} *Constraints:* `is_constructible_v<OtherExtents,Extents>` is `true`.
+* [2]{.pnum} *Constraints:* `is_constructible_v<Extents,OtherExtents>` is `true`.
 
 * [3]{.pnum} *Effects:* Initializes `extents_` with `other.extents()`.
 
@@ -1930,10 +1930,10 @@ struct layout_stride {
     constexpr mapping(const Extents&,
                       const array<size_type, Extents::rank()>&) noexcept;
     template<class OtherExtents>
-      explicit(!std::is_convertible_v(OtherExtents,Extents>)
+      explicit(!std::is_convertible_v<OtherExtents,Extents>)
       constexpr mapping(const mapping<OtherExtents>&) noexcept;
     template<class LayoutPolicy, class OtherExtents>
-      explicit(!std::is_convertible_v(OtherExtents,Extents>)
+      explicit(!std::is_convertible_v<OtherExtents,Extents>)
       constexpr mapping(const LayoutPolicy::template mapping<OtherExtents>&) noexcept;
 
     constexpr mapping& operator=(const mapping&) noexcept = default;
@@ -1992,23 +1992,23 @@ constexpr mapping(const Extents& e, array<size_type, Extents::rank()> s) noexcep
 
 ```c++
 template<class OtherExtents>
-  explicit(!std::is_convertible_v(OtherExtents,Extents>)
+  explicit(!std::is_convertible_v<OtherExtents,Extents>)
   constexpr mapping(const mapping<OtherExtents>& other) noexcept;
 ```
 
-* [4]{.pnum} *Constraints:* `is_constructible_v<OtherExtents,Extents>` is `true`.
+* [4]{.pnum} *Constraints:* `is_constructible_v<Extents,OtherExtents>` is `true`.
 
 * [5]{.pnum} *Effects:* Initializes `extents_` with `other.extents()`, and initializes `strides_` with `other.strides()`.
 
 ```c++
 template<class LayoutPolicy, class OtherExtents>
-  explicit(!std::is_convertible_v(OtherExtents,Extents>)
+  explicit(!std::is_convertible_v<OtherExtents,Extents>)
   constexpr mapping(const LayoutPolicy::template mapping<OtherExtents>& other) noexcept;
 ```
 
 * [6]{.pnum} *Constraints:*
 
-    * [6.1]{.pnum} `is_constructible_v<OtherExtents,Extents>` is `true`.
+    * [6.1]{.pnum} `is_constructible_v<Extents,OtherExtents>` is `true`.
 
     * [6.2]{.pnum} `LayoutPolicy` meets the layout mapping policy requirements.
 
@@ -2502,13 +2502,13 @@ template<class OtherElementType, class OtherExtents, class OtherLayoutPolicy, cl
 
 * [10]{.pnum} *Constraints:*
 
-    + [10.1]{.pnum} `is_constructible_v<OtherLayoutPolicy::template mapping<OtherExtents>, mapping_type` is `true`;
+    + [10.1]{.pnum} `is_constructible_v<mapping_type, OtherLayoutPolicy::template mapping<OtherExtents>` is `true`;
 
-    + [10.2]{.pnum} `is_constructible_v<OtherAccessor, Accessor>` is `true`;
+    + [10.2]{.pnum} `is_constructible_v<Accessor, OtherAccessor>` is `true`;
 
-    + [10.3]{.pnum} `is_constructible_v<OtherAccessor::pointer, pointer>` is `true`;
+    + [10.3]{.pnum} `is_constructible_v<pointer, OtherAccessor::pointer>` is `true`;
 
-    + [10.4]{.pnum} `is_constructible_v<OtherExtents, extents_type>` is `true`; and
+    + [10.4]{.pnum} `is_constructible_v<extents_type, OtherExtents>` is `true`; and
 
     + [10.5]{.pnum} For all `r` in the range `[0, rank())`,
        if `other.static_extent(r) != dynamic_extent && static_extent(r) != dynamic_extent` is `true`, 

--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -1299,9 +1299,10 @@ public:
   constexpr extents& operator=(extents&&) noexcept = default;
 
   template<size_t... OtherExtents>
+    explicit((((Extents!=dynamic_extent) && (OtherExtents==dynamic_extent)) || ... ))
     constexpr extents(const extents<OtherExtents...>&) noexcept;
   template<class... SizeTypes>
-    constexpr extents(SizeTypes...) noexcept;
+    explicit constexpr extents(SizeTypes...) noexcept;
   template<class SizeType>
     constexpr extents(const array<SizeType, rank_dynamic()>&) noexcept;
   template<size_t... OtherExtents>
@@ -1360,6 +1361,7 @@ equivalent to `dynamic_extent`.  Otherwise, `rank_dynamic()`.
 
 ```c++
 template<size_t... OtherExtents>
+  explicit((((Extents!=dynamic_extent) && (OtherExtents==dynamic_extent)) || ... ))
   constexpr extents(const extents<OtherExtents...>& other) noexcept;
 ```
 
@@ -1382,7 +1384,7 @@ template<size_t... OtherExtents>
 
 ```c++
 template<class... SizeTypes>
-  constexpr extents(SizeTypes... dynamic) noexcept;
+  explicit constexpr extents(SizeTypes... dynamic) noexcept;
 ```
 
 * [4]{.pnum} *Constraints:*
@@ -1632,6 +1634,7 @@ struct layout_left {
     constexpr mapping(mapping&&) noexcept = default;
     constexpr mapping(const Extents&) noexcept;
     template<class OtherExtents>
+      explicit(!std::is_convertible_v(OtherExtents,Extents>)
       constexpr mapping(const mapping<OtherExtents>&) noexcept;
 
     constexpr mapping& operator=(const mapping&) noexcept = default;
@@ -1676,10 +1679,11 @@ constexpr mapping(const Extents& e) noexcept;
 
 ```c++
 template<class OtherExtents>
+  explicit(!std::is_convertible_v(OtherExtents,Extents>)
   constexpr mapping(const mapping<OtherExtents>& other) noexcept;
 ```
 
-* [2]{.pnum} *Constraints:* `is_convertible_v<OtherExtents,Extents>` is `true`.
+* [2]{.pnum} *Constraints:* `is_constructible_v<OtherExtents,Extents>` is `true`.
 
 * [3]{.pnum} *Effects:* Initializes `extents_` with `other.extents()`.
 
@@ -1770,6 +1774,7 @@ struct layout_right {
     constexpr mapping(const Extents&) noexcept;
     constexpr mapping(mapping&&) noexcept = default;
     template<class OtherExtents>
+      explicit(!std::is_convertible_v(OtherExtents,Extents>)
       constexpr mapping(const mapping<OtherExtents>&) noexcept;
 
     constexpr mapping& operator=(const mapping&) noexcept = default;
@@ -1817,10 +1822,11 @@ constexpr mapping(const Extents& e) noexcept;
 
 ```c++
 template<class OtherExtents>
+  explicit(!std::is_convertible_v(OtherExtents,Extents>)
   constexpr mapping(const mapping<OtherExtents>& other) noexcept;
 ```
 
-* [2]{.pnum} *Constraints:* `is_convertible_v<OtherExtents,Extents>` is `true`.
+* [2]{.pnum} *Constraints:* `is_constructible_v<OtherExtents,Extents>` is `true`.
 
 * [3]{.pnum} *Effects:* Initializes `extents_` with `other.extents()`.
 
@@ -1919,8 +1925,10 @@ struct layout_stride {
     constexpr mapping(const Extents&,
                       const array<size_type, Extents::rank()>&) noexcept;
     template<class OtherExtents>
+      explicit(!std::is_convertible_v(OtherExtents,Extents>)
       constexpr mapping(const mapping<OtherExtents>&) noexcept;
     template<class LayoutPolicy, class OtherExtents>
+      explicit(!std::is_convertible_v(OtherExtents,Extents>)
       constexpr mapping(const LayoutPolicy::template mapping<OtherExtents>&) noexcept;
 
     constexpr mapping& operator=(const mapping&) noexcept = default;
@@ -1979,21 +1987,23 @@ constexpr mapping(const Extents& e, array<size_type, Extents::rank()> s) noexcep
 
 ```c++
 template<class OtherExtents>
+  explicit(!std::is_convertible_v(OtherExtents,Extents>)
   constexpr mapping(const mapping<OtherExtents>& other) noexcept;
 ```
 
-* [4]{.pnum} *Constraints:* `is_convertible_v<OtherExtents,Extents>` is `true`.
+* [4]{.pnum} *Constraints:* `is_constructible_v<OtherExtents,Extents>` is `true`.
 
 * [5]{.pnum} *Effects:* Initializes `extents_` with `other.extents()`, and initializes `strides_` with `other.strides()`.
 
 ```c++
 template<class LayoutPolicy, class OtherExtents>
+  explicit(!std::is_convertible_v(OtherExtents,Extents>)
   constexpr mapping(const LayoutPolicy::template mapping<OtherExtents>& other) noexcept;
 ```
 
-* [6]{.pnum} *Constraints:* 
+* [6]{.pnum} *Constraints:*
 
-    * [6.1]{.pnum} `is_convertible_v<OtherExtents,Extents>` is `true`.
+    * [6.1]{.pnum} `is_constructible_v<OtherExtents,Extents>` is `true`.
 
     * [6.2]{.pnum} `LayoutPolicy` meets the layout mapping policy requirements.
 
@@ -2220,7 +2230,7 @@ constexpr default_accessor(default_accessor<OtherElementType>) noexcept {}
 
 * [1]{.pnum} *Constraints:*
 
-    * [1.1]{.pnum} `is_convertible_v<typename default_accessor<OtherElementType>::pointer, pointer>` is `true`.
+    * [1.1]{.pnum} `is_convertible_v<typename default_accessor<OtherElementType>::pointer[], pointer[]>` is `true`.
 
 ```c++
 constexpr typename offset_policy::pointer
@@ -2299,6 +2309,12 @@ public:
   constexpr mdspan(pointer p, const mapping_type& m, const accessor_type& a);
 
   template<class OtherElementType, class OtherExtents, class OtherLayoutPolicy, class OtherAccessorPolicy>
+    explicit(!std::is_convertible_v<OtherElementType, ElementType> ||
+             !std::is_convertible_v<OtherExtents, Extents> ||
+             !std::is_convertible_v<OtherLayoutPolicy, LayoutPolicy> ||
+             !std::is_convertible_v<OtherAccessorPolicy, AccessorPolicy> ||
+             !std::is_convertible_v<typename OtherAccessorPolicy::pointer, pointer>
+            )
     constexpr mdspan(
       const mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessorPolicy>& other);
 
@@ -2470,18 +2486,24 @@ constexpr mdspan(pointer p, const mapping_type& m, const accessor_type& a);
 
 ```c++
 template<class OtherElementType, class OtherExtents, class OtherLayoutPolicy, class OtherAccessor>
+  explicit(!std::is_convertible_v<OtherElementType, ElementType> ||
+           !std::is_convertible_v<OtherExtents, Extents> ||
+           !std::is_convertible_v<OtherLayoutPolicy, LayoutPolicy> ||
+           !std::is_convertible_v<OtherAccessorPolicy, AccessorPolicy> ||
+           !std::is_convertible_v<typename OtherAccessorPolicy::pointer, pointer>
+          )
   constexpr mdspan(const mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessor>& other);
 ```
 
 * [10]{.pnum} *Constraints:*
 
-    + [10.1]{.pnum} `is_convertible_v<OtherLayoutPolicy::template mapping<OtherExtents>, mapping_type` is `true`;
+    + [10.1]{.pnum} `is_constructible_v<OtherLayoutPolicy::template mapping<OtherExtents>, mapping_type` is `true`;
 
-    + [10.2]{.pnum} `is_convertible_v<OtherAccessor, Accessor>` is `true`;
+    + [10.2]{.pnum} `is_constructible_v<OtherAccessor, Accessor>` is `true`;
 
-    + [10.3]{.pnum} `is_convertible_v<OtherAccessor::pointer, pointer>` is `true`;
+    + [10.3]{.pnum} `is_constructible_v<OtherAccessor::pointer, pointer>` is `true`;
 
-    + [10.4]{.pnum} `is_convertible_v<OtherExtents, extents_type>` is `true`; and
+    + [10.4]{.pnum} `is_constructible_v<OtherExtents, extents_type>` is `true`; and
 
     + [10.5]{.pnum} For all `r` in the range `[0, rank())`,
        if `other.static_extent(r) != dynamic_extent && static_extent(r) != dynamic_extent` is `true`, 

--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -1524,6 +1524,12 @@ Table � — Layout mapping policy and layout mapping requirements
   <td></td>
 </tr>
 <tr>
+  <td>`M::layout_type`</td>
+  <td>`MP`</td>
+  <td></td>
+  <td></td>
+</tr>
+<tr>
   <td>`is_nothrow_move_constructible_v<M>`</td>
   <td>`bool`</td>
   <td>`true`</td>
@@ -1934,9 +1940,10 @@ struct layout_stride {
     template<class OtherExtents>
       explicit(!std::is_convertible_v<OtherExtents,Extents>)
       constexpr mapping(const mapping<OtherExtents>&) noexcept;
-    template<class LayoutPolicy, class OtherExtents>
-      explicit(!std::is_convertible_v<OtherExtents,Extents>)
-      constexpr mapping(const LayoutPolicy::template mapping<OtherExtents>&) noexcept;
+
+    template<class LayoutMapping>
+      explicit(@_see below_@)
+      constexpr mapping(const LayoutMapping&) noexcept;
 
     constexpr mapping& operator=(const mapping&) noexcept = default;
     constexpr mapping& operator=(mapping&&) noexcept = default;
@@ -2003,23 +2010,29 @@ template<class OtherExtents>
 * [5]{.pnum} *Effects:* Initializes `extents_` with `other.extents()`, and initializes `strides_` with `other.strides()`.
 
 ```c++
-template<class LayoutPolicy, class OtherExtents>
-  explicit(!std::is_convertible_v<OtherExtents,Extents>)
-  constexpr mapping(const LayoutPolicy::template mapping<OtherExtents>& other) noexcept;
+template<class LayoutMapping>
+  explicit(@_see below_@)
+  constexpr mapping(const LayoutMapping& other) noexcept;
 ```
 
 * [6]{.pnum} *Constraints:*
 
-    * [6.1]{.pnum} `is_constructible_v<Extents,OtherExtents>` is `true`.
+    * [6.1]{.pnum} `LayoutMapping::layout_type` meets the layout mapping policy requirements.
 
-    * [6.2]{.pnum} `LayoutPolicy` meets the layout mapping policy requirements.
+    * [6.2]{.pnum} `std::is_same_v<LayoutMapping, LayoutMapping::layout_type::mapping<LayoutMapping::extents_type>` is `true`.
 
-    * [6.3]{.pnum} `other.is_always_unique()` is `true`.
+    * [6.3]{.pnum} `is_constructible_v<LayoutMapping::extents_type,Extents>` is `true`.
 
-    * [6.4]{.pnum} `other.is_always_strided()` is `true`.
+    * [6.4]{.pnum} `other.is_always_unique()` is `true`.
+
+    * [6.5]{.pnum} `other.is_always_strided()` is `true`.
+
 
 * [7]{.pnum} *Effects:* Initializes `extents_` with `other.extents()`, and initializes `strides_` such that
   `strides_[r] == other.stride(r)` is true for all $r$ in the range $[0,$ `Extents::rank()` $)$.
+
+* [8]{.pnum} *Remarks:* The expression inside `explicit` is equivalent to:
+  `!std::is_convertible_v<typename LayoutMapping::extents_type,Extents>`.
 
 ```c++
 template<class OtherExtents>

--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -45,6 +45,14 @@ parameters are only explicitly convertible
 - Improve submdspan wording
   - the wording defines more clearly how the submdspan is constructed, not just through ensures
 - made layout wording style consistent
+- don't require default constructibility from accessors and mappings (still require it for pointer though)
+- fixed layout_stride conversion construction
+- made deduction guide from integers for extents/mdspan explicit
+- tweaked constraints on mdspan to not include element type and the full extents 
+  - left pointer, since mdspan converts those in its converting constructor
+  - also left some specific constraints regarding extents to prevent custom layouts from
+    changing rank or assigning different sized static extents
+
 
 ## P0009r13: 2021-10 Mailing
 

--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -1200,7 +1200,7 @@ namespace std {
   constexpr size_t make_dynamic_extent() { return dynamic_extent; } // @_exposition only_@
 
   template <class... Integrals>
-  extents(Integrals...)
+  explicit extents(Integrals...)
     -> extents<make_dynamic_extent<Integrals>()...>;
 
 

--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -35,8 +35,13 @@ toc: true
 
 # Revision History
 
-## P0009r14: 2021-10
+## P0009r14: 2021-11 Mailing
 
+- made `extents` converting constructor conditionally explicit, for cases where dynamic extents are turned into static extents
+- made layout mapping converting constructors conditionally explicit, depending on `extents` being not implicitly convertible
+- made `mdspan` converting constructor conditionally explicit, for cases where any of the exposition only members or the template
+parameters are only explicitly convertible
+- made convertibility of `default_accessor` depend on convertibility of `pointer[]` instead of `pointer` to prevent derived class to base class assignment
 - Improve submdspan wording
   - the wording defines more clearly how the submdspan is constructed, not just through ensures
 - made layout wording style consistent

--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -2131,10 +2131,7 @@ a contiguous set of objects are accessed.
   * [2.2]{.pnum} a handle to a contiguous set of elements of type `element_type`,
     accessible through the policy's `access` method;
 
-  * [2.3]{.pnum} conversion of a handle to a contiguous set of elements,
-      to a pointer _[conv.array]_; and
-
-  * [2.4]{.pnum} getting a handle to the contiguous subset of elements
+  * [2.3]{.pnum} getting a handle to the contiguous subset of elements
     beginning at an integer offset value.
 
 [3]{.pnum} <i>[Note:</i> The type of `reference` need not be `element_type&`.
@@ -2256,7 +2253,7 @@ constexpr default_accessor(default_accessor<OtherElementType>) noexcept {}
 
 * [1]{.pnum} *Constraints:*
 
-    * [1.1]{.pnum} `is_convertible_v<typename default_accessor<OtherElementType>::pointer[], pointer[]>` is `true`.
+    * [1.1]{.pnum} `is_convertible_v<typename default_accessor<OtherElementType>::element_type(*)[], element_type(*)[]>` is `true`.
 
 ```c++
 constexpr typename offset_policy::pointer
@@ -2322,7 +2319,7 @@ public:
   using reference = typename accessor_type::reference;
 
   // [mdspan.basic.cons], mdspan constructors, assignment, and destructor
-  constexpr mdspan() = default;
+  constexpr mdspan() requires(rank_dynamic != 0) = default;
   constexpr mdspan(const mdspan& rhs) = default;
   constexpr mdspan(mdspan&& rhs) = default;
 
@@ -2559,19 +2556,19 @@ template<class OtherElementType, class OtherExtents, class OtherLayoutPolicy, cl
 
     + [13.2]{.pnum} `is_assignable_v<Accessor, OtherAccessor>` is `true`;
 
-    + [13.3]{.pnum} `is_assignable_v<pointer, OtherAccessor::pointer>` is `true`;
+    + [13.3]{.pnum} `OtherExtents::rank() == rank()` is `true`; and
 
-    + [13.4]{.pnum} `OtherExtents::rank() == rank()` is `true`; and
-
-    + [13.5]{.pnum} For all `r` in the range `[0, rank())`, 
+    + [13.4]{.pnum} For all `r` in the range `[0, rank())`, 
        if `other.static_extent(r) != dynamic_extent && static_extent(r) != dynamic_extent` is `true`,
        then `other.static_extent(r) == static_extent(r)` is `true`.
 
-* [14]{.pnum} *Preconditions:* For all `r` in the range `[0, rank())`,
+* [14]{.pnum} *Mandates:* `is_assignable_v<pointer, OtherAccessor::pointer>` is `true`.
+
+* [15]{.pnum} *Preconditions:* For all `r` in the range `[0, rank())`,
    if `other.static_extent(r) == dynamic_extent || static_extent(r) == dynamic_extent` is `true`,
    then `other.extent(r) == extent(r)` is `true`.
 
-* [15]{.pnum} *Effects:*
+* [16]{.pnum} *Effects:*
 
     + [15.1]{.pnum} Assigns `other.ptr_` to `ptr_`,
 

--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -1490,7 +1490,7 @@ template<size_t... OtherExtents>
 
 2. A layout mapping policy and its layout mapping nested class template meet the requirements in Table �.
 
-3. A layout mapping meets the requirements of *Cpp17DefaultConstructible*, *Cpp17CopyAssignable*, and *Cpp17EqualityComparable*.
+3. A layout mapping meets the requirements of *Cpp17CopyConstructible*, *Cpp17CopyAssignable*, and *Cpp17EqualityComparable*.
 
 4. In Table �:
     * `MP` denotes a layout mapping policy.
@@ -2053,14 +2053,14 @@ constexpr size_type required_span_size() const noexcept;
 
 
 ```c++
-template<class... Indices> 
+template<class... Indices>
   constexpr size_type operator()(Indices... i) const noexcept;
 ```
 
 * [10]{.pnum} *Constraints:*
-    
+
     * [10.1]{.pnum} `sizeof...(Indices) == Extents::rank()` is `true`, and
-    
+
     * [10.1]{.pnum} `(is_convertible_v<Indices, size_type> && ...)` is `true`.
 
 * [11]{.pnum} *Preconditions:* $0\:\le$ `array{i...}[r]` $\lt$ `extents().extent(r)` for all `r` in the range $[0,$ `Extents::rank()` $)$.
@@ -2076,7 +2076,7 @@ constexpr bool is_contiguous() const noexcept;
 * [13]{.pnum} Let $P$ be a permutation of the integers $0, ...,$ `Extents::rank()-1` and let $p_i$ be the $i^{th}$ element of $P$.
 
 * [14]{.pnum}*Returns:*
-    
+
     * [14.1]{.pnum} `true` if `Extents::ranks()` is zero.
 
     * [14.2]{.pnum} Otherwise, `true` if there is a permutation $P$ such that
@@ -2132,8 +2132,6 @@ a contiguous set of objects are accessed.
 [3]{.pnum} <i>[Note:</i> The type of `reference` need not be `element_type&`.
   The type of `pointer` need not be `element_type*`. <i>— end note]</i>
 
-[4]{.pnum} An accessor policy meets the requirements of *Cpp17DefaultConstructible*, *Cpp17CopyAssignable*, and *Cpp17EqualityComparable*.
-
 [5]{.pnum} In Table �:
 
   * [5.1]{.pnum} `A` denotes an accessor policy.
@@ -2154,7 +2152,7 @@ Table �: Accessor policy requirements
 <tr>
   <td>`A`</td>
   <td></td>
-  <td> `A` meets the requirements of _Cpp17DefaultConstructible_, _Cpp17CopyConstructible_, and _Cpp17CopyAssignable_.
+  <td> `A` meets the requirements of _Cpp17CopyConstructible_ and _Cpp17CopyAssignable_.
        `is_nothrow_move_constructible_v<A>` is `true` and `is_nothrow_move_assignable_v<A>` is `true`.
   </td>
 </tr>
@@ -2384,8 +2382,8 @@ public:
   }
 
 private:
-  accessor_type acc_{}; // @_exposition only_@
-  mapping_type map_{}; // @_exposition only_@
+  accessor_type acc_; // @_exposition only_@
+  mapping_type map_; // @_exposition only_@
   pointer ptr_{}; // @_exposition only_@
 };
 
@@ -2397,6 +2395,10 @@ private:
 [5]{.pnum} `mdspan<ElementType, Extents, LayoutPolicy, AccessorPolicy>` is a trivially copyable type if 
            `AccessorPolicy`, `LayoutPolicy::mapping_type<Extents>` and `AccessorPolicy::pointer` are
            trivially copyable types.
+           `mdspan<ElementType, Extents, LayoutPolicy, AccessorPolicy>`
+           is a default constructible type if
+           `AccessorPolicy` and `LayoutPolicy::mapping_type<Extents>` are
+           default constructible types.
            `mdspan<ElementType, Extents, LayoutPolicy, AccessorPolicy>`
            is a trivially default constructible type if
            `AccessorPolicy`, `LayoutPolicy::mapping_type<Extents>` and `AccessorPolicy::pointer` are


### PR DESCRIPTION
- makes mdspan, mapping and accessor constructors conditionally explicit
- makes extents conversion constructor explicit for dynamic -> static
- fixes the pointer derived to base class assignment for
  default_accessor