### PR TITLE
P1673: Fix givens_rotation_setup typo

### DIFF
--- a/D1673/P1673.bs
+++ b/D1673/P1673.bs
@@ -2,13 +2,13 @@
 Title: A free function linear algebra interface based on the BLAS
 Shortname: P1673
 Status: iso/P
-Level: 7
+Level: 8
 Group: WG21
 URL: https://github.com/ORNL/cpp-proposals-pub/blob/master/D1673/P1673.bs
 Editor: Mark Hoemmen, NVIDIA, mark.hoemmen@stellarscience.com
 Abstract: We propose a C++ Standard Library dense linear algebra interface based on the dense Basic Linear Algebra Subroutines (BLAS).  This corresponds to a subset of the BLAS Standard.
 Markup Shorthands: markdown yes
-Date: 2022-04-15
+Date: 202?-??-??
 </pre>
 
 # Authors and contributors
@@ -257,6 +257,11 @@ Date: 2022-04-15
         in `vector_norm2` note
 
     * Fill in missing parts of `matrix_frob_norm` and `vector_norm2` specification, addressing <a href="https://github.com/kokkos/stdBLAS/issues/143">this issue</a>
+
+* Revision 8 (electronic), to be submitted 202?-??-??
+
+    * Fix typo in `givens_rotation_setup` for complex numbers
+        (thanks to Phil Miller `phil.miller@intensecomputing.com` for reporting the issue)
 
 # Purpose of this paper
 
@@ -2644,7 +2649,7 @@ void givens_rotation_setup(const Real a,
                            Real& r);
 template<class Real>
 void givens_rotation_setup(const complex<Real>& a,
-                           const complex<Real>& a,
+                           const complex<Real>& b,
                            Real& c,
                            complex<Real>& s,
                            complex<Real>& r);
@@ -5687,7 +5692,7 @@ void givens_rotation_setup(const Real a,
 
 template<class Real>
 void givens_rotation_setup(const complex<Real>& a,
-                           const complex<Real>& a,
+                           const complex<Real>& b,
                            Real& c,
                            complex<Real>& s,
                            complex<Real>& r);


### PR DESCRIPTION
Fix typo in `givens_rotation_setup` for complex numbers.

Fixes #230.