### PR TITLE
Exposition only rename

### DIFF
--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -2462,19 +2462,19 @@ public:
   template<class SizeType, size_t N>
     constexpr reference operator[](const array<SizeType, N>& indices) const;
 
-  constexpr accessor_type accessor() const { return acc_; }
+  constexpr accessor_type accessor() const { return @_acc__@; }
 
   static constexpr size_t rank() { return Extents::rank(); }
   static constexpr size_t rank_dynamic() { return Extents::rank_dynamic(); }
   static constexpr size_type static_extent(size_t r) { return Extents::static_extent(r); }
 
-  constexpr Extents extents() const { return map_.extents(); }
+  constexpr Extents extents() const { return @_map__@.extents(); }
   constexpr size_type extent(size_t r) const { return extents().extent(r); }
   constexpr size_type size() const;
 
   // [mdspan.basic.codomain], mdspan observers of the codomain
-  constexpr pointer data() const { return ptr_; }
-  constexpr mapping_type mapping() const { return map_; }
+  constexpr pointer data() const { return @_ptr__@; }
+  constexpr mapping_type mapping() const { return @_map__@; }
 
   static constexpr bool is_always_unique() {
     return mapping_type::is_always_unique();
@@ -2487,22 +2487,22 @@ public:
   }
 
   constexpr bool is_unique() const {
-    return map_.is_unique();
+    return @_map__@.is_unique();
   }
   constexpr bool is_contiguous() const {
-    return map_.is_contiguous();
+    return @_map__@.is_contiguous();
   }
   constexpr bool is_strided() const {
-    return map_.is_strided();
+    return @_map__@.is_strided();
   }
   constexpr size_type stride(size_t r) const {
-    return map_.stride(r);
+    return @_map__@.stride(r);
   }
 
 private:
-  accessor_type acc_; // @_exposition only_@
-  mapping_type map_; // @_exposition only_@
-  pointer ptr_{}; // @_exposition only_@
+  accessor_type @_acc__@; // @_exposition only_@
+  mapping_type @_map__@; // @_exposition only_@
+  pointer @_ptr__@{}; // @_exposition only_@
 };
 
 template <class ElementType, class... Integrals>
@@ -2519,7 +2519,7 @@ mdspan(ElementType*, const extents<ExtentsPack...>&)
 
 template <class ElementType, class MappingType>
 mdspan(ElementType*, const MappingType&)
-  -> mdspan<ElementType, typename MappingType::extents_type, 
+  -> mdspan<ElementType, typename MappingType::extents_type,
             typename MappingType::layout_type>;
 
 template <class ElementType, class MappingType, class AccessorType>
@@ -2580,9 +2580,9 @@ template<class... SizeTypes>
 
 * [2]{.pnum} *Effects:*
 
-    + [2.1]{.pnum} Initializes `ptr_` with `ptr`, and
+    + [2.1]{.pnum} Initializes `@_ptr__@` with `ptr`, and
 
-    + [2.2]{.pnum} Initializes `map_` with `Extents(exts...)`.
+    + [2.2]{.pnum} Initializes `@_map__@` with `Extents(exts...)`.
 
 ```c++
 template<class SizeType, size_t N>
@@ -2602,9 +2602,9 @@ template<class SizeType, size_t N>
 
 * [4]{.pnum} *Effects:*
 
-    + [4.1]{.pnum} Initializes `ptr_` with `p`, and
+    + [4.1]{.pnum} Initializes `@_ptr__@` with `p`, and
 
-    + [4.2]{.pnum} Initializes `map_` with `Extents(exts)`.
+    + [4.2]{.pnum} Initializes `@_map__@` with `Extents(exts)`.
 
 ```c++
 constexpr mdspan(pointer p, const Extents& ext);
@@ -2626,9 +2626,9 @@ constexpr mdspan(pointer p, const mapping_type& m);
 
 * [8]{.pnum} *Effects:*
 
-    + [8.1]{.pnum} Initializes `ptr_` with `p`, and
+    + [8.1]{.pnum} Initializes `@_ptr__@` with `p`, and
 
