### PR TITLE
P0009: `operator==` for `layout_stride` should consider strides

### DIFF
--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -2209,7 +2209,7 @@ template<class OtherExtents>
   friend constexpr bool operator==(const mapping& x, const mapping<OtherExtents>& y) noexcept;
 ```
 
-* [17]{.pnum} *Effects:* Equivalent to: `return x.extents() == y.extents();`.
+* [17]{.pnum} *Effects:* Equivalent to: `return x.extents() == y.extents() && x.strides() == y.strides();`.
 
 
 <!--


### PR DESCRIPTION
I guess this is the intended behavior, although the layout mapping requirements table doesn't show `op==`, so it's not clear what the semantics are supposed to be in general.