### PR TITLE
P0009: Some small changes to harmonize with span

### DIFF
--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -2238,7 +2238,7 @@ class layout_stride::mapping {
     constexpr size_type required_span_size() const noexcept;
 
     template<class... Indices>
-      constexpr size_type operator()(Indices...) const noexcept ;
+      constexpr size_type operator()(Indices...) const noexcept;
 
     static constexpr bool is_always_unique() noexcept { return true; }
     static constexpr bool is_always_contiguous() noexcept { return false; }
@@ -2642,15 +2642,15 @@ public:
   using mapping_type = typename layout_type::template mapping<extents_type>;
   using element_type = ElementType;
   using value_type = remove_cv_t<element_type>;
-  using size_type = typename extents_type::size_type ;
-  using rank_type = typename extents_type::rank_type ;
+  using size_type = typename extents_type::size_type;
+  using rank_type = typename extents_type::rank_type;
   using pointer = typename accessor_type::pointer;
   using reference = typename accessor_type::reference;
 
-  static constexpr rank_type rank() { return extents_type::rank(); }
-  static constexpr rank_type rank_dynamic() { return extents_type::rank_dynamic(); }
-  static constexpr size_t static_extent(rank_type r) { return extents_type::static_extent(r); }
-  constexpr size_type extent(rank_type r) const { return extents().extent(r); }
+  static constexpr rank_type rank() noexcept { return extents_type::rank(); }
+  static constexpr rank_type rank_dynamic() noexcept { return extents_type::rank_dynamic(); }
+  static constexpr size_t static_extent(rank_type r) noexcept { return extents_type::static_extent(r); }
+  constexpr size_type extent(rank_type r) const noexcept { return extents().extent(r); }
 
   // [mdspan.mdspan.ctor], mdspan Constructors
   constexpr mdspan();
@@ -2687,14 +2687,15 @@ public:
   template<class SizeType>
     constexpr reference operator[](const array<SizeType, rank()>& indices) const;
 
-  constexpr size_t size() const;
+  constexpr size_t size() const noexcept;
+  [[nodiscard]] constexpr bool empty() const noexcept;
 
   friend constexpr void swap(mdspan& x, mdspan& y) noexcept;
 
-  constexpr const extents_type& extents() const { return @_map\__@.extents(); }
-  constexpr const pointer& data() const { return @_ptr\__@; }
-  constexpr const mapping_type& mapping() const { return @_map\__@; }
-  constexpr const accessor_type& accessor() const { return @_acc\__@; }
+  constexpr const extents_type& extents() const noexcept { return @_map\__@.extents(); }
+  constexpr const pointer& data() const noexcept { return @_ptr\__@; }
+  constexpr const mapping_type& mapping() const noexcept { return @_map\__@; }
+  constexpr const accessor_type& accessor() const noexcept { return @_acc\__@; }
 
   static constexpr bool is_always_unique() {
     return mapping_type::is_always_unique();
@@ -3013,7 +3014,7 @@ template<class SizeType>
             <br/> Equivalent to: `return operator[](static_cast<size_type>(as_const(indices[P]))...);`
 
 ```c++
-constexpr size_type size() const;
+constexpr size_type size() const noexcept;
 ```
 
 [7]{.pnum} *Precondition:* The size of the multidimensional index space `extents()` is a representable value of type `size_type` ([basic.fundamental]).
@@ -3021,10 +3022,16 @@ constexpr size_type size() const;
 [8]{.pnum} *Returns:* `extents().`_`fwd-prod-of-extents`_`(rank())`.
 
 ```c++
+[[nodiscard]] constexpr bool empty() const noexcept;
+```
+
+[9]{.pnum} *Effects:* Equivalent to: `return size() == 0;`
+
+```c++
 friend constexpr void swap(mdspan& x, mdspan& y) noexcept;
 ```
 
-[9]{.pnum} *Effects:* Equivalent to:
+[10]{.pnum} *Effects:* Equivalent to:
 
 ```c++
 swap(x.@_ptr\__@, y.@_ptr\__@);


### PR DESCRIPTION
Sorry to bother you at this time... I know that P0009 is nearing final review, the following are just some small defects I found in the proposal (or maybe more of some discrepancies with `std::span`). Feel free to ignore this if it is already too late to make changes!

Personally, I agree with #156's decision to remove conditional `noexcept`s in R13. However, I do think that some of the unconditional `noexcept`s removal decisions can have some more inspection into it... for example, `operator[]` should indeed be potentially throwing, since custom accessors can do bound checks and throw exceptions; however, I do think that some "simple enough" and important functions (like `size()` and `data()`) warrant a `noexcept` specification. There are several contributing factors to my conclusion:

First is the fact that we are already (practically) requiring these to be `noexcept` in current P0009. We should notice that the `Extent` parameter is actually required to be a specialization of `std::extents`, and obviously latter is not intended to be customizable (specialized by user), since extents is a pretty fixed concept (freedom is provided in custom layouts). This means that the specification of `std::extents` already dictates how these "wrappers" can perform. Therefore, for functions like `rank()`, the only thing it can invoke is `std::extents<...>::rank()`... which is already marked as `noexcept`! So basically the only thing that the lack of `noexcept` here is doing harm, since there is no freedom provided by this decision. This is very different from `operator[]`, which does have freedom since it is delegated to custom layouts, which is not controlled by P0009/stdlib.

`size()` is a similar story, since it is required to return `extents().fwd-prod-of-extents(rank())`. Now, if `extents()` and `rank()` are already marked `noexcept`, this can only call `std::extents<...>::fwd-prod-of-extents`, which is already marked `noexcept`. And for `extents()` itself, it is indeed provided by the custom layout... however it is required to return a `const extents_type&` in the proposal, so basically all this function can do is to bind a reference to its holding extent object, just like what `layout_{left,right,strided}` all do (and they already marked this as `noexcept`). There is not really a freedom provided here. So TLDR, I personally think the only right approach is to either, add a few `noexcept` to those trivial, already-forced functions, or remove all `noexcept` from `std::extents` also. But I strongly prefer the former, since... the second reason below.

The second reason is consistency, not only with `std::span`, but also with the rest of the standard library. `size()` and `data()` are pretty uniformly marked as `noexcept` across all standard containers, with good reason, since `size()` is pretty fundamental and is usually the first thing you obtain when dealing with a container passed in. I do think that documenting these kinds of fundamental functions as not throwing is pretty important to users.

So in short, I propose to restore the `noexcept` specifier on `rank()`, `rank_dynamic()`, `static_extent()`, `extent()`, `extents()`, `data()`, `mapping()`, `accessor()`, and `size()`. All of these are one-line functions that directly calls a `std::extents` function that is already marked as `noexcept` (and maybe additionally calls `extents()`, which I explained above don't really leave any freedom for the custom layouts since its return type is forced). I am _not_ proposing `noexcept` constructors or `operator[]`s, or any conditional `noexcept`s, as those are both limiting freedom and against LEWG policy.

Another change is to introduce `empty()`... because I can't think of a reason to not have it. Under as-if wording blanket, vendor can choose to implement faster algorithm for this compared to `size()` (such as check all extents > 0), which is why we were taught to use `empty()` instead of `size() == 0` whenever possible. Also, in the entire STL, there is not a single case of a dynamically-sized container that have `size()` does not also have `empty()` (there are reversed case, such as `forward_list` having only `empty()` but not `size()`, but all types that only have `size()` but not `empty()` is fixed-sized like `std::bitset`), and `span` have it, so I added it to the wording (which is also a one-liner).