### PR TITLE
P0009: Fix operator[](span-or-array)

### DIFF
--- a/P0009/P0009.md
+++ b/P0009/P0009.md
@@ -1025,9 +1025,9 @@ Consider the following implementation of a parallel dense matrix-vector product.
 ```c++
 using layout = /* see-below */;
 
-std::mdspan<double, std::extents<N, M>, layout> A = ...;
-std::mdspan<double, std::extents<N>> y = ...;
-std::mdspan<double, std::extents<M>> x = ...;
+std::mdspan<double, std::extents<int, N, M>, layout> A = ...;
+std::mdspan<double, std::extents<int, N>> y = ...;
+std::mdspan<double, std::extents<int, M>> x = ...;
 
 std::ranges::iota_view range{0, N};
 
@@ -1513,7 +1513,7 @@ template<class... OtherSizeTypes>
 
 [5]{.pnum} *Constraints:*
     
-   * [5.1]{.pnum} `(is_convertible_v<OtherSizeTypes, size_type> && ...)` is `true`, and
+   * [5.1]{.pnum} `(is_convertible_v<OtherSizeTypes, size_type> && ...)` is `true`,
 
    * [5.2]{.pnum} `(is_nothrow_constructible_v<size_type, OtherSizeTypes> && ...)` is `true`, and
 
@@ -1547,7 +1547,7 @@ template<class OtherSizeType, size_t N>
 
 [9]{.pnum} *Constraints:*
 
-   * [9.1]{.pnum} `is_convertible_v<const OtherSizeType&, size_type>` is `true`, and
+   * [9.1]{.pnum} `is_convertible_v<const OtherSizeType&, size_type>` is `true`,
 
    * [9.2]{.pnum} `is_nothrow_constructible_v<size_type, const OtherSizeType&>` is `true`, and
 
@@ -1672,7 +1672,7 @@ template <class SizeType, size_t Rank>
 
 [1]{.pnum} A type `M` meets the *layout mapping* requirements if: 
 
-   * [1.1]{.pnum} `M` models `copyable`, and `equality_comparable`,
+   * [1.1]{.pnum} `M` models `copyable` and `equality_comparable`,
    
    * [1.2]{.pnum} `is_nothrow_move_constructible_v<M>` is `true`,
 
@@ -2857,9 +2857,9 @@ template<class... OtherSizeTypes>
 
 [6]{.pnum} *Effects:*
 
-   * [6.1]{.pnum} Direct-non-list-initializes _`ptr_`_ with `std::move(p)`, and
+   * [6.1]{.pnum} Direct-non-list-initializes _`ptr_`_ with `std::move(p)`,
 
-   * [6.2]{.pnum} Direct-non-list-initializes _`map_`_ with `extents_type(static_cast<size_type>(std::move(exts))...)`.
+   * [6.2]{.pnum} Direct-non-list-initializes _`map_`_ with `extents_type(static_cast<size_type>(std::move(exts))...)`, and
 
    * [6.3]{.pnum} Value-initializes _`acc_`_.
 
@@ -2888,9 +2888,9 @@ template<class OtherSizeType, size_t N>
 
 [9]{.pnum} *Effects:*
 
-   * [9.1]{.pnum} Direct-non-list-initializes _`ptr_`_ with `std::move(p)`, and
+   * [9.1]{.pnum} Direct-non-list-initializes _`ptr_`_ with `std::move(p)`,
 
-   * [9.2]{.pnum} Direct-non-list-initializes _`map_`_ with `extents_type(exts)`.
+   * [9.2]{.pnum} Direct-non-list-initializes _`map_`_ with `extents_type(exts)`, and
 
    * [9.3]{.pnum} Value-initializes _`acc_`_.
 
@@ -2908,9 +2908,9 @@ constexpr mdspan(pointer p, const extents_type& ext);
 
 [12]{.pnum} *Effects:*
 
-   * [12.1]{.pnum} Direct-non-list-initializes _`ptr_`_ with `std::move(p)`, and
+   * [12.1]{.pnum} Direct-non-list-initializes _`ptr_`_ with `std::move(p)`,
 
-   * [12.2]{.pnum} Direct-non-list-initializes _`map_`_ with `ext`.
+   * [12.2]{.pnum} Direct-non-list-initializes _`map_`_ with `ext`, and
 
    * [12.3]{.pnum} Value-initializes _`acc_`_.
 
@@ -2952,13 +2952,13 @@ template<class OtherElementType, class OtherExtents,
 
 [18]{.pnum} *Constraints:*
 
-   * [18.1]{.pnum} `is_constructible_v<mapping_type, const OtherLayoutPolicy::template mapping<OtherExtents>&>` is `true`;
+   * [18.1]{.pnum} `is_constructible_v<mapping_type, const OtherLayoutPolicy::template mapping<OtherExtents>&>` is `true`, and
 
-   * [18.2]{.pnum} `is_constructible_v<accessor_type, const OtherAccessor&>` is `true`; and
+   * [18.2]{.pnum} `is_constructible_v<accessor_type, const OtherAccessor&>` is `true`.
 
 [19]{.pnum} *Mandates:* 
 
-   * [19.1]{.pnum} `is_constructible_v<pointer, const OtherAccessor::pointer&>` is `true`;
+   * [19.1]{.pnum} `is_constructible_v<pointer, const OtherAccessor::pointer&>` is `true`, and
 
    * [19.2]{.pnum} `is_constructible_v<extents_type, OtherExtents>` is `true`.
 
@@ -3030,7 +3030,7 @@ template<class OtherSizeType>
 
 [6]{.pnum} *Effects:* Let `P` be a parameter pack such that
             `is_same_v<make_index_sequence<rank()>, index_sequence<P...>>` is `true`.
-            <br/> Equivalent to: `return operator[](static_cast<size_type>(as_const(indices[P]))...);`
+            <br/> Equivalent to: `return operator[](as_const(indices[P])...);`
 
 ```c++
 constexpr size_t size() const noexcept;


### PR DESCRIPTION
Don't cast to size_type before invoking operator[](indices...),
so that operator[](indices...) can check preconditions.

Also, fix example in non-wording section to include IndexType
template arguments for extents.