-    + [8.2]{.pnum} Initializes `map_` with `m`.
+    + [8.2]{.pnum} Initializes `@_map__@` with `m`.
 
 ```c++
 constexpr mdspan(pointer p, const mapping_type& m, const accessor_type& a);
@@ -2636,11 +2636,11 @@ constexpr mdspan(pointer p, const mapping_type& m, const accessor_type& a);
 
 * [9]{.pnum}*Effects:*
 
-    + [9.1]{.pnum} Initializes `ptr_` with `p`,
+    + [9.1]{.pnum} Initializes `@_ptr__@` with `p`,
 
-    + [9.2]{.pnum} Initializes `map_` with `m`, and
+    + [9.2]{.pnum} Initializes `@_map__@` with `m`, and
 
-    + [9.3]{.pnum} Initializes `acc_` with `a`.
+    + [9.3]{.pnum} Initializes `@_acc__@` with `a`.
 
 ```c++
 template<class OtherElementType, class OtherExtents,
@@ -2669,11 +2669,11 @@ template<class OtherElementType, class OtherExtents,
 
 * [12]{.pnum} *Effects:*
 
-    + [12.1]{.pnum} Initializes `ptr_` with `other.ptr_`,
+    + [12.1]{.pnum} Initializes `@_ptr__@` with `other.@_ptr__@`,
 
-    + [12.2]{.pnum} initializes `map_` with `other.map_`, and
+    + [12.2]{.pnum} initializes `@_map__@` with `other.@_map__@`, and
 
-    + [12.3]{.pnum} initializes `acc_` with `other.acc_`.
+    + [12.3]{.pnum} initializes `@_acc__@` with `other.@_acc__@`.
 
 * [13]{.pnum} *Remarks:* The expression inside `explicit` is equivalent to:
              `!std::is_convertible_v<typename OtherLayoutPolicy::mapping_type, mapping_type> ||
@@ -2703,9 +2703,9 @@ template<class... SizeTypes>
 
     + [1.2]{.pnum} `sizeof...(SizeTypes) == rank()` is `true`.
 
-* [2]{.pnum} *Preconditions:* `acc_.access(ptr_, map_(indices...))` shall be valid.
+* [2]{.pnum} *Preconditions:* `@_acc__@.access(@_ptr__@, @_map__@(indices...))` shall be valid.
 
-* [3]{.pnum} *Effects:* Equivalent to: `return acc_.access(ptr_, map_(indices...));`.
+* [3]{.pnum} *Effects:* Equivalent to: `return @_acc__@.access(@_ptr__@, @_map__@(indices...));`.
 
 
 ```c++
@@ -2848,9 +2848,9 @@ define the values of `first[r]` and `last[r]` as follows:
 
 [9]{.pnum} *Effects:*
 
-* Initializes `sub.acc_` with `src.accessor()`.
-* Initializes `sub.ptr_` with `src.accessor().offset(src.data(),apply(src.mapping(),first))`.
-* Initializes `sub.map_` in a way that above conditions are satisfied.
+* Initializes `sub.@_acc__@` with `src.accessor()`.
+* Initializes `sub.@_ptr__@` with `src.accessor().offset(src.data(),apply(src.mapping(),first))`.
+* Initializes `sub.@_map__@` in a way that above conditions are satisfied.
 
 
 <br/>

--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -2066,7 +2066,7 @@ struct layout_stride {
 
     constexpr Extents extents() const noexcept { return extents_; }
     constexpr array<typename size_type, Extents::rank()> strides() const noexcept
-    { return strides_; }
+    { return @_strides__@; }
 
     constexpr size_type required_span_size() const noexcept;
 
@@ -2088,7 +2088,7 @@ struct layout_stride {
 
   private:
     Extents @_extents__@{}; // @_exposition only_@
-    array<size_type, Extents::rank()> strides_{}; // @_exposition only_@
+    array<size_type, Extents::rank()> @_strides__@{}; // @_exposition only_@
   };
 };
 }
@@ -2118,7 +2118,7 @@ constexpr mapping(const Extents& e, array<SizeType, N> s) noexcept;
       such that `s[` $p_i$ `] >= s[` $p_{i-1}$ `] * e.extent(` $p_{i-1}$ `)` is `true`
       for all $i$ in the range $[1,$ `Extents::rank()` $)$.
 
