### PR TITLE
P0009: Remove incorrect reference to `span`

### DIFF
--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -2387,7 +2387,7 @@ constexpr reference access(pointer p, size_t i) const noexcept;
 <b>22.7.�.1 `mdspan` overview [mdspan.basic.overview]</b>
 
 [1]{.pnum} `mdspan` maps a multidimensional index in its domain
-   to a reference to an element in its codomain `span`.
+   to a reference to an element in its codomain.
 
 [2]{.pnum} The *domain* of an `mdspan` object is a multidimensional index space defined by an `extents`.
 


### PR DESCRIPTION
The codomain of an `mdspan` isn't necessarily a `span`.