### PR TITLE
unique_size is unimplementable for non-unique non-contiguous

### DIFF
--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -54,6 +54,7 @@ parameters are only explicitly convertible
     changing rank or assigning different sized static extents
 - add feature test macro
 - fix layout_stride constructor to be flexible with integral types of strides array
+- remove `mdspan::unique_size`
 
 ## P0009r13: 2021-10 Mailing
 
@@ -2373,7 +2374,6 @@ public:
   constexpr Extents extents() const { return map_.extents(); }
   constexpr size_type extent(size_t r) const { return extents().extent(r); }
   constexpr size_type size() const;
-  constexpr size_type unique_size() const;
 
   // [mdspan.basic.codomain], mdspan observers of the codomain
   constexpr pointer data() const { return ptr_; }
@@ -2638,13 +2638,6 @@ constexpr size_type size() const;
 ```
 
 * [6]{.pnum} *Returns:* Product of `extent(r)` for all `r` in the range `[0, Extents::rank())`.
-
-```c++
-constexpr size_type unique_size() const;
-```
-
-* [7]{.pnum} *Returns:* The number of unique elements in the codomain.
-  _[Note:_ If `mapping().is_unique()` is `true`, this is identical to `size()`. _—end note]_
 
 <!--
 submdspan


### PR DESCRIPTION
For non-contiguous unique mappings required_span_size can be used.
For unique mdspans/mappings size can be used.