-* [4]{.pnum} *Effects:* Initializes `@_extents__@` with `e`, and initializes `strides_` with `s`.
+* [4]{.pnum} *Effects:* Initializes `@_extents__@` with `e`, and initializes `@_strides__@` with `s`.
 
 ```c++
 template<class OtherExtents>
@@ -2128,7 +2128,7 @@ template<class OtherExtents>
 
 * [5]{.pnum} *Constraints:* `is_constructible_v<Extents,OtherExtents>` is `true`.
 
-* [6]{.pnum} *Effects:* Initializes `@_extents__@` with `other.extents()`, and initializes `strides_` with `other.strides()`.
+* [6]{.pnum} *Effects:* Initializes `@_extents__@` with `other.extents()`, and initializes `@_strides__@` with `other.strides()`.
 
 ```c++
 template<class LayoutMapping>
@@ -2149,8 +2149,8 @@ template<class LayoutMapping>
     * [7.5]{.pnum} `other.is_always_strided()` is `true`.
 
 
-* [8]{.pnum} *Effects:* Initializes `@_extents__@` with `other.extents()`, and initializes `strides_` such that
-  `strides_[r] == other.stride(r)` is `true` for all $r$ in the range $[0,$ `Extents::rank()` $)$.
+* [8]{.pnum} *Effects:* Initializes `@_extents__@` with `other.extents()`, and initializes `@_strides__@` such that
+  `@_strides__@[r] == other.stride(r)` is `true` for all $r$ in the range $[0,$ `Extents::rank()` $)$.
 
 * [9]{.pnum} *Remarks:* The expression inside `explicit` is equivalent to:
   `!std::is_convertible_v<typename LayoutMapping::extents_type,Extents>`.

--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -1367,7 +1367,7 @@ public:
 private:
   static constexpr size_t @_dynamic-index_@(size_t) noexcept; // @_exposition only_@
   static constexpr size_t @_dynamic-index-inv_@(size_t i) noexcept; // @_exposition only_@
-  array<size_type, rank_dynamic()> dynamic_extents_{}; // @_exposition only_@
+  array<size_type, rank_dynamic()> @_dynamic_extents_@{}; // @_exposition only_@
 };
 
 template<class>
@@ -1391,7 +1391,7 @@ of rank equal to `sizeof...(Extents)`.
 
 [4]{.pnum} $E_r$ is a _dynamic extent_ if it is equal to `dynamic_extent`, otherwise $E_r$ is a _static extent_.
 
-[5]{.pnum} If $E_r$ is a dynamic extent, let $D_r$ be the value of `dynamic_extents_[@_dynamic-index_@(`_r_`)]`.
+[5]{.pnum} If $E_r$ is a dynamic extent, let $D_r$ be the value of `@_dynamic_extents_@[@_dynamic-index_@(`_r_`)]`.
 The $r^{th}$ interval of an `extents` object is as follows: 
   
   * [5.1]{.pnum} $[0, E_r)$ if $E_r$ is a static extent,
@@ -1434,7 +1434,7 @@ template<size_t... OtherExtents>
               `static_extent(r) == dynamic_extent || static_extent(r) == other.extent(r)` is `true`.
 
 * [3]{.pnum} *Effects:* For each $i$ in the range $[0, dynamic_rank())$,
-             initializes the $i^{th}$ element of `dynamic_extents_` with `other.extents(dynamic_extent_inv(i))`.
+             initializes the $i^{th}$ element of `@_dynamic_extents_@` with `other.extents(dynamic_extent_inv(i))`.
 
 * [4]{.pnum} *Remarks:* The expression inside `explicit` is equivalent to:
              `(((Extents!=dynamic_extent) && (OtherExtents==dynamic_extent)) || ... )`
@@ -1466,10 +1466,10 @@ Let `b` be `std::array<size_type,rank()>{exts...}`
 * [7]{.pnum} *Effects:*  
 
     * [7.1]{.pnum} If `sizeof...(sizeTypes)` equals `dynamic_rank()`, 
-                   initializes `dynamic_extents_` with `{exts...}`.
+                   initializes `@_dynamic_extents_@` with `{exts...}`.
 
     * [7.2]{.pnum} If `sizeof...(SizeTypes)` equals `rank()`, 
