### PR TITLE
P0009: misc. wording suggestions

### DIFF
--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -40,6 +40,13 @@ toc: true
 - `mdspan::rank[_dynamic]` returns `size_t`
 - fix comparison operator for `layout_stride` to take strides into account.
 - fix `layout_stride` mapping `required_span_size`
+- Consistently use "`<`_expr_`>` is `true`" instead of "`<`*expr*`>` is true".
+- In the layout mappings' `operator()` *Effects* clauses, use only `index_sequence`and fix syntax error in `stride(P())`.
+- Replace various unary folds with binary to handle `extents<>`.
+- Consistently use `Extents::rank()` in layout mapping wording.
+- Typo in `mdspan::mapping_type`: `template mapping_type` should be `template mapping`.
+- `mdspan`'s `array` constructor calls `Extents`'s `array` constructor.
+- Clarify the value of `static_stride` for `submdspan`'s result.
 
 ## P0009r14: 2021-11 Mailing
 
@@ -1386,7 +1393,7 @@ public:
   // [mdspan.extents.obs], Observers of the domain multidimensional index space
   static constexpr size_t rank() noexcept { return sizeof...(Extents); }
   static constexpr size_t rank_dynamic() noexcept
-    { return ((Extents == dynamic_extent) + ...); }
+    { return ((Extents == dynamic_extent) + ... + 0); }
   static constexpr size_type static_extent(size_t) noexcept;
   constexpr size_type extent(size_t) const noexcept;
 
@@ -1438,7 +1445,7 @@ equivalent to `dynamic_extent`.  Otherwise, `rank_dynamic()`.
 constexpr size_t dynamic_index_inv(size_t i) noexcept; // @_exposition only_@
 ```
 
-* [8]{.pnum} *Returns*: If `i < rank_dynamic()` is true,
+* [8]{.pnum} *Returns*: If `i < rank_dynamic()` is `true`,
                         the minimum value of $r$ such that `dynamic_index(r+1)` equals $i+1$.
                         Otherwise returns `rank()`.
 
@@ -1739,9 +1746,9 @@ struct layout_left {
     template<class OtherExtents>
       explicit(!std::is_convertible_v<OtherExtents,Extents>)
       constexpr mapping(const layout_right::template mapping<OtherExtents>&) noexcept
-      requires(rank() <= 1);
+      requires(Extents::rank() <= 1);
     template<class OtherExtents>
-      explicit(rank() > 0) constexpr mapping(
+      explicit(Extents::rank() > 0) constexpr mapping(
       const layout_stride::template mapping<OtherExtents>& other);
 
     constexpr mapping& operator=(const mapping&) noexcept = default;
@@ -1796,7 +1803,7 @@ template<class OtherExtents>
 template<class OtherExtents>
   explicit(!std::is_convertible_v<OtherExtents,Extents>)
   constexpr mapping(const layout_right::template mapping<OtherExtents>& other) noexcept
-  requires(rank() <= 1);
+  requires(Extents::rank() <= 1);
 ```
 
 * [4]{.pnum} *Constraints:* `is_constructible_v<Extents,OtherExtents>` is `true`.
@@ -1805,7 +1812,7 @@ template<class OtherExtents>
 
 ```c++
 template<class OtherExtents>
-  explicit(rank() > 0) constexpr mapping(
+  explicit(Extents::rank() > 0) constexpr mapping(
   const layout_stride::template mapping<OtherExtents>& other);
 ```
 
@@ -1815,7 +1822,7 @@ template<class OtherExtents>
 
    * [7.1]{.pnum} `other.stride(0)` equals `1`, and
 
-   * [7.2]{.pnum} for all `r` in the range $[1,$ `rank()`$)$, `other.stride(r)` equals
+   * [7.2]{.pnum} for all `r` in the range $[1,$ `Extents::rank()`$)$, `other.stride(r)` equals
                   the product of `extents().extent(k)` for all `k` in the range of $[0,$ `r`$)$.
 
 * [8]{.pnum} *Effects:* Initializes `extents_` with `other.extents()`.
