### PR TITLE
Add affiliations to some authors per request

### DIFF
--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -24,8 +24,10 @@ author:
     email: <ben.sander@amd.com>
   - name: Athanasios Iliopoulos 
     email: <athanasios.iliopoulos@nrl.navy.mil>
+    affiliation: Computational Multiphysics System Lab., US Naval Research Laboratory, Washington, DC
   - name: John Michopoulos 
     email: <john.michopoulos@nrl.navy.mil>
+    affiliation: Computational Multiphysics System Lab., US Naval Research Laboratory, Washington, DC
   - name: Nevin Liber
     email: <nliber@anl.gov>
 toc: true


### PR DESCRIPTION
Nasos and John have a requirement to put their affiliations on the proposal.  This PR implements that.