-                   for each $i$ in the range $[0, rank_dynamic())$, initializes the $i^{th}$ element of `dynamic_extents_`
+                   for each $i$ in the range $[0, rank_dynamic())$, initializes the $i^{th}$ element of `@_dynamic_extents_@`
                    with `std::array<size_type,rank()>{exts...}[@_dynamic-index-inv_@(i)]`.
 
 ```c++
@@ -1490,10 +1490,10 @@ template<class SizeType, size_t N>
 * [10]{.pnum} *Effects:*  
 
     * [10.1]{.pnum} If `N` equals `dynamic_rank()`, 
-                   initializes `dynamic_extents_` with `exts`.
+                   initializes `@_dynamic_extents_@` with `exts`.
 
     * [10.2]{.pnum} If `N` equals `rank()`, 
-                   for all $d$ in the range `[0, rank_dynamic())`, initializes `dynamic_extents_[d]`
+                   for all $d$ in the range `[0, rank_dynamic())`, initializes `@_dynamic_extents_@[d]`
                    with `exts[@_dynamic-index-inv_@(d)]`.
 
 <br/>
@@ -1513,7 +1513,7 @@ constexpr size_type extent(size_t r) const noexcept;
 
 * [3]{.pnum} *Preconditions:* `r < rank()` is `true`.
 
-* [4]{.pnum} *Returns:* `dynamic_extents_[@_dynamic-index_@(r)]` if `static_extent(r) == dynamic_extent` is `true`, otherwise `static_extent(r)`.
+* [4]{.pnum} *Returns:* `@_dynamic_extents_@[@_dynamic-index_@(r)]` if `static_extent(r) == dynamic_extent` is `true`, otherwise `static_extent(r)`.
 
 <br/>
 <b>22.7.�.4 `extents` comparison operators [mdspan.extents.compare]</b>

--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -1754,7 +1754,7 @@ struct layout_left {
       friend constexpr bool operator==(const mapping&, const mapping<OtherExtents>&) noexcept;
 
   private:
-    Extents extents_{}; // @_exposition only_@
+    Extents @_extents__@{}; // @_exposition only_@
   };
 };
 }
@@ -1766,7 +1766,7 @@ struct layout_left {
 constexpr mapping(const Extents& e) noexcept;
 ```
 
-* [1]{.pnum} *Effects:* Initializes `extents_` with `e`.
+* [1]{.pnum} *Effects:* Initializes `@_extents__@` with `e`.
 
 ```c++
 template<class OtherExtents>
@@ -1776,7 +1776,7 @@ template<class OtherExtents>
 
 * [2]{.pnum} *Constraints:* `is_constructible_v<Extents,OtherExtents>` is `true`.
 
-* [3]{.pnum} *Effects:* Initializes `extents_` with `other.extents()`.
+* [3]{.pnum} *Effects:* Initializes `@_extents__@` with `other.extents()`.
 
 ```c++
 template<class OtherExtents>
@@ -1787,7 +1787,7 @@ template<class OtherExtents>
 
 * [4]{.pnum} *Constraints:* `is_constructible_v<Extents,OtherExtents>` is `true`.
 
-* [5]{.pnum} *Effects:* Initializes `extents_` with `other.extents()`.
+* [5]{.pnum} *Effects:* Initializes `@_extents__@` with `other.extents()`.
 
 ```c++
 template<class OtherExtents>
@@ -1804,7 +1804,7 @@ template<class OtherExtents>
    * [7.2]{.pnum} for all `r` in the range $[1,$ `Extents::rank()`$)$, `other.stride(r)` equals
                   the product of `extents().extent(k)` for all `k` in the range of $[0,$ `r`$)$.
 
-* [8]{.pnum} *Effects:* Initializes `extents_` with `other.extents()`.
+* [8]{.pnum} *Effects:* Initializes `@_extents__@` with `other.extents()`.
 
 ```c++
 constexpr size_type required_span_size() const noexcept;
@@ -1915,7 +1915,7 @@ struct layout_right {
       friend constexpr bool operator==(const mapping&, const mapping<OtherExtents>&) noexcept;
 
   private:
-    Extents extents_{}; // @_exposition only_@
+    Extents @_extents__@{}; // @_exposition only_@
   };
 };
 }