@@ -1824,7 +1831,7 @@ template<class OtherExtents>
 constexpr size_type required_span_size() const noexcept;
 ```
 
-* [9]{.pnum} *Returns:* If `Extents::rank() > 0` is true, the product of `extents().extent(r)` for all `r` in the range $[0,$ `Extents::rank()` $)$. Otherwise, 1.
+* [9]{.pnum} *Returns:* If `Extents::rank() > 0` is `true`, the product of `extents().extent(r)` for all `r` in the range $[0,$ `Extents::rank()` $)$. Otherwise, 1.
 
 
 ```c++
@@ -1841,8 +1848,8 @@ template<class... Indices>
 * [11]{.pnum} *Preconditions:* $0\:\le$ `array{i...}[r]` $\lt$ `extents().extent(r)` for all `r` in the range $[0,$ `Extents::rank()` $)$.
 
 * [12]{.pnum} *Effects:* Let `P...` be the parameter pack such that
-              `is_same_v<make_index_sequence<size_type, sizeof...(Indices)>, integer_sequence<size_type, P...>>` is `true`.
-              <br/> Equivalent to: `return Extents::rank() > 0 ? (i*stride(P()) + ...) : 0;` 
+              `is_same_v<make_index_sequence<sizeof...(Indices)>, index_sequence<P...>>` is `true`.
+              <br/> Equivalent to: `return ((i*stride(P)) + ... + 0);`
 
 ```c++
 constexpr size_type stride(size_t r) const;
@@ -1900,9 +1907,9 @@ struct layout_right {
     template<class OtherExtents>
       explicit(!std::is_convertible_v<OtherExtents,Extents>)
       constexpr mapping(const layout_left::template mapping<OtherExtents>&) noexcept
-      requires(rank() <= 1);
+      requires(Extents::rank() <= 1);
     template<class OtherExtents>
-      explicit(rank() > 0) constexpr mapping(
+      explicit(Extents::rank() > 0) constexpr mapping(
       const layout_stride::template mapping<OtherExtents>& other) noexcept;
 
     constexpr mapping& operator=(const mapping&) noexcept = default;
@@ -1960,7 +1967,7 @@ template<class OtherExtents>
 template<class OtherExtents>
   explicit(!std::is_convertible_v<OtherExtents,Extents>)
   constexpr mapping(const layout_left::template mapping<OtherExtents>& other) noexcept
-  requires(rank() <= 1);
+  requires(Extents::rank() <= 1);
 ```
 
 * [4]{.pnum} *Constraints:* `is_constructible_v<Extents,OtherExtents>` is `true`.
@@ -1969,7 +1976,7 @@ template<class OtherExtents>
 
 ```c++
 template<class OtherExtents>
-  explicit(rank() > 0) constexpr mapping(
+  explicit(Extents::rank() > 0) constexpr mapping(
   const layout_stride::template mapping<OtherExtents>& other) noexcept;
 ```
 
@@ -1977,10 +1984,10 @@ template<class OtherExtents>
 
 * [7]{.pnum} *Preconditions:*
 
-   * [7.1]{.pnum} `other.stride(rank()-1)` equals `1`, and
+   * [7.1]{.pnum} `Extents::rank() == 0 || other.stride(Extents::rank()-1) == 1` is `true`, and
 
-   * [7.2]{.pnum} for all `r` in the range $[0,$ `rank()-2`$)$, `other.stride(r)` equals
-                  the product of `extents().extent(k)` for all `k` in the range of $[r+1,$ `rank()`$)$.
+   * [7.2]{.pnum} for all `r` in the range $[0,$ `Extents::rank()-2`$)$, `other.stride(r)` equals
+                  the product of `extents().extent(k)` for all `k` in the range of $[r+1,$ `Extents::rank()`$)$.
 
 * [8]{.pnum} *Effects:* Initializes `extents_` with `other.extents()`.
 
