### PR TITLE
P0009: Fix accessor policy; stop implying "contiguous"-ness

### DIFF
--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -779,7 +779,7 @@ and whose upper bound is the product of the <math>R</math> extents.
 
 More formally, a multidimensional array of rank <math>R</math>
 maps from its *domain*, a multidimensional index space of rank <math>R</math>,
-to its *codomain*, elements of a contiguous span of objects.
+to its *codomain*, a set of objects accessible from a contiguous range of integer indices.
 A *multidimensional index space* of rank <math>R</math>
 is the Cartesian product
 <math>[0, N<sub>0</sub>) &#10799; [0, N<sub>1</sub>) &#10799; ... &#10799; [0, N<sub>R-1</sub>)</math>
@@ -1516,8 +1516,8 @@ template<size_t... OtherExtents>
     * `m` denotes an object of type `M`.
     * `i...` and `j...` are multidimensional indices in the multidimensional index space defined by `e`.
     * `r` is an integral value in the range `[0, e.rank())`.
-    * `dr...` is an integer pack where `sizeof...(dr) == e.rank()` is `true`
-       and the `r`th element is equal to `1` and all other elements are `0`.
+    * `dr...` is an integer pack where `sizeof...(dr)` equals `e.rank()`,
+       the `r`-th element is equal to `1`, and all other elements are `0`.
 
 Table � — Layout mapping policy and layout mapping requirements
 <table border=1>
@@ -2136,19 +2136,28 @@ template<class OtherExtents>
 <b>22.7.� Accessor Policy [mdspan.accessor]</b>
 
 [1]{.pnum} An _accessor policy_ defines types and operations by which
-a contiguous set of objects are accessed.
+a set of objects are accessed from a contiguous range of integer indices.
 
 <b>22.7.�.1 Accessor policy requirements [mdspan.accessor.reqs]</b>
 
 [2]{.pnum} An accessor policy defines:
 
-  * [2.1]{.pnum} a handle to a single element of type `element_type`;
+  * [2.1]{.pnum} `pointer`, the type of a handle to a set of objects
+      accessible from a contiguous range of integer indices;
 
-  * [2.2]{.pnum} a handle to a contiguous set of elements of type `element_type`,
-    accessible through the policy's `access` method;
+  * [2.2]{.pnum} `reference`, the type of a handle to a single element of type `element_type`;
 
-  * [2.3]{.pnum} getting a handle to the contiguous subset of elements
-    beginning at an integer offset value.
+  * [2.3]{.pnum} `access`, a method to access the `i`-th element
+      in a range of elements represented by a `pointer`;
+
+  * [2.4]{.pnum} `offset`, a method to create a subrange,
+      beginning at an integer offset value and
+      accessible from a contiguous range of integer indices,
+      of a given range of elements; and
+
+  * [2.5]{.pnum} `offset_policy`, the type of a
+      <i>[Note:</i> possibly different <i>— end note]</i>
+      accessor policy for accessing the result of `offset`.
 
 [3]{.pnum} <i>[Note:</i> The type of `reference` need not be `element_type&`.
   The type of `pointer` need not be `element_type*`. <i>— end note]</i>
@@ -2311,7 +2320,7 @@ constexpr reference access(pointer p, size_t i) const noexcept;
 
 [2]{.pnum} The *domain* of an `mdspan` object is a multidimensional index space defined by an `extents`.
 
-[3]{.pnum} The *codomain* of an `mdspan` object is a contiguous span of elements.
+[3]{.pnum} The *codomain* of an `mdspan` object is a set of elements accessible from a contiguous range of integer indices.
 
 [4]{.pnum} As with `span`, the storage of the objects in the codomain of an `mdspan` is owned by some other object.
 

--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -2136,23 +2136,23 @@ template<class OtherExtents>
 <b>22.7.� Accessor Policy [mdspan.accessor]</b>
 
 [1]{.pnum} An _accessor policy_ defines types and operations by which
-a set of objects are accessed from a contiguous range of integer indices.
+a set of objects are accessed from a subset of a contiguous range of integer indices.
 
 <b>22.7.�.1 Accessor policy requirements [mdspan.accessor.reqs]</b>
 
 [2]{.pnum} An accessor policy defines:
 
   * [2.1]{.pnum} `pointer`, the type of a handle to a set of objects
-      accessible from a contiguous range of integer indices;
+      accessible from a subset of a contiguous range of integer indices;
 
   * [2.2]{.pnum} `reference`, the type of a handle to a single element of type `element_type`;
 
   * [2.3]{.pnum} `access`, a method to access the `i`-th element
-      in a range of elements represented by a `pointer`;
+      in the range of elements represented by a `pointer`;
 
   * [2.4]{.pnum} `offset`, a method to create a subrange,
       beginning at an integer offset value and
-      accessible from a contiguous range of integer indices,
+      accessible from a subset of a contiguous range of integer indices,
       of a given range of elements; and
 
   * [2.5]{.pnum} `offset_policy`, the type of a


### PR DESCRIPTION
@crtrott @dalg24 @nliber 

1. Fix accessor policy wording, in particular the bulleted list
   that wasn't lining up with the table.

2. Remove implications that the set of elements that an accessor
   accesses is contiguous in memory.  (It need not be.)