@@ -1929,7 +1929,7 @@ struct layout_right {
 constexpr mapping(const Extents& e) noexcept;
 ```
 
-* [1]{.pnum} *Effects:* Initializes `extents_` with `e`.
+* [1]{.pnum} *Effects:* Initializes `@_extents__@` with `e`.
 
 
 ```c++
@@ -1940,7 +1940,7 @@ template<class OtherExtents>
 
 * [2]{.pnum} *Constraints:* `is_constructible_v<Extents,OtherExtents>` is `true`.
 
-* [3]{.pnum} *Effects:* Initializes `extents_` with `other.extents()`.
+* [3]{.pnum} *Effects:* Initializes `@_extents__@` with `other.extents()`.
 
 ```c++
 template<class OtherExtents>
@@ -1951,7 +1951,7 @@ template<class OtherExtents>
 
 * [4]{.pnum} *Constraints:* `is_constructible_v<Extents,OtherExtents>` is `true`.
 
-* [5]{.pnum} *Effects:* Initializes `extents_` with `other.extents()`.
+* [5]{.pnum} *Effects:* Initializes `@_extents__@` with `other.extents()`.
 
 ```c++
 template<class OtherExtents>
@@ -1968,7 +1968,7 @@ template<class OtherExtents>
    * [7.2]{.pnum} for all `r` in the range $[0,$ `Extents::rank()-2`$)$, `other.stride(r)` equals
                   the product of `extents().extent(k)` for all `k` in the range of $[r+1,$ `Extents::rank()`$)$.
 
-* [8]{.pnum} *Effects:* Initializes `extents_` with `other.extents()`.
+* [8]{.pnum} *Effects:* Initializes `@_extents__@` with `other.extents()`.
 
 ```c++
 size_type required_span_size() const noexcept;
@@ -2087,7 +2087,7 @@ struct layout_stride {
       friend constexpr bool operator==(const mapping&, const mapping<OtherExtents>&) noexcept;
 
   private:
-    Extents extents_{}; // @_exposition only_@
+    Extents @_extents__@{}; // @_exposition only_@
     array<size_type, Extents::rank()> strides_{}; // @_exposition only_@
   };
 };
@@ -2118,7 +2118,7 @@ constexpr mapping(const Extents& e, array<SizeType, N> s) noexcept;
       such that `s[` $p_i$ `] >= s[` $p_{i-1}$ `] * e.extent(` $p_{i-1}$ `)` is `true`
       for all $i$ in the range $[1,$ `Extents::rank()` $)$.
 
-* [4]{.pnum} *Effects:* Initializes `extents_` with `e`, and initializes `strides_` with `s`.
+* [4]{.pnum} *Effects:* Initializes `@_extents__@` with `e`, and initializes `strides_` with `s`.
 
 ```c++
 template<class OtherExtents>
@@ -2128,7 +2128,7 @@ template<class OtherExtents>
 
 * [5]{.pnum} *Constraints:* `is_constructible_v<Extents,OtherExtents>` is `true`.
 
-* [6]{.pnum} *Effects:* Initializes `extents_` with `other.extents()`, and initializes `strides_` with `other.strides()`.
+* [6]{.pnum} *Effects:* Initializes `@_extents__@` with `other.extents()`, and initializes `strides_` with `other.strides()`.
 
 ```c++
 template<class LayoutMapping>
@@ -2149,7 +2149,7 @@ template<class LayoutMapping>
     * [7.5]{.pnum} `other.is_always_strided()` is `true`.
 
 
-* [8]{.pnum} *Effects:* Initializes `extents_` with `other.extents()`, and initializes `strides_` such that
+* [8]{.pnum} *Effects:* Initializes `@_extents__@` with `other.extents()`, and initializes `strides_` such that
   `strides_[r] == other.stride(r)` is `true` for all $r$ in the range $[0,$ `Extents::rank()` $)$.
 
 * [9]{.pnum} *Remarks:* The expression inside `explicit` is equivalent to:

--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -1365,8 +1365,8 @@ public:
     friend constexpr bool operator==(const extents&, const extents<OtherExtents...>&) noexcept;
 
 private:
-  static constexpr size_t dynamic_index(size_t) noexcept; // @_exposition only_@
-  static constexpr size_t dynamic_index_inv(size_t i) noexcept; // @_exposition only_@
+  static constexpr size_t @_dynamic-index_@(size_t) noexcept; // @_exposition only_@
+  static constexpr size_t @_dynamic-index-inv_@(size_t i) noexcept; // @_exposition only_@
   array<size_type, rank_dynamic()> dynamic_extents_{}; // @_exposition only_@
 };
 
@@ -1391,7 +1391,7 @@ of rank equal to `sizeof...(Extents)`.
 
 [4]{.pnum} $E_r$ is a _dynamic extent_ if it is equal to `dynamic_extent`, otherwise $E_r$ is a _static extent_.
 
-[5]{.pnum} If $E_r$ is a dynamic extent, let $D_r$ be the value of `dynamic_extents_[dynamic_index(`_r_`)]`.
+[5]{.pnum} If $E_r$ is a dynamic extent, let $D_r$ be the value of `dynamic_extents_[@_dynamic-index_@(`_r_`)]`.
 The $r^{th}$ interval of an `extents` object is as follows: 
   
   * [5.1]{.pnum} $[0, E_r)$ if $E_r$ is a static extent,
@@ -1401,7 +1401,7 @@ The $r^{th}$ interval of an `extents` object is as follows:
 ---
 
 ```c++
-constexpr size_t dynamic_index(size_t i) noexcept; // @_exposition only_@
+constexpr size_t @_dynamic-index_@(size_t i) noexcept; // @_exposition only_@
 ```
 
 * [7]{.pnum} *Precondition:* `i <= rank()` is `true` 
@@ -1409,12 +1409,12 @@ constexpr size_t dynamic_index(size_t i) noexcept; // @_exposition only_@
 * [8]{.pnum} *Returns:* Number of $E_r$ with $r<i$ for which $E_r$ is a dynamic extent.
 
 ```c++
-constexpr size_t dynamic_index_inv(size_t i) noexcept; // @_exposition only_@
+constexpr size_t @_dynamic-index-inv_@(size_t i) noexcept; // @_exposition only_@
 ```
 
 * [9]{.pnum} *Precondition:* `i < rank_dynamic()` is `true`
 
-* [10]{.pnum} *Returns:* Minimum value of $r$ such that `dynamic_index(`$r$`+1) == i+1` is `true`.
+* [10]{.pnum} *Returns:* Minimum value of $r$ such that `@_dynamic-index_@(`$r$`+1) == i+1` is `true`.
 
 <b>22.7.�.3 Constructors and assignment [mdspan.extents.cons]</b>
 
@@ -1470,7 +1470,7 @@ Let `b` be `std::array<size_type,rank()>{exts...}`
 
     * [7.2]{.pnum} If `sizeof...(SizeTypes)` equals `rank()`, 
                    for each $i$ in the range $[0, rank_dynamic())$, initializes the $i^{th}$ element of `dynamic_extents_`
-                   with `std::array<size_type,rank()>{exts...}[dynamic_index_inv(i)]`.
+                   with `std::array<size_type,rank()>{exts...}[@_dynamic-index-inv_@(i)]`.
 
 ```c++
 template<class SizeType, size_t N>
@@ -1494,7 +1494,7 @@ template<class SizeType, size_t N>
 
     * [10.2]{.pnum} If `N` equals `rank()`, 
                    for all $d$ in the range `[0, rank_dynamic())`, initializes `dynamic_extents_[d]`
-                   with `exts[dynamic_index_inv(d)]`.
+                   with `exts[@_dynamic-index-inv_@(d)]`.
 
 <br/>
 <b>22.7.�.3 Observers of the domain multidimensional index space [mdspan.extents.obs]</b>
@@ -1513,7 +1513,7 @@ constexpr size_type extent(size_t r) const noexcept;
 
 * [3]{.pnum} *Preconditions:* `r < rank()` is `true`.
 
-* [4]{.pnum} *Returns:* `dynamic_extents_[dynamic_index(r)]` if `static_extent(r) == dynamic_extent` is `true`, otherwise `static_extent(r)`.
+* [4]{.pnum} *Returns:* `dynamic_extents_[@_dynamic-index_@(r)]` if `static_extent(r) == dynamic_extent` is `true`, otherwise `static_extent(r)`.
 
 <br/>
 <b>22.7.�.4 `extents` comparison operators [mdspan.extents.compare]</b>

--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -1367,7 +1367,7 @@ public:
 private:
   static constexpr size_t @_dynamic-index_@(size_t) noexcept; // @_exposition only_@
   static constexpr size_t @_dynamic-index-inv_@(size_t i) noexcept; // @_exposition only_@
-  array<size_type, rank_dynamic()> @_dynamic_extents_@{}; // @_exposition only_@
+  array<size_type, rank_dynamic()> @_dynamic-extents_@{}; // @_exposition only_@
 };
 
 template<class>