@@ -1988,7 +1995,7 @@ template<class OtherExtents>
 size_type required_span_size() const noexcept;
 ```
 
-* [9]{.pnum} *Returns:* If `Extents::rank() > 0` is true, the product of `extents().extent(r)` for all `r` in the range $[0,$ `Extents::rank()` $)$. Otherwise, 1.
+* [9]{.pnum} *Returns:* If `Extents::rank() > 0` is `true`, the product of `extents().extent(r)` for all `r` in the range $[0,$ `Extents::rank()` $)$. Otherwise, 1.
 
 ```c++
 template<class... Indices> 
@@ -2004,8 +2011,8 @@ template<class... Indices>
 * [11]{.pnum} *Preconditions:* $0\:\le$ `array{i...}[r]` $\lt$ `extents().extent(r)` for all `r` in the range $[0,$ `Extents::rank()` $)$.
 
 * [11]{.pnum} *Effects:* Let `P...` be the parameter pack such that
-              `is_same_v<make_index_sequence<size_type, sizeof...(Indices)>, integer_sequence<size_type, P...>>` is `true`.
-              <br/> Equivalent to: `return Extents::rank() > 0 ? (i*stride(P()) + ...) : 0;` 
+              `is_same_v<make_index_sequence<sizeof...(Indices)>, index_sequence<P...>>` is `true`.
+              <br/> Equivalent to: `return ((i*stride(P)) + ... + 0);`
 
 ```c++
 constexpr size_type stride(size_t r) const noexcept;
@@ -2122,7 +2129,7 @@ constexpr mapping(const Extents& e, array<SizeType, N> s) noexcept;
 
     * [2.1]{.pnum} `is_convertible_v<SizeType, size_type>` is `true` and
 
-    * [2.2]{.pnum} `N == rank()` is `true`.
+    * [2.2]{.pnum} `N == Extents::rank()` is `true`.
 
 * [3]{.pnum} *Preconditions:*
 
@@ -2164,7 +2171,7 @@ template<class LayoutMapping>
 
 
 * [8]{.pnum} *Effects:* Initializes `extents_` with `other.extents()`, and initializes `strides_` such that
-  `strides_[r] == other.stride(r)` is true for all $r$ in the range $[0,$ `Extents::rank()` $)$.
+  `strides_[r] == other.stride(r)` is `true` for all $r$ in the range $[0,$ `Extents::rank()` $)$.
 
 * [9]{.pnum} *Remarks:* The expression inside `explicit` is equivalent to:
   `!std::is_convertible_v<typename LayoutMapping::extents_type,Extents>`.
@@ -2175,7 +2182,7 @@ constexpr size_type required_span_size() const noexcept;
 
 * [11]{.pnum} *Returns:*
 
-    * [11.1]{.pnum} One plus the sum of `(extents().extent(r) - 1) * stride(r)` for all `r` in the range $[0,$ `Extents::rank()` $)$ if `(extents().extent(r) > 0)` is true for all `r` in the range $[0,$ `Extents::rank()` $)$.
+    * [11.1]{.pnum} One plus the sum of `(extents().extent(r) - 1) * stride(r)` for all `r` in the range $[0,$ `Extents::rank()` $)$ if `(extents().extent(r) > 0)` is `true` for all `r` in the range $[0,$ `Extents::rank()` $)$.
 
     * [11.2]{.pnum} Otherwise, `0`.
 
@@ -2193,8 +2200,8 @@ template<class... Indices>
 * [13]{.pnum} *Preconditions:* $0\:\le$ `array{i...}[r]` $\lt$ `extents().extent(r)` for all `r` in the range $[0,$ `Extents::rank()` $)$.
 
 * [14]{.pnum} *Effects:* Let `P...` be the parameter pack such that
-              `is_same_v<make_index_sequence<size_type, sizeof...(Indices)>, integer_sequence<size_type, P...>>` is `true`.
-              <br/> Equivalent to: `return Extents::rank() > 0 ? (i*stride(P()) + ...) : 0;` 
+              `is_same_v<make_index_sequence<sizeof...(Indices)>, index_sequence<P...>>` is `true`.
+              <br/> Equivalent to: `return ((i*stride(P)) + ... + 0);`
 
 ```c++
 constexpr bool is_contiguous() const noexcept;
