### PR TITLE
P0009: Remove e-mails per request; update audience

### DIFF
--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -2,7 +2,7 @@
 title: "`MDSPAN`"
 document: P0009r14
 date: today
-audience: LWG
+audience: LEWG
 author:
   - name: Christian Trott 
     email: <crtrott@sandia.gov>
@@ -22,11 +22,9 @@ author:
     email: <mbianco@cscs.ch>
   - name: Ben Sander 
     email: <ben.sander@amd.com>
-  - name: Athanasios Iliopoulos 
-    email: <athanasios.iliopoulos@nrl.navy.mil>
+  - name: Athanasios Iliopoulos
     affiliation: Computational Multiphysics System Lab., US Naval Research Laboratory, Washington, DC
   - name: John Michopoulos 
-    email: <john.michopoulos@nrl.navy.mil>
     affiliation: Computational Multiphysics System Lab., US Naval Research Laboratory, Washington, DC
   - name: Nevin Liber
     email: <nliber@anl.gov>


### PR DESCRIPTION
@crtrott 

1. Remove e-mails of two authors (but retain affiliations) per request.

2. Update "audience" field in top matter from LWG to LEWG.