### PR TITLE
Let `mdspan::rank[_dynamic]` return `size_t`

### DIFF
--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -2469,8 +2469,8 @@ public:
 
   constexpr accessor_type accessor() const { return acc_; }
 
-  static constexpr int rank() { return Extents::rank(); }
-  static constexpr int rank_dynamic() { return Extents::rank_dynamic(); }
+  static constexpr size_t rank() { return Extents::rank(); }
+  static constexpr size_t rank_dynamic() { return Extents::rank_dynamic(); }
   static constexpr size_type static_extent(size_t r) { return Extents::static_extent(r); }
 
   constexpr Extents extents() const { return map_.extents(); }

--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -74,6 +74,8 @@ toc: true
          return return_t(ptr, mdspan1.extent(0),mdspan2.extent(1));
        }
        ```
+#### Changes from R14
+- `mdspan::rank[_dynamic]` returns `size_t`
 
 #### Changes from R13
 


### PR DESCRIPTION
For consistency with `extents::rank[_dynamic]`