@@ -2438,7 +2445,7 @@ public:
   using extents_type = Extents;
   using layout_type = LayoutPolicy;
   using accessor_type = AccessorPolicy;
-  using mapping_type = typename layout_type::template mapping_type<extents_type>;
+  using mapping_type = typename layout_type::template mapping<extents_type>;
   using element_type = ElementType;
   using value_type = remove_cv_t<element_type>;
   using size_type = size_t ;
@@ -2591,7 +2598,11 @@ template<class SizeType, size_t N>
 
     + [3.4]{.pnum} `is_default_constructible_v<accessor_type>` is `true`.
 
-* [4]{.pnum} *Effects:* Equivalent to: `mdspan(p, exts[Rs]...)`, with `Rs...` from `index_sequence<Rs...>` matching `make_index_sequence<N>`.
+* [4]{.pnum} *Effects:*
+
+    + [4.1]{.pnum} Initializes `ptr_` with `p`, and
+
+    + [4.2]{.pnum} Initializes `map_` with `Extents(exts)`.
 
 ```c++
 constexpr mdspan(pointer p, const Extents& ext);
@@ -2809,10 +2820,11 @@ define the values of `first[r]` and `last[r]` as follows:
 * If `src.is_strided()` is `true`, then `sub.is_strided()` is `true`,
   and for all `k` in the range `[0, src.rank())`, if `map_rank[k] != dynamic_extent` is `true`, then
   `sub.stride(map_rank[k])` equals `src.stride(k)`.
-* For all `k` in the range `[0, src.rank())`, if `map_rank[k] != dynamic_extent` is `true` and 
-  `src.static_extent(k)` does not equal `dynamic_extent` and
-  `is_convertible_v<`$S_k$`,full_extent_t>` is `true`,
-  then `sub.static_extent(map_rank[k])` equals `src.static_extent(k)`.
+* For all `k` in the range `[0, src.rank())`, if `map_rank[k] != dynamic_extent` is `true`, then:
+  * if `src.static_extent(k)` does not equal `dynamic_extent` and
+    `is_convertible_v<`$S_k$`,full_extent_t>` is `true`,
+    then `sub.static_extent(map_rank[k])` equals `src.static_extent(k)`, otherwise
+  * `sub.static_extent(map_rank[k])` equals `dynamic_extent`.
 * If `LayoutPolicy` is `layout_left` and `sub.rank() > 0` is `true`, then:
   * if `is_convertible_v<`$S_k$`,full_extent_t>` is `true` for all
     `k` in the range $[0,$`sub.rank()-1`$)$ and


### PR DESCRIPTION
I mentioned to @crtrott by private email that I was working on an `mdspan` implementation. I'm still implmenting `submdspan`, but I think I've now read all the wording closely enough to offer a single set of wording suggestions. From the changelog:

- Consistently use "`<`_expr_`>` is `true`" instead of "`<`*expr*`>` is true".
- In the layout mappings' `operator()` *Effects* clauses, use only `index_sequence`and fix syntax error in `stride(P())`.
- Replace various unary folds with binary to handle `extents<>`.
- Consistently use `Extents::rank()` in layout mapping wording.
- Typo in `mdspan::mapping_type`: `template mapping_type` should be `template mapping`.
- `mdspan`'s `array` constructor calls `Extents`'s `array` constructor.
- Clarify the value of `static_stride` for `submdspan`'s result.

I'm happy to discuss or clarify any of these, or remove any that you'd rather not change.