@@ -1391,7 +1391,7 @@ of rank equal to `sizeof...(Extents)`.
 
 [4]{.pnum} $E_r$ is a _dynamic extent_ if it is equal to `dynamic_extent`, otherwise $E_r$ is a _static extent_.
 
-[5]{.pnum} If $E_r$ is a dynamic extent, let $D_r$ be the value of `@_dynamic_extents_@[@_dynamic-index_@(`_r_`)]`.
+[5]{.pnum} If $E_r$ is a dynamic extent, let $D_r$ be the value of `@_dynamic-extents_@[@_dynamic-index_@(`_r_`)]`.
 The $r^{th}$ interval of an `extents` object is as follows: 
   
   * [5.1]{.pnum} $[0, E_r)$ if $E_r$ is a static extent,
@@ -1434,7 +1434,7 @@ template<size_t... OtherExtents>
               `static_extent(r) == dynamic_extent || static_extent(r) == other.extent(r)` is `true`.
 
 * [3]{.pnum} *Effects:* For each $i$ in the range $[0, dynamic_rank())$,
-             initializes the $i^{th}$ element of `@_dynamic_extents_@` with `other.extents(dynamic_extent_inv(i))`.
+             initializes the $i^{th}$ element of `@_dynamic-extents_@` with `other.extents(@_dynamic-index-inv_@(i))`.
 
 * [4]{.pnum} *Remarks:* The expression inside `explicit` is equivalent to:
              `(((Extents!=dynamic_extent) && (OtherExtents==dynamic_extent)) || ... )`
