### PR TITLE
Fix layout_stride constructor for flexible stride array

### DIFF
--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -53,6 +53,7 @@ parameters are only explicitly convertible
   - also left some specific constraints regarding extents to prevent custom layouts from
     changing rank or assigning different sized static extents
 - add feature test macro
+- fix layout_stride constructor to be flexible with integral types of strides array
 
 ## P0009r13: 2021-10 Mailing
 
@@ -1950,8 +1951,9 @@ struct layout_stride {
     constexpr mapping() noexcept = default;
     constexpr mapping(const mapping&) noexcept = default;
     constexpr mapping(mapping&&) noexcept = default;
+    template<class SizeType, size_t N>
     constexpr mapping(const Extents&,
-                      const array<size_type, Extents::rank()>&) noexcept;
+                      const array<SizeType, N>&) noexcept;
     template<class OtherExtents>
       explicit(!std::is_convertible_v<OtherExtents,Extents>)
       constexpr mapping(const mapping<OtherExtents>&) noexcept;
@@ -2000,19 +2002,26 @@ struct layout_stride {
 
 
 ```c++
-constexpr mapping(const Extents& e, array<size_type, Extents::rank()> s) noexcept;
+template<class SizeType, size_t N>
+constexpr mapping(const Extents& e, array<SizeType, N> s) noexcept;
 ```
 [1]{.pnum} Let $P$ be a permutation of the integers $0, ...,$ `Extents::rank()-1` and let $p_i$ be the $i^{th}$ element of $P$.
 
-* [2]{.pnum} *Preconditions:*
+* [2]{.pnum} *Constraints:*
 
-    * [2.1]{.pnum}`s[i] > 0` is `true` for all `i` in the range $[0,$ `Extents::rank()` $)$.
+    * [2.1]{.pnum} `is_convertible_v<SizeType, size_type>` is `true` and
 
-    * [2.2]{.pnum} If `Extents::rank()` is greater than zero, then there exists a permutation $P$ 
+    * [2.2]{.pnum} `N == rank()` is `true`.
+
+* [3]{.pnum} *Preconditions:*
+
+    * [3.1]{.pnum}`s[i] > 0` is `true` for all `i` in the range $[0,$ `Extents::rank()` $)$.
+
+    * [3.2]{.pnum} If `Extents::rank()` is greater than zero, then there exists a permutation $P$ 
       such that `s[` $p_i$ `] >= s(` $p_{i-1}$ `]) * e.extent(` $p_{i-1}$ `)` is `true`
       for all $i$ in the range $[1,$ `Extents::rank()` $)$.
 
-* [3]{.pnum} *Effects:* Initializes `extents_` with `e`, and initializes `strides_` with `s`.
+* [4]{.pnum} *Effects:* Initializes `extents_` with `e`, and initializes `strides_` with `s`.
 
 ```c++
 template<class OtherExtents>
@@ -2020,9 +2029,9 @@ template<class OtherExtents>
   constexpr mapping(const mapping<OtherExtents>& other) noexcept;
 ```
 
-* [4]{.pnum} *Constraints:* `is_constructible_v<Extents,OtherExtents>` is `true`.
+* [5]{.pnum} *Constraints:* `is_constructible_v<Extents,OtherExtents>` is `true`.
 
-* [5]{.pnum} *Effects:* Initializes `extents_` with `other.extents()`, and initializes `strides_` with `other.strides()`.
+* [6]{.pnum} *Effects:* Initializes `extents_` with `other.extents()`, and initializes `strides_` with `other.strides()`.
 
 ```c++
 template<class LayoutMapping>
@@ -2030,23 +2039,23 @@ template<class LayoutMapping>
   constexpr mapping(const LayoutMapping& other) noexcept;
 ```
 
-* [6]{.pnum} *Constraints:*
+* [7]{.pnum} *Constraints:*
 
-    * [6.1]{.pnum} `LayoutMapping::layout_type` meets the layout mapping policy requirements.
+    * [7.1]{.pnum} `LayoutMapping::layout_type` meets the layout mapping policy requirements.
 
-    * [6.2]{.pnum} `std::is_same_v<LayoutMapping, LayoutMapping::layout_type::mapping<LayoutMapping::extents_type>` is `true`.
+    * [7.2]{.pnum} `std::is_same_v<LayoutMapping, LayoutMapping::layout_type::mapping<LayoutMapping::extents_type>` is `true`.
 
-    * [6.3]{.pnum} `is_constructible_v<LayoutMapping::extents_type,Extents>` is `true`.
+    * [7.3]{.pnum} `is_constructible_v<LayoutMapping::extents_type,Extents>` is `true`.
 
-    * [6.4]{.pnum} `other.is_always_unique()` is `true`.
+    * [7.4]{.pnum} `other.is_always_unique()` is `true`.
 
-    * [6.5]{.pnum} `other.is_always_strided()` is `true`.
+    * [7.5]{.pnum} `other.is_always_strided()` is `true`.
 
 
-* [7]{.pnum} *Effects:* Initializes `extents_` with `other.extents()`, and initializes `strides_` such that
+* [8]{.pnum} *Effects:* Initializes `extents_` with `other.extents()`, and initializes `strides_` such that
   `strides_[r] == other.stride(r)` is true for all $r$ in the range $[0,$ `Extents::rank()` $)$.
 
-* [8]{.pnum} *Remarks:* The expression inside `explicit` is equivalent to:
+* [9]{.pnum} *Remarks:* The expression inside `explicit` is equivalent to:
   `!std::is_convertible_v<typename LayoutMapping::extents_type,Extents>`.
 
 ```c++
@@ -2054,7 +2063,7 @@ template<class OtherExtents>
   constexpr mapping& operator=(const mapping<OtherExtents>& other) noexcept;
 ```
 
-* [8]{.pnum} *Effects:* Equivalent to: 
+* [10]{.pnum} *Effects:* Equivalent to: 
 
    ```c++
    extents_ = other.extents();
@@ -2064,7 +2073,7 @@ template<class OtherExtents>
 ```c++
 constexpr size_type required_span_size() const noexcept;
 ```
-* [9]{.pnum} *Returns:* If `(Extents::rank() > 0)` is true and `(extents().extent(r) > 0)` is true for all `r` in the range $[0,$ `Extents::rank()` $)$, the maximum of `extents().extent(r) * stride(r)` for all `r` in the range $[0,$ `Extents::rank()` $)$. Otherwise, `Extents::rank() == 0 ? 1 : 0`.
+* [11]{.pnum} *Returns:* If `(Extents::rank() > 0)` is true and `(extents().extent(r) > 0)` is true for all `r` in the range $[0,$ `Extents::rank()` $)$, the maximum of `extents().extent(r) * stride(r)` for all `r` in the range $[0,$ `Extents::rank()` $)$. Otherwise, `Extents::rank() == 0 ? 1 : 0`.
 
 
 ```c++
@@ -2072,15 +2081,15 @@ template<class... Indices>
   constexpr size_type operator()(Indices... i) const noexcept;
 ```
 
-* [10]{.pnum} *Constraints:*
+* [12]{.pnum} *Constraints:*
 
-    * [10.1]{.pnum} `sizeof...(Indices) == Extents::rank()` is `true`, and
+    * [12.1]{.pnum} `sizeof...(Indices) == Extents::rank()` is `true`, and
 
-    * [10.1]{.pnum} `(is_convertible_v<Indices, size_type> && ...)` is `true`.
+    * [12.1]{.pnum} `(is_convertible_v<Indices, size_type> && ...)` is `true`.
 
-* [11]{.pnum} *Preconditions:* $0\:\le$ `array{i...}[r]` $\lt$ `extents().extent(r)` for all `r` in the range $[0,$ `Extents::rank()` $)$.
+* [13]{.pnum} *Preconditions:* $0\:\le$ `array{i...}[r]` $\lt$ `extents().extent(r)` for all `r` in the range $[0,$ `Extents::rank()` $)$.
 
-* [12]{.pnum} *Effects:* Let `P...` be the parameter pack such that
+* [14]{.pnum} *Effects:* Let `P...` be the parameter pack such that
               `is_same_v<make_index_sequence<size_type, sizeof...(Indices)>, integer_sequence<size_type, P...>>` is `true`.
               <br/> Equivalent to: `return Extents::rank() > 0 ? (i*stride(P()) + ...) : 0;` 
 
@@ -2088,18 +2097,18 @@ template<class... Indices>
 constexpr bool is_contiguous() const noexcept;
 ```
 
-* [13]{.pnum} Let $P$ be a permutation of the integers $0, ...,$ `Extents::rank()-1` and let $p_i$ be the $i^{th}$ element of $P$.
+* [15]{.pnum} Let $P$ be a permutation of the integers $0, ...,$ `Extents::rank()-1` and let $p_i$ be the $i^{th}$ element of $P$.
 
-* [14]{.pnum}*Returns:*
+* [16]{.pnum}*Returns:*
 
-    * [14.1]{.pnum} `true` if `Extents::ranks()` is zero.
+    * [16.1]{.pnum} `true` if `Extents::ranks()` is zero.
 
-    * [14.2]{.pnum} Otherwise, `true` if there is a permutation $P$ such that
+    * [16.2]{.pnum} Otherwise, `true` if there is a permutation $P$ such that
       `min(stride(` $p_i$ `)` equals one for $i$ in the range $[0,$ `Extents::rank()` $)$, and
       `stride(` $p_i$ `)` equals `stride(` $p_{i-1}$ `) * extents().extent(` $p_{i-1}$ `)`
       for $i$ in the range $[1,$ `Extents::rank()` $)$.
 
-    * [14.3]{.pnum} Otherwise, `false`.
+    * [16.3]{.pnum} Otherwise, `false`.
 
 
 ```c++
@@ -2107,7 +2116,7 @@ template<class OtherExtents>
   friend constexpr bool operator==(const mapping& x, const mapping<OtherExtents>& y) noexcept;
 ```
 
-* [15]{.pnum} *Effects:* Equivalent to: `return x.extents() == y.extents();`.
+* [17]{.pnum} *Effects:* Equivalent to: `return x.extents() == y.extents();`.
 
 
 <!--

--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -2104,8 +2104,8 @@ constexpr bool is_contiguous() const noexcept;
     * [16.1]{.pnum} `true` if `Extents::ranks()` is zero.
 
     * [16.2]{.pnum} Otherwise, `true` if there is a permutation $P$ such that
-      `min(stride(` $p_i$ `)` equals one for $i$ in the range $[0,$ `Extents::rank()` $)$, and
-      `stride(` $p_i$ `)` equals `stride(` $p_{i-1}$ `) * extents().extent(` $p_{i-1}$ `)`
+      `min(stride(` $p_0$ `))` equals one, and `stride(` $p_i$ `)` equals
+      `stride(` $p_{i-1}$ `) * extents().extent(` $p_{i-1}$ `)`
       for $i$ in the range $[1,$ `Extents::rank()` $)$.
 
     * [16.3]{.pnum} Otherwise, `false`.


### PR DESCRIPTION
Allow strides std::array to be any size type convertible.
I.e. follow other places where we take arrays.