@@ -1466,10 +1466,10 @@ Let `b` be `std::array<size_type,rank()>{exts...}`
 * [7]{.pnum} *Effects:*  
 
     * [7.1]{.pnum} If `sizeof...(sizeTypes)` equals `dynamic_rank()`, 
-                   initializes `@_dynamic_extents_@` with `{exts...}`.
+                   initializes `@_dynamic-extents_@` with `{exts...}`.
 
     * [7.2]{.pnum} If `sizeof...(SizeTypes)` equals `rank()`, 
-                   for each $i$ in the range $[0, rank_dynamic())$, initializes the $i^{th}$ element of `@_dynamic_extents_@`
+                   for each $i$ in the range $[0, rank_dynamic())$, initializes the $i^{th}$ element of `@_dynamic-extents_@`
                    with `std::array<size_type,rank()>{exts...}[@_dynamic-index-inv_@(i)]`.
 
 ```c++
@@ -1490,10 +1490,10 @@ template<class SizeType, size_t N>
 * [10]{.pnum} *Effects:*  
 
     * [10.1]{.pnum} If `N` equals `dynamic_rank()`, 
-                   initializes `@_dynamic_extents_@` with `exts`.
+                   initializes `@_dynamic-extents_@` with `exts`.
 
     * [10.2]{.pnum} If `N` equals `rank()`, 
-                   for all $d$ in the range `[0, rank_dynamic())`, initializes `@_dynamic_extents_@[d]`
+                   for all $d$ in the range `[0, rank_dynamic())`, initializes `@_dynamic-extents_@[d]`
                    with `exts[@_dynamic-index-inv_@(d)]`.
 
 <br/>
@@ -1513,7 +1513,7 @@ constexpr size_type extent(size_t r) const noexcept;
 
 * [3]{.pnum} *Preconditions:* `r < rank()` is `true`.
 
-* [4]{.pnum} *Returns:* `@_dynamic_extents_@[@_dynamic-index_@(r)]` if `static_extent(r) == dynamic_extent` is `true`, otherwise `static_extent(r)`.
+* [4]{.pnum} *Returns:* `@_dynamic-extents_@[@_dynamic-index_@(r)]` if `static_extent(r) == dynamic_extent` is `true`, otherwise `static_extent(r)`.
 
 <br/>
 <b>22.7.�.4 `extents` comparison operators [mdspan.extents.compare]</b>


### PR DESCRIPTION
This follows guidance that all expositon only names should be cursive themselves. 