### PR TITLE
P1673: Start on R11 changes and Pandoc-ification

### DIFF
--- a/D1673/.gitignore
+++ b/D1673/.gitignore
@@ -1,0 +1,1 @@
+generated/

--- a/D1673/Makefile
+++ b/D1673/Makefile
@@ -1,0 +1,3 @@
+include ../P0009/wg21/Makefile
+
+.DEFAULT_GOAL := $(HTML)

--- a/D1673/P1673.md
+++ b/D1673/P1673.md
@@ -7573,13 +7573,7 @@ void matrix_vector_product(ExecutionPolicy&& exec,
                            out_vector_t y);
 ```
 
-For `i` in the domain of `y` and `N` equal to `A.extent(1)`,
-the mathematical expression for the algorithm is
-`y[i] =` the sum of `A[i,j] * x[j]`
-for all `j` such that `i,j` is in the domain of `A`.
-
-* *Effects:* Assigns to the elements of `y` the product of the matrix
-    `A` with the vector `x`.
+* *Effects:* Computes $y = A x$.
 
 [*Example:*
 ```c++
@@ -7639,13 +7633,7 @@ void matrix_vector_product(ExecutionPolicy&& exec,
                            out_vector_t z);
 ```
 
-For `i` in the domain of `z` and `N` equal to `A.extent(1)`,
-the mathematical expression for the algorithm is
-`z[i] = y[i] + A[i,j] * x[j]`
-for all `j` such that `i,j` is in the domain of `A`.
-
-* *Effects:* Assigns to the elements of `z` the elementwise sum of
-    `y`, and the product of the matrix `A` with the vector `x`.
+* *Effects:* Computes $z = y + A x$.
 
 #### Symmetric matrix-vector product [linalg.algs.blas2.symv]
 
@@ -7726,16 +7714,7 @@ void symmetric_matrix_vector_product(ExecutionPolicy&& exec,
                                      out_vector_t y);
 ```
 
-For `i` in the domain of `y`,
-the mathematical expression for the algorithm is
-`y[i] =` the sum of `A[i,j] * x[j]`
-for all `j` in the triangle of `A` specified by `t`,
-plus the sum of `A[j,i] * x[j]`
-for all `j` not equal to `i` such that `j,i` is in the domain of A
-but not in the triangle of `A` specified by `t`.
-
-* *Effects:* Assigns to the elements of `y` the product of the matrix
-    `A` with the vector `x`.
+* *Effects:* Computes $y = A x$.
 
 ##### Updating symmetric matrix-vector product
 
@@ -7767,16 +7746,7 @@ void symmetric_matrix_vector_product(
   out_vector_t z);
 ```
 
-For `i` in the domain of `y`,
-the mathematical expression for the algorithm is
-`z[i] = y[i]` plus the sum of `A[i,j] * x[j]`
-for all `j` in the triangle of `A` specified by `t`,
-plus the sum of `A[j,i] * x[j]`
-for all `j` not equal to `i` such that `j,i` is in the domain of A
-but not in the triangle of `A` specified by `t`.
-
-* *Effects:* Assigns to the elements of `z` the elementwise sum of
-    `y`, with the product of the matrix `A` with the vector `x`.
+* *Effects:* Computes $z = y + A x$.
 
 #### Hermitian matrix-vector product [linalg.algs.blas2.hemv]
 
@@ -7857,16 +7827,7 @@ void hermitian_matrix_vector_product(ExecutionPolicy&& exec,
                                      out_vector_t y);
 ```
 
-For `i` in the domain of `y`,
-the mathematical expression for the algorithm is
-`y[i] =` the sum of `A[i,j] * x[j]`
-for all `j` in the triangle of `A` specified by `t`,
-plus the sum of _`conj-if-needed`_`(A[j,i]) * x[j]`
-for all `j` not equal to `i` such that `j,i` is in the domain of A
-but not in the triangle of `A` specified by `t`.
-
-* *Effects:* Assigns to the elements of `y` the product of the matrix
-    `A` with the vector `x`.
+* *Effects:* Computes $y = A x$.
 
 ##### Updating Hermitian matrix-vector product
 
@@ -7896,16 +7857,7 @@ void hermitian_matrix_vector_product(ExecutionPolicy&& exec,
                                      out_vector_t z);
 ```
 
-For `i` in the domain of `y`,
-the mathematical expression for the algorithm is
-`z[i] = y[i]` plus the sum of `A[i,j] * x[j]`
-for all `j` in the triangle of `A` specified by `t`,
-plus the sum of _`conj-if-needed`_`(A[j,i]) * x[j]`
-for all `j` not equal to `i` such that `j,i` is in the domain of A
-but not in the triangle of `A` specified by `t`.
-
-* *Effects:* Assigns to the elements of `z` the elementwise sum of
-    `y`, and the product of the matrix `A` with the vector `x`.
+* *Effects:* Computes $z = y + A x$.
 
 #### Triangular matrix-vector product [linalg.algs.blas2.trmv]
 
@@ -8002,13 +7954,7 @@ void triangular_matrix_vector_product(
   out_vector_t y);
 ```
 
-For `i` in the domain of `y`,
-the mathematical expression for the algorithm is
-`y[i] =` the sum of `A[i,j] * x[j]`
-for all `j` in the subset of the domain of `A` specified by `t` and `d`.
-
-* *Effects:* Assigns to the elements of `y` the product of the matrix
-    `A` with the vector `x`.
+* *Effects:* Computes $y = A x$.
 
 ##### In-place triangular matrix-vector product [linalg.algs.blas2.trmv.in-place]
 
@@ -8044,19 +7990,13 @@ This is why the `ExecutionPolicy` overload exists.
 
 --*end note]*
 
-For `i` in the domain of `y`,
-the mathematical expression for the algorithm is
-`y[i] =` the sum of `A[i,j] * y[j]`
-for all `j` in the subset of the domain of `A` specified by `t` and `d`.
-
 * *Preconditions:* `A.extent(1)` equals `y.extent(0)`.
 
 * *Mandates:* If neither `A.static_extent(1)` nor `y.static_extent(0)`
     equals `dynamic_extent`, then `A.static_extent(1)` equals
     `y.static_extent(0)`.
 
-* *Effects:* Overwrites `y` (on output) with the product of the matrix
-    `A` with the vector `y` (on input).
+* *Effects:* Computes $y = A x$.
 
 ##### Updating triangular matrix-vector product [linalg.algs.blas2.trmv.up]
 
@@ -8090,13 +8030,7 @@ void triangular_matrix_vector_product(ExecutionPolicy&& exec,
                                       out_vector_t z);
 ```
 
-For `i` in the domain of `y`,
-the mathematical expression for the algorithm is
-`z[i] = y[i]` plus the sum of `A[i,j] * x[j]`
-for all `j` in the subset of the domain of `A` specified by `t` and `d`.
-
-* *Effects:* Assigns to the elements of `z` the elementwise sum of
-    `y`, with the product of the matrix `A` with the vector `x`.
+* *Effects:* Computes $z = y + A x$.
 
 #### Solve a triangular linear system [linalg.algs.blas2.trsv]
 

--- a/D1673/P1673.md
+++ b/D1673/P1673.md
@@ -7573,7 +7573,7 @@ void matrix_vector_product(ExecutionPolicy&& exec,
                            out_vector_t y);
 ```
 
-* *Effects:* Computes $y = A x$.
+* *Effects:* Computes $y$ such that $y = A x$.
 
 [*Example:*
 ```c++
@@ -7633,7 +7633,7 @@ void matrix_vector_product(ExecutionPolicy&& exec,
                            out_vector_t z);
 ```
 
-* *Effects:* Computes $z = y + A x$.
+* *Effects:* Computes $z$ such that $z = y + A x$.
 
 #### Symmetric matrix-vector product [linalg.algs.blas2.symv]
 
@@ -7714,7 +7714,7 @@ void symmetric_matrix_vector_product(ExecutionPolicy&& exec,
                                      out_vector_t y);
 ```
 
-* *Effects:* Computes $y = A x$.
+* *Effects:* Computes $y$ such that $y = A x$.
 
 ##### Updating symmetric matrix-vector product
 
@@ -7746,7 +7746,7 @@ void symmetric_matrix_vector_product(
   out_vector_t z);
 ```
 
-* *Effects:* Computes $z = y + A x$.
+* *Effects:* Computes $z$ such that $z = y + A x$.
 
 #### Hermitian matrix-vector product [linalg.algs.blas2.hemv]
 
@@ -7827,7 +7827,7 @@ void hermitian_matrix_vector_product(ExecutionPolicy&& exec,
                                      out_vector_t y);
 ```
 
-* *Effects:* Computes $y = A x$.
+* *Effects:* Computes $y$ such that $y = A x$.
 
 ##### Updating Hermitian matrix-vector product
 
@@ -7857,7 +7857,7 @@ void hermitian_matrix_vector_product(ExecutionPolicy&& exec,
                                      out_vector_t z);
 ```
 
-* *Effects:* Computes $z = y + A x$.
+* *Effects:* Computes $z$ such that $z = y + A x$.
 
 #### Triangular matrix-vector product [linalg.algs.blas2.trmv]
 
@@ -7954,7 +7954,7 @@ void triangular_matrix_vector_product(
   out_vector_t y);
 ```
 
-* *Effects:* Computes $y = A x$.
+* *Effects:* Computes $y$ such that $y = A x$.
 
 ##### In-place triangular matrix-vector product [linalg.algs.blas2.trmv.in-place]
 
@@ -7996,7 +7996,7 @@ This is why the `ExecutionPolicy` overload exists.
     equals `dynamic_extent`, then `A.static_extent(1)` equals
     `y.static_extent(0)`.
 
-* *Effects:* Computes $y = A x$.
+* *Effects:* Computes $y$ such that $y = A x$.
 
 ##### Updating triangular matrix-vector product [linalg.algs.blas2.trmv.up]
 
@@ -8030,7 +8030,7 @@ void triangular_matrix_vector_product(ExecutionPolicy&& exec,
                                       out_vector_t z);
 ```
 
-* *Effects:* Computes $z = y + A x$.
+* *Effects:* Computes $z$ such that $z = y + A x$.
 
 #### Solve a triangular linear system [linalg.algs.blas2.trsv]
 

--- a/D1673/P1673.md
+++ b/D1673/P1673.md
@@ -3506,7 +3506,7 @@ template<class ElementType,
 constexpr auto conjugate_transposed(
   mdspan<ElementType, Extents, Layout, Accessor> a);
 
-// [linalg.concepts], exposition-only concepts
+// [linalg.concepts], exposition-only concepts and traits
 
 template<class T>
 struct @_is-mdspan_@; // exposition only
@@ -5033,10 +5033,10 @@ its mathematical expression(s) are either explicitly stated as such,
 or are implicitly stated in the algorithm's or method's description.
 The requirements below will refer to those mathematical expression(s).
 
-*[Note:*
+<i>[Note:</i>
 This notion of parameterizing requirements on a mathematical expression
 generalizes *GENERALIZED_SUM*.
---*end note]*
+<i>-- end note]</i>
 
 All of the following requirements presume that the algorithm's
 asymptotic complexity requirements, if any, are satisfied.
@@ -5150,10 +5150,10 @@ asymptotic complexity requirements, if any, are satisfied.
 
 11. The algorithm or method may reorder addends and partial sums
     in its mathematical expression arbitrarily.
-    *[Note:*
+    <i>[Note:</i>
     Factors in each product are not reordered;
     multiplication is not necessarily commutative.
-    --*end note]*
+    <i>-- end note]</i>
 
 12. The algorithm or method may replace any value
     with the sum of that value
@@ -5194,9 +5194,9 @@ as long as
 2. the algorithm or method is *logarithmically stable*,
     in the sense of (Demmel 2007).
 
-*[Note:*
+<i>[Note:</i>
 Strassen's algorithm for matrix-matrix multiply is an example of a logarithmically stable algorithm.
---*end note]*
+<i>-- end note]</i>
 
 ## Tag classes [linalg.tags]
 
@@ -5243,7 +5243,7 @@ access the upper triangle (`upper_triangular_t`) or lower triangle
 restrictions of `implicit_unit_diagonal_t` if that tag is also
 applied; see below.
 
-*[Note:*
+<i>[Note:</i>
 The `conjugate_transposed` and `transposed` functions in this section
 return a view of an input `mdspan`
 with its rightmost two indices effectively reversed.
@@ -5254,7 +5254,7 @@ the triangle tag refers to the actual input matrix,
 *after* any transformations like `transposed`.
 This differs from the BLAS' `UPLO` argument,
 which refers to the pre-transformed "original" matrix.
---*end note]*
+<i>-- end note]</i>
 
 ### Diagonal tags [linalg.tags.diagonal]
 
@@ -5308,13 +5308,13 @@ packs matrix elements starting with the topmost (least row index) row,
 and proceeding row by row, from the leftmost (least column index)
 entry.
 
-*[Note:*
+<i>[Note:</i>
 
 `layout_blas_packed` describes the data layout used by the BLAS'
 Symmetric Packed (SP), Hermitian Packed (HP), and Triangular Packed
 (TP) matrix types.
 
---*end note]*
+<i>-- end note]</i>
 
 ```c++
 template<class Triangle,
@@ -5418,8 +5418,8 @@ constexpr index_type required_span_size() const noexcept;
 
 *Returns:* `extent(0)` * (`extent(0)` + 1)/2.
 
-*[Note:* For example, a 5 x 5 packed matrix
-only stores 15 matrix elements. --*end note]*
+<i>[Note:</i> For example, a 5 x 5 packed matrix
+only stores 15 matrix elements. <i>-- end note]</i>
 
 ```c++
 template<class ... Indices>
@@ -5460,14 +5460,14 @@ template<class ... Indices>
         then `j` + `i` * (`i` + 1)/2 if `i` ≥ `j`,
         else `i` + `j` * (`j` + 1)/2.
 
-*[Note:*
+<i>[Note:</i>
 
 An `mdspan` layout mapping must permit access
 for all multidimensional indices in the cross product of the extents,
 so the above definition cannot exclude indices outside the matrix's triangle.
 Instead, it interprets such indices as if the matrix were symmetric.
 
---*end note]*
+<i>-- end note]</i>
 
 ```c++
 template<class OtherExtents>
@@ -5519,7 +5519,7 @@ void w_equals_alpha_times_x_plus_beta_times_y(
 ```
 --*end example*]
 
-*[Note:*
+<i>[Note:</i>
 
 An implementation could dispatch to a function in the BLAS library, by
 noticing that the first argument has an `accessor_scaled` `Accessor`
@@ -5527,7 +5527,7 @@ type.  It could use this information to extract the appropriate
 run-time value(s) of the relevant BLAS function arguments (e.g.,
 `ALPHA` and/or `BETA`), by calling `accessor_scaled::scaling_factor`.
 
---*end note]*
+<i>-- end note]</i>
 
 ### Exposition-only function object _`conj-if-needed`_ [linalg.scaled.conj]
 
@@ -5546,13 +5546,13 @@ is expression-equivalent to:
 
   * else, `E`.
 
-*[Note:*
+<i>[Note:</i>
 The special case for arithmetic types
 preserves the type of its argument, unlike `std::conj`.
 The `conj(E)` case invokes `conj` via unqualified lookup.
 The `E` case presumes that a type without a `conj` function is noncomplex,
 so that the conjugate is the identity.
---*end note]*
+<i>-- end note]</i>
 
 ### Exposition-only class templates _`proxy-reference-base`_ and _`proxy-reference`_ [linalg.scaled.base]
 
@@ -5693,12 +5693,12 @@ is expression-equivalent to:
 
 <!-- TODO (mfh 2022/07/06) this lookup language will go into front matter. -->
 
-*[Note:*
+<i>[Note:</i>
 This function exists because of `vector_norm2` and `vector_abs_sum`.
 
 The unsigned integer special case avoids an ambiguous lookup.
 The other case invokes `abs` via unqualified lookup.
---*end note]*
+<i>-- end note]</i>
 
 ```c++
 constexpr friend auto real(const derived_type& x);
@@ -5721,7 +5721,7 @@ is expression-equivalent to:
 
   * else, `value_type(static_cast<const this_type&>(E))`.
 
-*[Note:*
+<i>[Note:</i>
 This function exists because of `vector_abs_sum`.
 
 The arithmetic type special case exists because
@@ -5731,7 +5731,7 @@ All arithmetic types represent a noncomplex number.
 Otherwise, if `real` can be found via unqualified lookup, it is used.
 If not, then `value_type` is assumed to represent a noncomplex number,
 for which the number's real part is the same as the number.
---*end note]*
+<i>-- end note]</i>
 
 ```c++
 constexpr friend auto imag(const derived_type& x);
@@ -5754,7 +5754,7 @@ is expression-equivalent to:
 
   * else, `value_type{}`.
 
-*[Note:*
+<i>[Note:</i>
 This function exists because of `vector_abs_sum`.
 
 The arithmetic type special case exists because
@@ -5765,7 +5765,7 @@ Otherwise, if `imag` can be found via unqualified lookup, it is used.
 If not, then `value_type` is assumed to represent a noncomplex number,
 for which the number's imaginary part is zero
 (which is constructed by value-initializing `value_type`).
---*end note]*
+<i>-- end note]</i>
 
 ```c++
 constexpr friend auto conj(const derived_type& x);
@@ -5778,8 +5778,8 @@ constexpr friend auto conj(const derived_type& x);
 The exposition-only class template _`scaled-scalar`_ represents a
 read-only value, which is the product of a fixed value (the "scaling
 factor") and the value of a reference to an element of a
-`mdspan`.  *[Note:* The value is read only to avoid confusion
-with the definition of "assigning to a scaled scalar."  --*end note]*
+`mdspan`.  <i>[Note:</i> The value is read only to avoid confusion
+with the definition of "assigning to a scaled scalar."  <i>-- end note]</i>
 _`scaled-scalar`_ is part of the implementation of `accessor_scaled`
 **[linalg.scaled.accessor_scaled]**.
 
@@ -5808,7 +5808,7 @@ public:
 };
 ```
 
-*[Note:*
+<i>[Note:</i>
 
 The point of the `ReferenceValue` template parameter
 is so that the input of `to_value` can be cast to a value immediately,
@@ -5817,7 +5817,7 @@ This ensures the original order of operations,
 as if computing nonlazily.
 It also makes fewer requirements of the reference type.
 
---*end note]*
+<i>-- end note]</i>
 
 *Mandates:*
 
@@ -5931,9 +5931,9 @@ The `scaled` function takes a scaling factor `alpha` and an `mdspan`
 as `x`, that represents the elementwise product of `alpha` with each
 element of `x`.
 
-*[Note:*
+<i>[Note:</i>
 Terms in this product will not be reordered.
---*end note]*
+<i>-- end note]</i>
 
 ```c++
 template<class ScalingFactor,
@@ -5948,7 +5948,7 @@ constexpr auto scaled(
 *Effects:* Equivalent to
     `return mdspan{x.data(), x.mapping(), accessor_scaled{alpha, x.accessor()}};`.
 
-*[Note:*
+<i>[Note:</i>
 The elements of the returned `mdspan` are read only.
 
 Nested `scaled` expressions remain nested.
@@ -5960,7 +5960,7 @@ For example, if `x` is a rank-1 `mdspan` whose `value_type` is `double`,
 and if `sizeof(int)` is 4 and `double` is IEEE 754 binary64,
 then `scaled(1 << 20, scaled(1 << 20, x))` does not overflow `int`,
 but `scaled((1 << 20) * (1 << 20), x)` would overflow `int`.
---*end note]*
+<i>-- end note]</i>
 
 [*Example:*
 ```c++
@@ -5981,7 +5981,7 @@ a new read-only `mdspan` `y` with the same domain as `x`, whose
 elements are the complex conjugates of the corresponding elements of
 `x`.
 
-*[Note:*
+<i>[Note:</i>
 
 An implementation could dispatch to a function in the BLAS library, by
 noticing that the `Accessor` type of an `mdspan` input has type
@@ -5990,15 +5990,15 @@ compatible with the BLAS library.  If so, it could set the
 corresponding `TRANS*` BLAS function argument accordingly and call the
 BLAS function.
 
---*end note]*
+<i>-- end note]</i>
 
 ### Exposition-only class template _`conjugated-scalar`_
 
 The exposition-only class template _`conjugated-scalar`_ represents a
 read-only value, which is the complex conjugate of the value of a
-reference to an element of an `mdspan`.  *[Note:* The value is
+reference to an element of an `mdspan`.  <i>[Note:</i> The value is
 read only to avoid confusion with the definition of "assigning to the
-conjugate of a scalar."  --*end note]* _`conjugated-scalar`_ is part of
+conjugate of a scalar."  <i>-- end note]</i> _`conjugated-scalar`_ is part of
 the implementation of `accessor_conjugate`
 **[linalg.conj.accessor_conjugate]**.
 
@@ -6108,7 +6108,7 @@ Let the exposition-only type `pre-const-element-type` name
 
 Then, `element_type` names `add_const_t<`_`pre-const-element-type`_`>`.
 
-*[Note:* `accessor_conjugate` provides read-only access. --*end note]*
+<i>[Note:</i> `accessor_conjugate` provides read-only access. <i>-- end note]</i>
 
 ```c++
 using offset_policy = /* see below */;
@@ -6167,8 +6167,8 @@ where
 
     * if `Accessor` is `accessor_conjugate<NestedAccessor>`
         for some `NestedAccessor`, then
-        `typename NestedAccessor::element_type` *[Note:*
-        conjugation is self-annihilating --*end note]*;
+        `typename NestedAccessor::element_type` <i>[Note:</i>
+        conjugation is self-annihilating <i>-- end note]</i>;
 
     * else if `remove_cv_t<ElementType>` is an arithmetic type,
         then `ElementType`;
@@ -6178,13 +6178,13 @@ where
   * and `ReturnAccessor` is:
 
     * if `Accessor` is `accessor_conjugate<NestedAccessor>`
-        for some `NestedAccessor`, then `NestedAccessor` *[Note:*
-        conjugation is self-annihilating --*end note]*;
+        for some `NestedAccessor`, then `NestedAccessor` <i>[Note:</i>
+        conjugation is self-annihilating <i>-- end note]</i>;
 
     * else if `remove_cv_t<ElementType>` is an arithmetic type,
-        then `Accessor` *[Note:* this reduces nesting
+        then `Accessor` <i>[Note:</i> this reduces nesting
         in cases where conjugation is known to be the identity
-        --*end note]*;
+        <i>-- end note]</i>;
 
     * else `accessor_conjugate<Accessor>`.
 
@@ -6201,9 +6201,9 @@ where
   * else, equivalent to
       `return R(a.data(), a.mapping(), ReturnAccessor(a.accessor()));`;
 
-*[Note:*
+<i>[Note:</i>
 The elements of the returned `mdspan` are read only.
---*end note]*;
+<i>-- end note]</i>;
 
 [*Example:*
 ```c++
@@ -6481,10 +6481,10 @@ where
     * if `Accessor` is `default_accessor<ElementType>`,
         then `add_const_t<ElementType>`;
 
-    * else, `ElementType`; *[Note:* For general accessors,
+    * else, `ElementType`; <i>[Note:</i> For general accessors,
         the `const ElementType` version of the accessor may not exist;
         Even if it does, `transposed` has no way to deduce it generically.
-        --*end note]*
+        <i>-- end note]</i>
 
 * `ReturnLayout` is:
 
@@ -6514,10 +6514,10 @@ where
             row_major_t, column_major_t>`;
 
     * else if `Layout` is `layout_transpose<NestedLayout>`
-        for some `NestedLayout`, then `NestedLayout` *[Note:*
+        for some `NestedLayout`, then `NestedLayout` <i>[Note:</i>
         this optimizes applying `transposed` twice
         to an `mdspan` with a custom layout,
-        as long as there are no intervening layout changes --*end note]*;
+        as long as there are no intervening layout changes <i>-- end note]</i>;
 
     * else, `layout_transpose<Layout>`;
 
@@ -6561,7 +6561,7 @@ return R(a.data(),
 ```
 
     * else, if `Layout` is `layout_stride`, then equivalent to
-        *[Note:* reverse the strides as well as the extents --*end note]*
+        <i>[Note:</i> reverse the strides as well as the extents <i>-- end note]</i>
 ```c++
 return R(a.data(),
   ReturnMapping(
@@ -6574,7 +6574,7 @@ return R(a.data(),
 
     * else, if `Layout` is `layout_transpose<NestedLayout>`
         for some `NestedLayout`, then equivalent to
-        *[Note:* getting the nested mapping untransposes the extents --*end note]*
+        <i>[Note:</i> getting the nested mapping untransposes the extents <i>-- end note]</i>
 ```c++        
 return R(a.data(), a.mapping().nested_mapping(), a.accessor());
 ```
@@ -6673,10 +6673,12 @@ void test_conjugate_transposed(
 ```
 --*end example*]
 
-## Exposition-only concepts [linalg.concepts]
+## Exposition-only concepts and traits [linalg.concepts]
 
 The exposition-only concepts defined in this section
 constrain the algorithms in *[linalg.algs]*.
+The exposition-only trait(s) defined in this section
+help define the exposition-only concepts.
 
 ```c++
 template<class T>
@@ -6747,11 +6749,11 @@ If an algorithm in *[linalg.algs]* accesses the elements
 of an _`in-vector`_, _`in-matrix`_, or _`in-object`_,
 it will do so in read-only fashion.
 
-*[Note:* The `element_type` of an
+<i>[Note:</i> The `element_type` of an
 _`in-vector`_, _`in-matrix`_, or _`in-object`_ need not be `const`,
 because an mdspan accessor with a nonconst `element_type`
 need not necessarily be convertible to an accessor
-with a const `element_type`. --*end note]*
+with a const `element_type`. <i>-- end note]</i>
 
 If an algorithm in *[linalg.algs]* accesses the elements
 of an _`out-vector`_, _`out-matrix`_, or _`out-object`_,
@@ -6771,7 +6773,7 @@ or other things as appropriate.
     are parallel algorithms **[algorithms.parallel.defns]**.
 
 * `Real` is any type such that `complex<Real>` is specified.
-    *[Note:* See **[complex.numbers.general]**. --*end note]*
+    <i>[Note:</i> See **[complex.numbers.general]**. <i>-- end note]</i>
 
 * `Triangle` is either `upper_triangle_t` or `lower_triangle_t`.
 
@@ -6782,7 +6784,7 @@ or other things as appropriate.
 
 ### BLAS 1 functions [linalg.algs.blas1]
 
-*[Note:*
+<i>[Note:</i>
 
 The BLAS developed in three "levels": 1, 2, and 3.  BLAS 1 includes
 vector-vector operations, BLAS 2 matrix-vector operations, and BLAS 3
@@ -6792,7 +6794,7 @@ Increasing level also comes with increasing potential for data reuse.
 The BLAS traditionally lists computing a Givens rotation among the
 BLAS 1 operations, even though it only operates on scalars.
 
---*end note]*
+<i>-- end note]</i>
 
 *Complexity:*
 All algorithms in this Clause with `mdspan` parameters
@@ -6821,7 +6823,7 @@ void givens_rotation_setup(const complex<Real>& a,
 
 This function computes the plane (Givens) rotation represented by the
 two values `c` and `s` such that the 2x2 system of equations
-*[Note:* use of monospaced text in this equation does not indicate C++ code --*end note]*
+<i>[Note:</i> use of monospaced text in this equation does not indicate C++ code <i>-- end note]</i>
 
 ```
 [c        s]   [a]   [r]
@@ -6835,18 +6837,18 @@ right by the input vector whose components are `a` and `b`, produces a
 result vector whose first component `r` is the Euclidean norm of the
 input vector, and whose second component as zero.
 
-*[Note:*
+<i>[Note:</i>
 This function corresponds to the LAPACK function `xLARTG`.
 The BLAS variant `xROTG` takes four arguments -- `a`, `b`, `c`, and
 `s`-- and overwrites the input `a` with `r`.  We have chosen
 `xLARTG`'s interface because it separates input and output, and to
 encourage following `xLARTG`'s more careful implementation.
---*end note]*
+<i>-- end note]</i>
 
-*[Note:*
+<i>[Note:</i>
 `givens_rotation_setup` has an overload for complex numbers,
 because the output argument `c` (cosine) is a signed magnitude.
---*end note]*
+<i>-- end note]</i>
 
 * *Effects:* Assigns to `c` and `s` the plane (Givens) rotation
     corresponding to the input `a` and `b`.  Assigns to `r` the
@@ -6898,12 +6900,12 @@ void givens_rotation_apply(
   const complex<Real> s);
 ```
 
-*[Note:*
+<i>[Note:</i>
 These functions correspond to the BLAS function `xROT`.  `c` and `s`
 form a plane (Givens) rotation.  Users normally would compute `c` and
 `s` using `givens_rotation_setup`, but they are not required to do
 this.
---*end note]*
+<i>-- end note]</i>
 
 For `i` in the domains of both `x` and `y`,
 the mathematical expressions for the algorithm are
@@ -6937,8 +6939,8 @@ void swap_elements(ExecutionPolicy&& exec,
                    InOutObj2 y);
 ```
 
-*[Note:* These functions correspond to the BLAS function `xSWAP`.
---*end note]*
+<i>[Note:</i> These functions correspond to the BLAS function `xSWAP`.
+<i>-- end note]</i>
 
 * *Preconditions:* For all `r` in 0, 1, ..., `x.rank()` - 1,
     `x.extent(r)` equals `y.extent(r)`.
@@ -6976,8 +6978,8 @@ void scale(ExecutionPolicy&& exec,
            InOutObj obj);
 ```
 
-*[Note:* These functions correspond to the BLAS function `xSCAL`.
---*end note]*
+<i>[Note:</i> These functions correspond to the BLAS function `xSCAL`.
+<i>-- end note]</i>
 
 For `i...` in the domain of `obj`,
 the mathematical expression for the algorithm is `obj[i...] = alpha * obj[i...]`.
@@ -7003,8 +7005,8 @@ void copy(ExecutionPolicy&& exec,
           OutObj y);
 ```
 
-*[Note:* These functions correspond to the BLAS function `xCOPY`.
---*end note]*
+<i>[Note:</i> These functions correspond to the BLAS function `xCOPY`.
+<i>-- end note]</i>
 
 * *Preconditions:* For all `r` in 0, 1, ..., `x.rank()` - 1,
     `x.extent(r)` equals `y.extent(r)`.
@@ -7044,8 +7046,8 @@ void add(ExecutionPolicy&& exec,
          OutObj z);
 ```
 
-*[Note:* These functions correspond to the BLAS function `xAXPY`.
---*end note]*
+<i>[Note:</i> These functions correspond to the BLAS function `xAXPY`.
+<i>-- end note]</i>
 
 For `i...` in the domains of `x`, `y`, and `z`,
 the mathematical expression for the algorithm is `z[i...] = x[i...] + y[i...]`.
@@ -7078,9 +7080,9 @@ the mathematical expression for the algorithm is `z[i...] = x[i...] + y[i...]`.
 
 ##### Nonconjugated dot product of two vectors [linalg.algs.blas1.dot.dotu]
 
-*[Note:* The functions in this section correspond to the BLAS
+<i>[Note:</i> The functions in this section correspond to the BLAS
 functions `xDOT` (for real element types) and `xDOTU` (for complex
-element types).  --*end note]*
+element types).  <i>-- end note]</i>
 
 Nonconjugated dot product with specified result type
 
@@ -7121,16 +7123,16 @@ for all `i` in the domain of `v1`.
     higher precision than `InVec1::value_type` or `InVec2::value_type`, then
     intermediate terms in the sum use `T`'s precision or greater.
 
-*[Note:* Like `reduce`, `dot` applies binary `operator+` in an
+<i>[Note:</i> Like `reduce`, `dot` applies binary `operator+` in an
 unspecified order.  This may yield a nondeterministic result for
 non-associative or non-commutative `operator+` such as floating-point
 addition.  However, implementations may perform extra work to make the
 result deterministic.  They may do so for all `dot` overloads, or just
-for specific `ExecutionPolicy` types. --*end note]*
+for specific `ExecutionPolicy` types. <i>-- end note]</i>
 
-*[Note:* Users can get `xDOTC` behavior by giving the first argument
+<i>[Note:</i> Users can get `xDOTC` behavior by giving the first argument
 as the result of `conjugated`.  Alternately, they can use the shortcut `dotc`
-below. --*end note]*
+below. <i>-- end note]</i>
 
 Nonconjugated dot product with default result type
 
@@ -7153,7 +7155,7 @@ auto dot(ExecutionPolicy&& exec,
 
 ##### Conjugated dot product of two vectors [linalg.algs.blas1.dot.dotc]
 
-*[Note:*
+<i>[Note:</i>
 
 The functions in this section correspond to the BLAS functions `xDOT`
 (for real element types) and `xDOTC` (for complex element types).
@@ -7161,7 +7163,7 @@ The functions in this section correspond to the BLAS functions `xDOT`
 `dotc` exists to give users reasonable default inner product behavior
 for both real and complex element types.
 
---*end note]*
+<i>-- end note]</i>
 
 Conjugated dot product with specified result type
 
@@ -7229,8 +7231,8 @@ sum_of_squares_result<T> vector_sum_of_squares(
   sum_of_squares_result<T> init);
 ```
 
-*[Note:* These functions correspond to the LAPACK function `xLASSQ`.
---*end note]*
+<i>[Note:</i> These functions correspond to the LAPACK function `xLASSQ`.
+<i>-- end note]</i>
 
 * *Preconditions:*
 
@@ -7278,32 +7280,32 @@ T vector_norm2(ExecutionPolicy&& exec,
                T init);
 ```
 
-*[Note:* These functions correspond to the BLAS function `xNRM2`.
---*end note]*
+<i>[Note:</i> These functions correspond to the BLAS function `xNRM2`.
+<i>-- end note]</i>
 
 For `N` equal to `v.extent(0)`,
 the mathematical expression for the algorithm is
 `sqrt(init + s)`,
 where `s` is the sum of `abs(v[i]) * abs(v[i])`
 for all `i` in the domain of `v`.
-*[Note:*
+<i>[Note:</i>
 This does not imply a recommended implementation for floating-point types.
 See *Remarks* below.
---*end note]*
+<i>-- end note]</i>
 
 * *Preconditions:* `init + abs(declval<InVec::value_type>())*abs(declval<InVec::value_type>())`
     shall be convertible to `T`.
 
 * *Effects:* Returns the square root of the sum of squares
     of `init` and the absolute values of the elements of `A`.
-    *[Note:*
+    <i>[Note:</i>
     For `init` equal to zero, this is the Euclidean norm
     (also called 2-norm) of the vector `v`.
 
     This description does not imply a recommended implementation
     for floating-point types.
     See *Remarks* below.
-    --*end note]*
+    <i>-- end note]</i>
 
 * *Remarks:* If `InVec::value_type` is a floating-point type
     or a complex version thereof, and if `T` is a floating-point type, then
@@ -7314,13 +7316,13 @@ See *Remarks* below.
     * any guarantees regarding overflow and underflow of `vector_norm2`
         are implementation-defined.
 
-*[Note:*
+<i>[Note:</i>
 The `abs` function is invoked via unqualified lookup.
 
 A suggested implementation of this function for floating-point types `T`
 would use the `scaled_sum_of_squares` result
 from `vector_sum_of_squares(x, {.scaling_factor=1.0, .scaled_sum_of_squares=init})`.
---*end note]*
+<i>-- end note]</i>
 
 ##### Euclidean norm with default result type
 
@@ -7356,11 +7358,11 @@ T vector_abs_sum(ExecutionPolicy&& exec,
                  T init);
 ```
 
-*[Note:* This function corresponds to the BLAS functions `SASUM`,
+<i>[Note:</i> This function corresponds to the BLAS functions `SASUM`,
 `DASUM`, `CSASUM`, and `DZASUM`.  The different behavior for complex
 element types is based on the observation that this lower-cost
 approximation of the one-norm serves just as well as the actual
-one-norm for many linear algebra algorithms in practice. --*end note]*
+one-norm for many linear algebra algorithms in practice. <i>-- end note]</i>
 
 For `N` equal to `v.extent(0)`,
 the mathematical expression for the algorithm is
@@ -7387,9 +7389,9 @@ for all `i` in the domain of `v`.
     and if `T` has higher precision than `InVec::value_type`,
     then intermediate terms in the sum use `T`'s precision or greater.
 
-*[Note:*
+<i>[Note:</i>
 The `abs`, `real`, and `imag` functions are invoked via unqualified lookup.
---*end note]*
+<i>-- end note]</i>
 
 ##### Sum of absolute values with default result type
 
@@ -7420,8 +7422,8 @@ typename InVec::size_type idx_abs_max(
   InVec v);
 ```
 
-*[Note:* These functions correspond to the BLAS function `IxAMAX`.
---*end note]*
+<i>[Note:</i> These functions correspond to the BLAS function `IxAMAX`.
+<i>-- end note]</i>
 
 * *Preconditions:* For `i` in the domain of `v`,
     let `abs_value_type` be `decltype(v[i])`;
@@ -7432,9 +7434,9 @@ typename InVec::size_type idx_abs_max(
     zero elements, then returns
     `numeric_limits<typename InVec::size_type>::max()`.
 
-*[Note:*
+<i>[Note:</i>
 The `abs` function is invoked via unqualified lookup.
---*end note]*
+<i>-- end note]</i>
 
 #### Frobenius norm of a matrix [linalg.algs.blas1.matfrobnorm]
 
@@ -7460,13 +7462,13 @@ T matrix_frob_norm(
 
 * *Effects:* Returns the square root of the sum of squares
     of `init` and the absolute values of the elements of `A`.
-    *[Note:*
+    <i>[Note:</i>
     For `init` equal to zero, this is the Frobenius norm of the matrix `A`.
 
     This description does not imply a recommended implementation
     for floating-point types.
     See *Remarks* below.
-    --*end note]*
+    <i>-- end note]</i>
 
 * *Remarks:* If `InMat::value_type` is a floating-point type
     or `complex<R>` for some floating-point type `R`,
@@ -7478,9 +7480,9 @@ T matrix_frob_norm(
     * any guarantees regarding overflow and underflow of `matrix_frob_norm`
         are implementation-defined.
 
-*[Note:*
+<i>[Note:</i>
 The `abs` function is invoked via unqualified lookup.
---*end note]*
+<i>-- end note]</i>
 
 ##### Frobenius norm with default result type
 
@@ -7555,9 +7557,9 @@ auto matrix_one_norm(
     and the two-parameter overload is equivalent to
     `matrix_one_norm(exec, A, T{});`.
 
-*[Note:*
+<i>[Note:</i>
 The `abs` function is invoked via unqualified lookup.
---*end note]*
+<i>-- end note]</i>
 
 #### Infinity norm of a matrix [linalg.algs.blas1.matinfnorm]
 
@@ -7594,9 +7596,9 @@ T matrix_inf_norm(
     and if `T` has higher precision than `InMat::value_type`,
     then intermediate terms in each sum use `T`'s precision or greater.
 
-*[Note:*
+<i>[Note:</i>
 The `abs` function is invoked via unqualified lookup.
---*end note]*
+<i>-- end note]</i>
 
 ##### Infinity norm with default result type
 
@@ -7621,8 +7623,8 @@ auto matrix_inf_norm(
 
 #### General matrix-vector product [linalg.algs.blas2.gemv]
 
-*[Note:* These functions correspond to the BLAS function
-`xGEMV`. --*end note]*
+<i>[Note:</i> These functions correspond to the BLAS function
+`xGEMV`. <i>-- end note]</i>
 
 The following requirements apply to all functions in this section.
 
@@ -7736,8 +7738,8 @@ void matrix_vector_product(ExecutionPolicy&& exec,
 
 #### Symmetric matrix-vector product [linalg.algs.blas2.symv]
 
-*[Note:* These functions correspond to the BLAS functions `xSYMV` and
-`xSPMV`. --*end note]*
+<i>[Note:</i> These functions correspond to the BLAS functions `xSYMV` and
+`xSPMV`. <i>-- end note]</i>
 
 The following requirements apply to all functions in this section.
 
@@ -7849,8 +7851,8 @@ void symmetric_matrix_vector_product(
 
 #### Hermitian matrix-vector product [linalg.algs.blas2.hemv]
 
-*[Note:* These functions correspond to the BLAS functions `xHEMV` and
-`xHPMV`. --*end note]*
+<i>[Note:</i> These functions correspond to the BLAS functions `xHEMV` and
+`xHPMV`. <i>-- end note]</i>
 
 The following requirements apply to all functions in this section.
 
@@ -7960,8 +7962,8 @@ void hermitian_matrix_vector_product(ExecutionPolicy&& exec,
 
 #### Triangular matrix-vector product [linalg.algs.blas2.trmv]
 
-*[Note:* These functions correspond to the BLAS functions `xTRMV` and
-`xTPMV`. --*end note]*
+<i>[Note:</i> These functions correspond to the BLAS functions `xTRMV` and
+`xTPMV`. <i>-- end note]</i>
 
 The following requirements apply to all functions in this section.
 
@@ -8080,14 +8082,14 @@ void triangular_matrix_vector_product(
   InOutVec y);
 ```
 
-*[Note:*
+<i>[Note:</i>
 
 Performing this operation in place hinders parallelization.
 However, other `ExecutionPolicy`-specific optimizations,
 such as vectorization, are still possible.
 This is why the `ExecutionPolicy` overload exists.
 
---*end note]*
+<i>-- end note]</i>
 
 * *Preconditions:* `A.extent(1)` equals `y.extent(0)`.
 
@@ -8133,8 +8135,8 @@ void triangular_matrix_vector_product(ExecutionPolicy&& exec,
 
 #### Solve a triangular linear system [linalg.algs.blas2.trsv]
 
-*[Note:* These functions correspond to the BLAS functions `xTRSV` and
-`xTPSV`. --*end note]*
+<i>[Note:</i> These functions correspond to the BLAS functions `xTRSV` and
+`xTPSV`. <i>-- end note]</i>
 
 The following requirements apply to all functions in this section.
 
@@ -8286,14 +8288,14 @@ void triangular_matrix_vector_solve(
   BinaryDivideOp divide);
 ```
 
-*[Note:*
+<i>[Note:</i>
 
 Performing triangular solve in place hinders parallelization.
 However, other `ExecutionPolicy`-specific optimizations,
 such as vectorization, are still possible.
 This is why the `ExecutionPolicy` overload exists.
 
---*end note]*
+<i>-- end note]</i>
 
 * *Preconditions:* `A.extent(0)` equals `b.extent(0)`.
 
@@ -8357,7 +8359,7 @@ void matrix_rank_1_update(
   InOutMat A);
 ```
 
-*[Note:* This function corresponds to the BLAS functions `xGER` (for
+<i>[Note:</i> This function corresponds to the BLAS functions `xGER` (for
 real element types) and `xGERU` (for complex element types). --*end
 note]*
 
@@ -8390,9 +8392,9 @@ the mathematical expression for the algorithm is
 * *Complexity:* The count of `mdspan` array accesses and arithmetic operations
     is linear in `x.extent(0)` times `y.extent(0)`.
 
-*[Note:* Users can get `xGERC` behavior by giving the second argument
+<i>[Note:</i> Users can get `xGERC` behavior by giving the second argument
 as the result of `conjugated`.  Alternately, they can use the shortcut
-`matrix_rank_1_update_c` below. --*end note]*
+`matrix_rank_1_update_c` below. <i>-- end note]</i>
 
 ##### Nonsymmetric conjugated rank-1 update [linalg.algs.blas2.rank1.gerc]
 
@@ -8416,7 +8418,7 @@ void matrix_rank_1_update_c(
   InOutMat A);
 ```
 
-*[Note:* This function corresponds to the BLAS functions `xGER` (for
+<i>[Note:</i> This function corresponds to the BLAS functions `xGER` (for
 real element types) and `xGERC` (for complex element types). --*end
 note]*
 
@@ -8463,14 +8465,14 @@ void symmetric_matrix_rank_1_update(
   Triangle t);
 ```
 
-*[Note:*
+<i>[Note:</i>
 
 These functions correspond to the BLAS functions `xSYR` and `xSPR`.
 
 They have overloads taking a scaling factor `alpha`, because it would be
 impossible to express updates like C = C - x x^T otherwise.
 
- --*end note]*
+ <i>-- end note]</i>
 
 For `i,j` in the domain of `A`
 and in the triangle of `A` specified by `t`,
@@ -8563,14 +8565,14 @@ void hermitian_matrix_rank_1_update(
   Triangle t);
 ```
 
-*[Note:*
+<i>[Note:</i>
 
 These functions correspond to the BLAS functions `xHER` and `xHPR`.
 
 They have overloads taking a scaling factor `alpha`, because it would be
 impossible to express the update A = A - x x^H otherwise.
 
---*end note]*
+<i>-- end note]</i>
 
 For `i,j` in the domain of `A`
 and in the triangle of `A` specified by `t`,
@@ -8653,8 +8655,8 @@ void symmetric_matrix_rank_2_update(
   Triangle t);
 ```
 
-*[Note:* These functions correspond to the BLAS functions `xSYR2` and
-`xSPR2`. --*end note]*
+<i>[Note:</i> These functions correspond to the BLAS functions `xSYR2` and
+`xSPR2`. <i>-- end note]</i>
 
 For `i,j` in the domain of `A`
 and in the triangle of `A` specified by `t`,
@@ -8730,8 +8732,8 @@ void hermitian_matrix_rank_2_update(
   Triangle t);
 ```
 
-*[Note:* These functions correspond to the BLAS functions `xHER2` and
-`xHPR2`. --*end note]*
+<i>[Note:</i> These functions correspond to the BLAS functions `xHER2` and
+`xHPR2`. <i>-- end note]</i>
 
 For `i,j` in the domain of `A`
 and in the triangle of `A` specified by `t`,
@@ -8786,8 +8788,8 @@ the mathematical expression for the algorithm is
 
 #### General matrix-matrix product [linalg.algs.blas3.gemm]
 
-*[Note:* These functions correspond to the BLAS function `xGEMM`.
---*end note]*
+<i>[Note:</i> These functions correspond to the BLAS function `xGEMM`.
+<i>-- end note]</i>
 
 The following requirements apply to all functions in this section.
 
@@ -8891,14 +8893,14 @@ for all `k` such that `i,k` is in the domain of `A`.
 
 #### Symmetric matrix-matrix product [linalg.algs.blas3.symm]
 
-*[Note:*
+<i>[Note:</i>
 
 These functions correspond to the BLAS function `xSYMM`.
 
 Unlike the symmetric rank-1 or rank-k update functions, these functions assume
 that the input matrix `A` -- not the output matrix -- is symmetric.
 
---*end note]*
+<i>-- end note]</i>
 
 The following requirements apply to all functions in this section.
 
@@ -9170,14 +9172,14 @@ and in the triangle of `A` specified by `t`.
 
 #### Hermitian matrix-matrix product [linalg.algs.blas3.hemm]
 
-*[Note:*
+<i>[Note:</i>
 
 These functions correspond to the BLAS function `xHEMM`.
 
 Unlike the Hermitian rank-1 or rank-k update functions, these functions assume
 that the input matrix -- not the output matrix -- is Hermitian.
 
---*end note]*
+<i>-- end note]</i>
 
 The following requirements apply to all functions in this section.
 
@@ -9451,8 +9453,8 @@ and in the triangle of `A` specified by `t`.
 
 #### Triangular matrix-matrix product [linalg.algs.blas3.trmm]
 
-*[Note:* These functions correspond to the BLAS function `xTRMM`.
---*end note]*
+<i>[Note:</i> These functions correspond to the BLAS function `xTRMM`.
+<i>-- end note]</i>
 
 The following requirements apply to all functions in this section.
 
@@ -9804,9 +9806,9 @@ and in the triangle of `A` specified by `t` and `d`.
 
 #### Rank-k update of a symmetric or Hermitian matrix [linalg.alg.blas3.rank-k]
 
-*[Note:* Users can achieve the effect of the `TRANS` argument of these
+<i>[Note:</i> Users can achieve the effect of the `TRANS` argument of these
 BLAS functions, by applying `transposed` or `conjugate_transposed`
-to the input matrix. --*end note]*
+to the input matrix. <i>-- end note]</i>
 
 * *Complexity:* For all algorithms in this Clause,
     the count of `mdspan` array accesses and arithmetic operations
@@ -9837,7 +9839,7 @@ void symmetric_matrix_rank_k_update(
   Triangle t);
 ```
 
-*[Note:*
+<i>[Note:</i>
 
 These functions correspond to the BLAS function `xSYRK`.
 
@@ -9846,7 +9848,7 @@ impossible to express the update C = C - A A^T otherwise.
 The scaling factor parameter is required
 in order to avoid ambiguity with `ExecutionPolicy`.
 
---*end note]*
+<i>-- end note]</i>
 
 For `i,j` in the domain of `C`
 and in the triangle of `C` specified by `t`,
@@ -9916,7 +9918,7 @@ void hermitian_matrix_rank_k_update(
   Triangle t);
 ```
 
-*[Note:*
+<i>[Note:</i>
 
 These functions correspond to the BLAS function `xHERK`.
 
@@ -9926,7 +9928,7 @@ otherwise.
 The scaling factor parameter is required
 in order to avoid ambiguity with `ExecutionPolicy`.
 
---*end note]*
+<i>-- end note]</i>
 
 For `i,j` in the domain of `C`
 and in the triangle of `C` specified by `t`,
@@ -9973,9 +9975,9 @@ for all `k` such that `i,k` is in the domain of `A`.
 
 #### Rank-2k update of a symmetric or Hermitian matrix [linalg.alg.blas3.rank2k]
 
-*[Note:* Users can achieve the effect of the `TRANS` argument of these
+<i>[Note:</i> Users can achieve the effect of the `TRANS` argument of these
 BLAS functions, by applying `transposed` or `conjugate_transposed`
-to the input matrices. --*end note]*
+to the input matrices. <i>-- end note]</i>
 
 * *Complexity:* The count of `mdspan` array accesses and arithmetic operations
     is linear in `A.extent(0)` times `A.extent(1)` times `B.extent(1)`.
@@ -10005,9 +10007,9 @@ void symmetric_matrix_rank_2k_update(
   Triangle t);
 ```
 
-*[Note:* These functions correspond to the BLAS function `xSYR2K`.
+<i>[Note:</i> These functions correspond to the BLAS function `xSYR2K`.
 The BLAS "quick reference" has a typo; the "ALPHA" argument of
-`CSYR2K` and `ZSYR2K` should not be conjugated.  --*end note]*
+`CSYR2K` and `ZSYR2K` should not be conjugated.  <i>-- end note]</i>
 
 For `i,j` in the domain of `C`
 and in the triangle of `C` specified by `t`,
@@ -10085,8 +10087,8 @@ void hermitian_matrix_rank_2k_update(
   Triangle t);
 ```
 
-*[Note:* These functions correspond to the BLAS function `xHER2K`.
---*end note]*
+<i>[Note:</i> These functions correspond to the BLAS function `xHER2K`.
+<i>-- end note]</i>
 
 For `i,j` in the domain of `C`
 and in the triangle of `C` specified by `t`,
@@ -10140,8 +10142,8 @@ for all `k2` such that `i,k2` is in the domain of `B`.
 
 #### Solve multiple triangular linear systems [linalg.alg.blas3.trsm]
 
-*[Note:* These functions correspond to the BLAS function `xTRSM`.  The
-Reference BLAS does not have a `xTPSM` function. --*end note]*
+<i>[Note:</i> These functions correspond to the BLAS function `xTRSM`.  The
+Reference BLAS does not have a `xTPSM` function. <i>-- end note]</i>
 
 The following requirements apply to all functions in this section.
 
@@ -10267,14 +10269,14 @@ where `s` is the sum of `A[i,k] * X[k,j]`
 for all `k` not equal to `i`
 in the subset of the domain of `A` specified by `t`.
 
-*[Note:*
+<i>[Note:</i>
 Since the triangular matrix is on the left,
 the desired `divide` implementation
 in the case of noncommutative multiplication
 would be mathematically equivalent to
 the product of (the inverse of the second argument)
 and the first argument, in that order.
---*end note]*
+<i>-- end note]</i>
 
 If `DiagonalStorage` is `implicit_unit_diagonal_t`,
 then for `i,j` in the domain of `X`,
@@ -10343,7 +10345,7 @@ void triangular_matrix_matrix_left_solve(
   InOutMat B);
 ```
 
-*[Note:*
+<i>[Note:</i>
 
 This algorithm makes it possible to compute factorizations like
 Cholesky and LU in place.
@@ -10353,7 +10355,7 @@ However, other `ExecutionPolicy`-specific optimizations,
 such as vectorization, are still possible.
 This is why the `ExecutionPolicy` overload exists.
 
---*end note]*
+<i>-- end note]</i>
 
 If `DiagonalStorage` is `explicit_diagonal_t`,
 then for `i,j` in the domain of `B`,
@@ -10368,14 +10370,14 @@ where `s` is the sum of `A[i,k] * B[k,j]`
 for all `k` not equal to `i`
 in the subset of the domain of `A` specified by `t`.
 
-*[Note:*
+<i>[Note:</i>
 Since the triangular matrix is on the left,
 the desired `divide` implementation
 in the case of noncommutative multiplication
 would be mathematically equivalent to
 the product of (the inverse of the second argument)
 and the first argument, in that order.
---*end note]*
+<i>-- end note]</i>
 
 If `DiagonalStorage` is `implicit_unit_diagonal_t`,
 then for `i,j` in the domain of `B`,
@@ -10470,7 +10472,7 @@ where `s` is the sum of `X[i,k] * A[k,j]`
 for all `k` not equal to `j`
 in the subset of the domain of `A` specified by `t`.
 
-*[Note:*
+<i>[Note:</i>
 Since the triangular matrix is on the right,
 the desired `divide` implementation
 in the case of noncommutative multiplication
@@ -10478,7 +10480,7 @@ would be mathematically equivalent to
 the product of the first argument, and
 (the inverse of the second argument),
 in that order.
---*end note]*
+<i>-- end note]</i>
 
 If `DiagonalStorage` is `implicit_unit_diagonal_t`,
 then for `i,j` in the domain of `X`,
@@ -10488,7 +10490,7 @@ where `s` is the sum of `X[i,k] * A[k,j]`
 for all `k` not equal to `j`
 in the subset of the domain of `A` specified by `t`.
 
-*[Note:*
+<i>[Note:</i>
 
 One can derive these mathematical expressions
 from the mathematical expressions of the
@@ -10502,7 +10504,7 @@ taking the transpose of both sides does not change the equation,
 and the transpose of a product of two matrices
 is the product of the reversed matrices in transposed order.
 
---*end note]*
+<i>-- end note]</i>
 
 * *Preconditions:* `A.extent(1)` equals `B.extent(1)`.
 
@@ -10563,7 +10565,7 @@ void triangular_matrix_matrix_right_solve(
   InOutMat B);
 ```
 
-*[Note:*
+<i>[Note:</i>
 
 This algorithm makes it possible to compute factorizations like
 Cholesky and LU in place.
@@ -10573,7 +10575,7 @@ However, other `ExecutionPolicy`-specific optimizations,
 such as vectorization, are still possible.
 This is why the `ExecutionPolicy` overload exists.
 
---*end note]*
+<i>-- end note]</i>
 
 If `DiagonalStorage` is `explicit_diagonal_t`,
 then for `i,j` in the domain of `B`,
@@ -10588,7 +10590,7 @@ where `s` is the sum of `B[i,k] * A[k,j]`
 for all `k` not equal to `j`
 in the subset of the domain of `A` specified by `t`.
 
-*[Note:*
+<i>[Note:</i>
 Since the triangular matrix is on the right,
 the desired `divide` implementation
 in the case of noncommutative multiplication
@@ -10596,7 +10598,7 @@ would be mathematically equivalent to
 the product of the first argument, and
 (the inverse of the second argument),
 in that order.
---*end note]*
+<i>-- end note]</i>
 
 If `DiagonalStorage` is `implicit_unit_diagonal_t`,
 then for `i,j` in the domain of `B`,

--- a/D1673/P1673.md
+++ b/D1673/P1673.md
@@ -456,6 +456,12 @@ toc: true
       (Retain the unique layout constraint
       for symmetric and Hermitian matrix-vector product.)
 
+  * Remove all constraints on *[linalg.algs.blas3.gemm]*.
+      It is unnecessary to constraint input matrix parameter(s)
+      to have unique layout.
+      All other constraints were redundant
+      with the new exposition-only concepts.
+
 # Purpose of this paper
 
 This paper proposes a C++ Standard Library dense linear algebra
@@ -4304,36 +4310,36 @@ void hermitian_matrix_rank_2_update(
 // general matrix-matrix product
 template<class in_matrix_1_t,
          class in_matrix_2_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void matrix_product(in_matrix_1_t A,
                     in_matrix_2_t B,
-                    out_matrix_t C);
+                    OutMat C);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class in_matrix_2_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void matrix_product(ExecutionPolicy&& exec,
                     in_matrix_1_t A,
                     in_matrix_2_t B,
-                    out_matrix_t C);
+                    OutMat C);
 template<class in_matrix_1_t,
          class in_matrix_2_t,
          class in_matrix_3_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void matrix_product(in_matrix_1_t A,
                     in_matrix_2_t B,
                     in_matrix_3_t E,
-                    out_matrix_t C);
+                    OutMat C);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class in_matrix_2_t,
          class in_matrix_3_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void matrix_product(ExecutionPolicy&& exec,
                     in_matrix_1_t A,
                     in_matrix_2_t B,
                     in_matrix_3_t E,
-                    out_matrix_t C);
+                    OutMat C);
 
 // [linalg.algs.blas3.symm],
 // symmetric matrix-matrix product
@@ -4343,46 +4349,46 @@ void matrix_product(ExecutionPolicy&& exec,
 template<class in_matrix_1_t,
          class Triangle,
          class in_matrix_2_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void symmetric_matrix_left_product(
   in_matrix_1_t A,
   Triangle t,
   in_matrix_2_t B,
-  out_matrix_t C);
+  OutMat C);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class in_matrix_2_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void symmetric_matrix_left_product(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
   in_matrix_2_t B,
-  out_matrix_t C);
+  OutMat C);
 
 // [linalg.algs.blas3.symm.ov.right],
 // overwriting symmetric matrix-matrix right product
 template<class in_matrix_1_t,
          class Triangle,
          class in_matrix_2_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void symmetric_matrix_right_product(
   in_matrix_1_t A,
   Triangle t,
   in_matrix_2_t B,
-  out_matrix_t C);
+  OutMat C);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class in_matrix_2_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void symmetric_matrix_right_product(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
   in_matrix_2_t B,
-  out_matrix_t C);
+  OutMat C);
 
 // [linalg.algs.blas3.symm.up.left],
 // updating symmetric matrix-matrix left product
@@ -4390,26 +4396,26 @@ template<class in_matrix_1_t,
          class Triangle,
          class in_matrix_2_t,
          class in_matrix_3_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void symmetric_matrix_left_product(
   in_matrix_1_t A,
   Triangle t,
   in_matrix_2_t B,
   in_matrix_3_t E,
-  out_matrix_t C);
+  OutMat C);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class in_matrix_2_t,
          class in_matrix_3_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void symmetric_matrix_left_product(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
   in_matrix_2_t B,
   in_matrix_3_t E,
-  out_matrix_t C);
+  OutMat C);
 
 // [linalg.algs.blas3.symm.up.right],
 // updating symmetric matrix-matrix right product
@@ -4417,26 +4423,26 @@ template<class in_matrix_1_t,
          class Triangle,
          class in_matrix_2_t,
          class in_matrix_3_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void symmetric_matrix_right_product(
   in_matrix_1_t A,
   Triangle t,
   in_matrix_2_t B,
   in_matrix_3_t E,
-  out_matrix_t C);
+  OutMat C);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class in_matrix_2_t,
          class in_matrix_3_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void symmetric_matrix_right_product(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
   in_matrix_2_t B,
   in_matrix_3_t E,
-  out_matrix_t C);
+  OutMat C);
 
 // [linalg.algs.blas3.hemm],
 // Hermitian matrix-matrix product
@@ -4446,46 +4452,46 @@ void symmetric_matrix_right_product(
 template<class in_matrix_1_t,
          class Triangle,
          class in_matrix_2_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void hermitian_matrix_left_product(
   in_matrix_1_t A,
   Triangle t,
   in_matrix_2_t B,
-  out_matrix_t C);
+  OutMat C);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class in_matrix_2_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void hermitian_matrix_left_product(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
   in_matrix_2_t B,
-  out_matrix_t C);
+  OutMat C);
 
 // [linalg.algs.blas3.hemm.ov.right],
 // overwriting Hermitian matrix-matrix right product
 template<class in_matrix_1_t,
          class Triangle,
          class in_matrix_2_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void hermitian_matrix_right_product(
   in_matrix_1_t A,
   Triangle t,
   in_matrix_2_t B,
-  out_matrix_t C);
+  OutMat C);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class in_matrix_2_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void hermitian_matrix_right_product(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
   in_matrix_2_t B,
-  out_matrix_t C);
+  OutMat C);
 
 // [linalg.algs.blas3.hemm.up.left],
 // updating Hermitian matrix-matrix left product
@@ -4493,26 +4499,26 @@ template<class in_matrix_1_t,
          class Triangle,
          class in_matrix_2_t,
          class in_matrix_3_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void hermitian_matrix_left_product(
   in_matrix_1_t A,
   Triangle t,
   in_matrix_2_t B,
   in_matrix_3_t E,
-  out_matrix_t C);
+  OutMat C);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class in_matrix_2_t,
          class in_matrix_3_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void hermitian_matrix_left_product(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
   in_matrix_2_t B,
   in_matrix_3_t E,
-  out_matrix_t C);
+  OutMat C);
 
 // [linalg.algs.blas3.hemm.up.right],
 // updating Hermitian matrix-matrix right product
@@ -4520,26 +4526,26 @@ template<class in_matrix_1_t,
          class Triangle,
          class in_matrix_2_t,
          class in_matrix_3_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void hermitian_matrix_right_product(
   in_matrix_1_t A,
   Triangle t,
   in_matrix_2_t B,
   in_matrix_3_t E,
-  out_matrix_t C);
+  OutMat C);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class in_matrix_2_t,
          class in_matrix_3_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void hermitian_matrix_right_product(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
   in_matrix_2_t B,
   in_matrix_3_t E,
-  out_matrix_t C);
+  OutMat C);
 
 // [linalg.algs.blas3.trmm],
 // triangular matrix-matrix product
@@ -4550,26 +4556,26 @@ template<class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
          class in_matrix_2_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void triangular_matrix_left_product(
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
   in_matrix_2_t B,
-  out_matrix_t C);
+  OutMat C);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
          class in_matrix_2_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void triangular_matrix_left_product(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
   in_matrix_2_t B,
-  out_matrix_t C);
+  OutMat C);
 template<class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
@@ -4597,26 +4603,26 @@ template<class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
          class in_matrix_2_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void triangular_matrix_right_product(
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
   in_matrix_2_t B,
-  out_matrix_t C);
+  OutMat C);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
          class in_matrix_2_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void triangular_matrix_right_product(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
   in_matrix_2_t B,
-  out_matrix_t C);
+  OutMat C);
 template<class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
@@ -4645,21 +4651,21 @@ template<class in_matrix_1_t,
          class DiagonalStorage,
          class in_matrix_2_t,
          class in_matrix_3_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void triangular_matrix_left_product(
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
   in_matrix_2_t B,
   in_matrix_3_t E,
-  out_matrix_t C);
+  OutMat C);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
          class in_matrix_2_t,
          class in_matrix_3_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void triangular_matrix_left_product(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
@@ -4667,7 +4673,7 @@ void triangular_matrix_left_product(
   DiagonalStorage d,
   in_matrix_2_t B,
   in_matrix_3_t E,
-  out_matrix_t C);
+  OutMat C);
 
 // [linalg.algs.blas3.trmm.up.right],
 // updating triangular matrix-matrix right product
@@ -4676,21 +4682,21 @@ template<class in_matrix_1_t,
          class DiagonalStorage,
          class in_matrix_2_t,
          class in_matrix_3_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void triangular_matrix_right_product(
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
   in_matrix_2_t B,
   in_matrix_3_t E,
-  out_matrix_t C);
+  OutMat C);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
          class in_matrix_2_t,
          class in_matrix_3_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void triangular_matrix_right_product(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
@@ -4698,7 +4704,7 @@ void triangular_matrix_right_product(
   DiagonalStorage d,
   in_matrix_2_t B,
   in_matrix_3_t E,
-  out_matrix_t C);
+  OutMat C);
 
 // [linalg.alg.blas3.rank-k.syrk],
 // rank-k symmetric matrix update
@@ -4802,21 +4808,21 @@ template<class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
          class in_matrix_2_t,
-         class out_matrix_t,
+         out_matrix OutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_left_solve(
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
   in_matrix_2_t B,
-  out_matrix_t X,
+  OutMat X,
   BinaryDivideOp divide);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
          class in_matrix_2_t,
-         class out_matrix_t,
+         out_matrix OutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_left_solve(
   ExecutionPolicy&& exec,
@@ -4824,7 +4830,7 @@ void triangular_matrix_matrix_left_solve(
   Triangle t,
   DiagonalStorage d,
   in_matrix_2_t B,
-  out_matrix_t X,
+  OutMat X,
   BinaryDivideOp divide);
 template<class in_matrix_1_t,
          class Triangle,
@@ -4855,26 +4861,26 @@ template<class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
          class in_matrix_2_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void triangular_matrix_matrix_left_solve(
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
   in_matrix_2_t B,
-  out_matrix_t X);
+  OutMat X);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
          class in_matrix_2_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void triangular_matrix_matrix_left_solve(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
   in_matrix_2_t B,
-  out_matrix_t X);
+  OutMat X);
 template<class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
@@ -4903,21 +4909,21 @@ template<class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
          class in_matrix_2_t,
-         class out_matrix_t,
+         out_matrix OutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_right_solve(
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
   in_matrix_2_t B,
-  out_matrix_t X,
+  OutMat X,
   BinaryDivideOp divide);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
          class in_matrix_2_t,
-         class out_matrix_t,
+         out_matrix OutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_right_solve(
   ExecutionPolicy&& exec,
@@ -4925,7 +4931,7 @@ void triangular_matrix_matrix_right_solve(
   Triangle t,
   DiagonalStorage d,
   InMat B,
-  out_matrix_t X,
+  OutMat X,
   BinaryDivideOp divide);
 template<class in_matrix_1_t,
          class Triangle,
@@ -4956,26 +4962,26 @@ template<class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
          class in_matrix_2_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void triangular_matrix_matrix_right_solve(
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
   in_matrix_2_t B,
-  out_matrix_t X);
+  OutMat X);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
          class in_matrix_2_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void triangular_matrix_matrix_right_solve(
   ExecutionPolicy&& exec,
   InMat A,
   Triangle t,
   DiagonalStorage d,
   InMat B,
-  out_matrix_t X);
+  OutMat X);
 template<class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
@@ -8799,14 +8805,6 @@ The following requirements apply to all functions in this section.
 
     * `B.extent(1)` equals `C.extent(1)`.
 
-* *Constraints:*
-
-    * `in_matrix_1_t`, `in_matrix_2_t`, `in_matrix_3_t` (if applicable),
-        and `out_matrix_t` have unique layout.
-
-    * `A.rank()` equals 2, `B.rank()` equals 2, `C.rank()` equals 2, and
-        `E.rank()` (if applicable) equals 2.
-
 * *Mandates:*
 
     * For all `r` in 0, 1, ..., `C.rank()` - 1, if neither
@@ -8835,19 +8833,19 @@ The following requirements apply to all functions in this section.
 ```c++
 template<class in_matrix_1_t,
          class in_matrix_2_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void matrix_product(in_matrix_1_t A,
                     in_matrix_2_t B,
-                    out_matrix_t C);
+                    OutMat C);
 
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class in_matrix_2_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void matrix_product(ExecutionPolicy&& exec,
                     in_matrix_1_t A,
                     in_matrix_2_t B,
-                    out_matrix_t C);
+                    OutMat C);
 ```
 
 For `i,j` in the domain of `C`,
@@ -8864,22 +8862,22 @@ for all `k` such that `i,k` is in the domain of `A`.
 template<class in_matrix_1_t,
          class in_matrix_2_t,
          class in_matrix_3_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void matrix_product(in_matrix_1_t A,
                     in_matrix_2_t B,
                     in_matrix_3_t E,
-                    out_matrix_t C);
+                    OutMat C);
 
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class in_matrix_2_t,
          class in_matrix_3_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void matrix_product(ExecutionPolicy&& exec,
                     in_matrix_1_t A,
                     in_matrix_2_t B,
                     in_matrix_3_t E,
-                    out_matrix_t C);
+                    OutMat C);
 ```
 
 For `i,j` in the domain of `C`,
@@ -8920,7 +8918,7 @@ The following requirements apply to all functions in this section.
         or `layout_blas_packed` layout.
 
     * `in_matrix_2_t`, `in_matrix_3_t` (if applicable),
-        and `out_matrix_t` have unique layout.
+        and `OutMat` have unique layout.
 
     * If `in_matrix_1_t` has `layout_blas_packed` layout, then the
         layout's `Triangle` template argument has the same type as
@@ -9012,23 +9010,23 @@ The following requirements apply to all overloads of
 template<class in_matrix_1_t,
          class Triangle,
          class in_matrix_2_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void symmetric_matrix_left_product(
   in_matrix_1_t A,
   Triangle t,
   in_matrix_2_t B,
-  out_matrix_t C);
+  OutMat C);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class in_matrix_2_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void symmetric_matrix_left_product(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
   in_matrix_2_t B,
-  out_matrix_t C);
+  OutMat C);
 ```
 
 For `i,j` in the domain of `C`,
@@ -9051,23 +9049,23 @@ and in the triangle of `A` specified by `t`.
 template<class in_matrix_1_t,
          class Triangle,
          class in_matrix_2_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void symmetric_matrix_right_product(
   in_matrix_1_t A,
   Triangle t,
   in_matrix_2_t B,
-  out_matrix_t C);
+  OutMat C);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class in_matrix_2_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void symmetric_matrix_right_product(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
   in_matrix_2_t B,
-  out_matrix_t C);
+  OutMat C);
 ```
 
 For `i,j` in the domain of `C`,
@@ -9092,26 +9090,26 @@ template<class in_matrix_1_t,
          class Triangle,
          class in_matrix_2_t,
          class in_matrix_3_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void symmetric_matrix_left_product(
   in_matrix_1_t A,
   Triangle t,
   in_matrix_2_t B,
   in_matrix_3_t E,
-  out_matrix_t C);
+  OutMat C);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class in_matrix_2_t,
          class in_matrix_3_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void symmetric_matrix_left_product(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
   in_matrix_2_t B,
   in_matrix_3_t E,
-  out_matrix_t C);
+  OutMat C);
 ```
 
 For `i,j` in the domain of `C`,
@@ -9135,26 +9133,26 @@ template<class in_matrix_1_t,
          class Triangle,
          class in_matrix_2_t,
          class in_matrix_3_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void symmetric_matrix_right_product(
   in_matrix_1_t A,
   Triangle t,
   in_matrix_2_t B,
   in_matrix_3_t E,
-  out_matrix_t C);
+  OutMat C);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class in_matrix_2_t,
          class in_matrix_3_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void symmetric_matrix_right_product(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
   in_matrix_2_t B,
   in_matrix_3_t E,
-  out_matrix_t C);
+  OutMat C);
 ```
 
 For `i,j` in the domain of `C`,
@@ -9199,7 +9197,7 @@ The following requirements apply to all functions in this section.
         or `layout_blas_packed` layout.
 
     * `in_matrix_2_t`, `in_matrix_3_t` (if applicable), and
-        `out_matrix_t` have unique layout.
+        `OutMat` have unique layout.
 
     * If `in_matrix_1_t` has `layout_blas_packed` layout, then the
         layout's `Triangle` template argument has the same type as
@@ -9291,23 +9289,23 @@ The following requirements apply to all overloads of
 template<class in_matrix_1_t,
          class Triangle,
          class in_matrix_2_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void hermitian_matrix_left_product(
   in_matrix_1_t A,
   Triangle t,
   in_matrix_2_t B,
-  out_matrix_t C);
+  OutMat C);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class in_matrix_2_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void hermitian_matrix_left_product(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
   in_matrix_2_t B,
-  out_matrix_t C);
+  OutMat C);
 ```
 
 For `i,j` in the domain of `C`,
@@ -9331,23 +9329,23 @@ and in the triangle of `A` specified by `t`.
 template<class in_matrix_1_t,
          class Triangle,
          class in_matrix_2_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void hermitian_matrix_right_product(
   in_matrix_1_t A,
   Triangle t,
   in_matrix_2_t B,
-  out_matrix_t C);
+  OutMat C);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class in_matrix_2_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void hermitian_matrix_right_product(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
   in_matrix_2_t B,
-  out_matrix_t C);
+  OutMat C);
 ```
 
 For `i,j` in the domain of `C`,
@@ -9372,26 +9370,26 @@ template<class in_matrix_1_t,
          class Triangle,
          class in_matrix_2_t,
          class in_matrix_3_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void hermitian_matrix_left_product(
   in_matrix_1_t A,
   Triangle t,
   in_matrix_2_t B,
   in_matrix_3_t E,
-  out_matrix_t C);
+  OutMat C);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class in_matrix_2_t,
          class in_matrix_3_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void hermitian_matrix_left_product(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
   in_matrix_2_t B,
   in_matrix_3_t E,
-  out_matrix_t C);
+  OutMat C);
 ```
 
 For `i,j` in the domain of `C`,
@@ -9416,26 +9414,26 @@ template<class in_matrix_1_t,
          class Triangle,
          class in_matrix_2_t,
          class in_matrix_3_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void hermitian_matrix_right_product(
   in_matrix_1_t A,
   Triangle t,
   in_matrix_2_t B,
   in_matrix_3_t E,
-  out_matrix_t C);
+  OutMat C);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class in_matrix_2_t,
          class in_matrix_3_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void hermitian_matrix_right_product(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
   in_matrix_2_t B,
   in_matrix_3_t E,
-  out_matrix_t C);
+  OutMat C);
 ```
 
 For `i,j` in the domain of `C`,
@@ -9573,26 +9571,26 @@ template<class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
          class in_matrix_2_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void triangular_matrix_left_product(
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
   in_matrix_2_t B,
-  out_matrix_t C);
+  OutMat C);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
          class in_matrix_2_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void triangular_matrix_left_product(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
   in_matrix_2_t B,
-  out_matrix_t C);
+  OutMat C);
 ```
 
 For `i,j` in the domain of `C`,
@@ -9652,26 +9650,26 @@ template<class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
          class in_matrix_2_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void triangular_matrix_right_product(
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
   in_matrix_2_t B,
-  out_matrix_t C);
+  OutMat C);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
          class in_matrix_2_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void triangular_matrix_right_product(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
   in_matrix_2_t B,
-  out_matrix_t C);
+  OutMat C);
 ```
 
 For `i,j` in the domain of `C`,
@@ -9730,21 +9728,21 @@ template<class in_matrix_1_t,
          class DiagonalStorage,
          class in_matrix_2_t,
          class in_matrix_3_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void triangular_matrix_left_product(
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
   in_matrix_2_t B,
   in_matrix_3_t E,
-  out_matrix_t C);
+  OutMat C);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
          class in_matrix_2_t,
          class in_matrix_3_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void triangular_matrix_left_product(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
@@ -9752,7 +9750,7 @@ void triangular_matrix_left_product(
   DiagonalStorage d,
   in_matrix_2_t B,
   in_matrix_3_t E,
-  out_matrix_t C);
+  OutMat C);
 ```
 
 For `i,j` in the domain of `C`,
@@ -9772,21 +9770,21 @@ template<class in_matrix_1_t,
          class DiagonalStorage,
          class in_matrix_2_t,
          class in_matrix_3_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void triangular_matrix_right_product(
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
   in_matrix_2_t B,
   in_matrix_3_t E,
-  out_matrix_t C);
+  OutMat C);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
          class in_matrix_2_t,
          class in_matrix_3_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void triangular_matrix_right_product(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
@@ -9794,7 +9792,7 @@ void triangular_matrix_right_product(
   DiagonalStorage d,
   in_matrix_2_t B,
   in_matrix_3_t E,
-  out_matrix_t C);
+  OutMat C);
 ```
 
 For `i,j` in the domain of `C`,
@@ -10207,21 +10205,21 @@ template<class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
          class in_matrix_2_t,
-         class out_matrix_t,
+         out_matrix OutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_left_solve(
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
   in_matrix_2_t B,
-  out_matrix_t X,
+  OutMat X,
   BinaryDivideOp divide);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
          class in_matrix_2_t,
-         class out_matrix_t,
+         out_matrix OutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_left_solve(
   ExecutionPolicy&& exec,
@@ -10229,33 +10227,33 @@ void triangular_matrix_matrix_left_solve(
   Triangle t,
   DiagonalStorage d,
   in_matrix_2_t B,
-  out_matrix_t X,
+  OutMat X,
   BinaryDivideOp divide);
 
 template<class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
          class in_matrix_2_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void triangular_matrix_matrix_left_solve(
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
   in_matrix_2_t B,
-  out_matrix_t X);
+  OutMat X);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
          class in_matrix_2_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void triangular_matrix_matrix_left_solve(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
   in_matrix_2_t B,
-  out_matrix_t X);
+  OutMat X);
 ```
 
 If `DiagonalStorage` is `explicit_diagonal_t`,
@@ -10410,21 +10408,21 @@ template<class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
          class in_matrix_2_t,
-         class out_matrix_t,
+         out_matrix OutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_right_solve(
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
   in_matrix_2_t B,
-  out_matrix_t X,
+  OutMat X,
   BinaryDivideOp divide);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
          class in_matrix_2_t,
-         class out_matrix_t,
+         out_matrix OutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_right_solve(
   ExecutionPolicy&& exec,
@@ -10432,33 +10430,33 @@ void triangular_matrix_matrix_right_solve(
   Triangle t,
   DiagonalStorage d,
   in_matrix_2_t B,
-  out_matrix_t X,
+  OutMat X,
   BinaryDivideOp divide);
 
 template<class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
          class in_matrix_2_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void triangular_matrix_matrix_right_solve(
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
   in_matrix_2_t B,
-  out_matrix_t X);
+  OutMat X);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
          class in_matrix_2_t,
-         class out_matrix_t>
+         out_matrix OutMat>
 void triangular_matrix_matrix_right_solve(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
   in_matrix_2_t B,
-  out_matrix_t X);
+  OutMat X);
 ```
 
 If `DiagonalStorage` is `explicit_diagonal_t`,
@@ -10830,15 +10828,15 @@ cholesky_tsqr_one_step(
 // Compute QR factorization A = Q R.  Use R_tmp as temporary R factor
 // storage for iterative refinement.
 template<in_matrix InMat,
-         class out_matrix_1_t,
-         class out_matrix_2_t,
-         class out_matrix_3_t>
-optional<typename out_matrix_1_t::size_type>
+         out_matrix OutMat1,
+         out_matrix OutMat2,
+         out_matrix OutMat3>
+optional<typename OutMat1::size_type>
 cholesky_tsqr(
   InMat A,
-  out_matrix_1_t Q,
-  out_matrix_2_t R_tmp,
-  out_matrix_3_t R)
+  OutMat1 Q,
+  OutMat2 R_tmp,
+  OutMat3 R)
 {
   assert(R.extent(0) == R.extent(1));
   assert(A.extent(1) == R.extent(0));

--- a/D1673/P1673.md
+++ b/D1673/P1673.md
@@ -1,0 +1,10835 @@
+<pre class='metadata'>
+Title: A free function linear algebra interface based on the BLAS
+Shortname: P1673
+Status: iso/P
+Level: 10
+Group: WG21
+URL: https://github.com/ORNL/cpp-proposals-pub/blob/master/D1673/P1673.bs
+Editor: Mark Hoemmen, NVIDIA, mhoemmen@nvidia.com
+Abstract: We propose a C++ Standard Library dense linear algebra interface based on the dense Basic Linear Algebra Subroutines (BLAS).  This corresponds to a subset of the BLAS Standard.
+Markup Shorthands: markdown yes
+Date: 2022-10-15
+</pre>
+
+# Authors and contributors
+
+## Authors
+
+* Mark Hoemmen (mhoemmen@nvidia.com) (NVIDIA)
+* Daisy Hollman (cpp@dsh.fyi) (Google)
+* Christian Trott (crtrott@sandia.gov) (Sandia National Laboratories)
+* Daniel Sunderland (dansunderland@gmail.com)
+* Nevin Liber (nliber@anl.gov) (Argonne National Laboratory)
+* Alicia Klinvex (alicia.klinvex@unnpp.gov) (Naval Nuclear Laboratory)
+* Li-Ta Lo (ollie@lanl.gov) (Los Alamos National Laboratory)
+* Damien Lebrun-Grandie (lebrungrandt@ornl.gov) (Oak Ridge National Laboratories)
+* Graham Lopez (glopez@nvidia.com) (NVIDIA)
+* Peter Caday (peter.caday@intel.com) (Intel)
+* Sarah Knepper (sarah.knepper@intel.com) (Intel)
+* Piotr Luszczek (luszczek@icl.utk.edu) (University of Tennessee)
+* Timothy Costa (tcosta@nvidia.com) (NVIDIA)
+
+## Contributors
+
+* Chip Freitag (chip.freitag@amd.com) (AMD)
+* Bryce Adelstein Lelbach (brycelelbach@gmail.com) (NVIDIA)
+* Srinath Vadlamani (Srinath.Vadlamani@arm.com) (ARM)
+* Rene Vanoostrum (Rene.Vanoostrum@amd.com) (AMD)
+
+# Revision history
+
+* Revision 0 (pre-Cologne) submitted 2019-06-17
+
+    * Received feedback in Cologne from SG6, LEWGI, and (???).
+
+* Revision 1 (pre-Belfast) to be submitted 2019-10-07
+
+    * Account for Cologne 2019 feedback
+
+        * Make interface more consistent with existing Standard algorithms
+
+        * Change `dot`, `dotc`, `vector_norm2`, and `vector_abs_sum` to
+            imitate `reduce`, so that they return their result, instead of
+            taking an output parameter.  Users may set the result type via
+            optional `init` parameter.
+
+    * Minor changes to "expression template" classes, based on
+        implementation experience
+
+    * Briefly address LEWGI request of exploring concepts for input arguments.
+
+    * Lazy ranges style API was NOT explored.
+
+* Revision 2 (pre-Cologne) to be submitted 2020-01-13
+
+    * Add "Future work" section.
+
+    * Remove "Options and votes" section (which were addressed in SG6,
+        SG14, and LEWGI).
+
+    * Remove `basic_mdarray` overloads.
+
+    * Remove batched linear algebra operations.
+
+    * Remove over- and underflow requirement for `vector_norm2`.
+
+    * *Mandate* any extent compatibility checks that can be done at
+        compile time.
+
+    * Add missing functions `{symmetric,hermitian}_matrix_rank_k_update`
+        and `triangular_matrix_{left,right}_product`.
+
+    * Remove `packed_view` function.
+
+    * Fix wording for `{conjugate,transpose,conjugate_transpose}_view`,
+        so that implementations may optimize the return type.  Make sure
+        that `transpose_view` of a `layout_blas_packed` matrix returns a
+        `layout_blas_packed` matrix with opposite `Triangle` and
+        `StorageOrder`.
+
+    * Remove second template parameter `T` from `accessor_conjugate`.
+
+    * Make `scaled_scalar` and `conjugated_scalar` exposition only.
+
+    * Add in-place overloads of
+        `triangular_matrix_matrix_{left,right}_solve`,
+        `triangular_matrix_{left,right}_product`, and
+        `triangular_matrix_vector_solve`.
+
+    * Add `alpha` overloads to
+        `{symmetric,hermitian}_matrix_rank_{1,k}_update`.
+
+    * Add Cholesky factorization and solve examples.
+
+* Revision 3 (electronic) to be submitted 2021-04-15
+
+    * Per LEWG request, add a section on our investigation
+        of constraining template parameters with concepts,
+        in the manner of P1813R0 with the numeric algorithms.
+        We concluded that we disagree with the approach of P1813R0,
+        and that the Standard's current *GENERALIZED_SUM* approach
+        better expresses numeric algorithms' behavior.
+
+    * Update references to the current revision of P0009 (`mdspan`).
+
+    * Per LEWG request, introduce `std::linalg` namespace and put everything in there.
+
+    * Per LEWG request, replace the `linalg_` prefix with the aforementioned namespace.
+        We renamed `linalg_add` to `add`,
+        `linalg_copy` to `copy`, and
+        `linalg_swap` to `swap_elements`.
+
+    * Per LEWG request, do not use `_view` as a suffix,
+        to avoid confusion with "views" in the sense of Ranges.
+        We renamed `conjugate_view` to `conjugated`,
+        `conjugate_transpose_view` to `conjugate_transposed`,
+        `scaled_view` to `scaled`, and
+        `transpose_view` to `transposed`.
+
+    * Change wording from "then implementations will use `T`'s precision or greater
+        for intermediate terms in the sum,"
+        to "then intermediate terms in the sum use `T`'s precision or greater."
+        Thanks to Jens Maurer for this suggestion (and many others!).
+
+    * Before, a Note on `vector_norm2` said,
+        "We recommend that implementers document their guarantees regarding overflow and underflow
+        of `vector_norm2` for floating-point return types."
+        Implementations always document "implementation-defined behavior" per **[defs.impl.defined]**.
+        (Thanks to Jens Maurer for pointing out that "We recommend..." does not belong in the Standard.)
+        Thus, we changed this from a Note to normative wording in Remarks:
+        "If either `in_vector_t::element_type` or `T` are
+        floating-point types or complex versions thereof,
+        then any guarantees regarding overflow and underflow of `vector_norm2`
+        are implementation-defined."
+
+    * Define return types of the
+        `dot`, `dotc`, `vector_norm2`, and `vector_abs_sum` overloads
+        with `auto` return type.
+
+    * Remove the explicitly stated constraint on `add` and `copy`
+        that the rank of the array arguments be no more than 2.
+        This is redundant, because we already impose this
+        via the existing constraints on template parameters named
+        `in_object*_t`, `inout_object*_t`, or `out_object*_t`.
+        If we later wish to relax this restriction,
+        then we only have to do so in one place.
+
+    * Add `vector_sum_of_squares`.
+        First, this gives implementers a path to implementing `vector_norm2`
+        in a way that achieves the over/underflow guarantees
+        intended by the BLAS Standard.
+        Second, this is a useful algorithm in itself
+        for parallelizing vector 2-norm computation.
+
+    * Add `matrix_frob_norm`, `matrix_one_norm`, and `matrix_inf_norm`
+        (thanks to coauthor Piotr Luszczek).
+
+    * Address LEWG request for us to investigate support for GPU memory.
+        See section "Explicit support for asynchronous return of scalar values."
+
+    * Add `ExecutionPolicy` overloads of the in-place versions of
+        `triangular_matrix_vector_solve`,
+        `triangular_matrix_left_product`,
+        `triangular_matrix_right_product`,
+        `triangular_matrix_matrix_left_solve`, and
+        `triangular_matrix_matrix_right_solve`.
+
+* Revision 4 (electronic), to be submitted 2021-08-15
+
+    * Update authors' contact info.
+
+    * Rebase atop P2299R3, which in turn sits atop P0009R12.
+        Make any needed fixes due to these changes.
+        (P1673R3 was based on P0009R10, without P2299.)
+        Update P0009 references to point to the latest version (R12).
+
+    * Fix requirements for `{symmetric,hermitian}_matrix_{left,right}_product`.
+
+    * Change `SemiRegular<Scalar>` to `semiregular<Scalar>`.
+
+    * Make `Real` requirements refer to **[complex.numbers.general]**,
+        rather than explicitly listing allowed types.
+        Remove redundant constraints on `Real`.
+
+    * In **[linalg.algs.reqs]**, clarify that "unique layout"
+        for output matrix, vector, or object types
+        means `is_always_unique()` equals `true`.
+
+    * Change file format from Markdown to Bikeshed.
+
+    * Impose requirements on the types on which algorithms compute,
+        and on the algorithms themselves (e.g., what rearrangements are permitted).
+        Add a section explaining how we came up with the requirements.
+        Lift the requirements into a new higher-level section
+        that applies to the entire contents of **[linalg]**,
+        not just to **[linalg.algs]**.
+
+    * Add "Overview of contents" section.
+
+    * In the last review, LEWG had asked us to consider using exposition-only concepts
+        and `requires` clauses to express requirements more clearly.
+        We decided not to do so, because we did not think it would add clarity.
+
+    * Add more examples.
+
+* Revision 5 (electronic), to be submitted 2021-10-15
+
+    * P0009R13 (to be submitted 2021-10-15) changes `mdspan` to use `operator[]`
+        instead of `operator()` as the array access operator.
+        Revision 5 of P1673 adopts this change, and is "rebased" atop P1673R5.
+
+* Revision 6 (electronic), to be submitted 2021-12-15
+
+    * Update references to P0009 (P0009R14) and P2128 (P2128R6).
+
+    * Fix typos in `*rank_2k` descriptions.
+
+    * Remove references to any `mdspan` rank greater than 2.
+        (These were left over from earlier versions of the proposal
+        that included "batched" operations.)
+    
+    * Fix `vector_sum_of_squares` name in BLAS comparison table.
+
+    * Replace "Requires" with "Preconditions," per new wording guidelines.
+
+    * Remove all overloads of `symmetric_matrix_rank_k_update` and
+        `hermitian_matrix_rank_k_update` that do not take an `alpha` parameter.
+        This prevents ambiguity between overloads
+        that take `ExecutionPolicy&&` but not `alpha`,
+        and overloads that take `alpha` but not `ExecutionPolicy&&`.
+    
+    * Harmonize with the implementation, by adding `operator+`, `operator*`,
+        and comparison operators to `conjugated_scalar`.
+
+* Revision 7 (electronic), to be submitted 2022-04-15
+
+    * Update author affiliations and e-mail addresses
+
+    * Update proposal references
+
+    * Fix typo observed <a href="https://github.com/kokkos/stdBLAS/issues/158">here</a>
+
+    * Add missing `ExecutionPolicy` overload of in-place
+        `triangular_matrix_vector_product`; issue was observed
+        <a href="https://github.com/kokkos/stdBLAS/issues/150">here</a>
+
+    * Fix mixed-up order of `sum_of_squares_result` aggregate initialization arguments
+        in `vector_norm2` note
+
+    * Fill in missing parts of `matrix_frob_norm` and `vector_norm2` specification, addressing <a href="https://github.com/kokkos/stdBLAS/issues/143">this issue</a>
+
+* Revision 8 (electronic), to be submitted 2022-05-15
+
+    * Fix `Triangle` and `R[0,0]` in Cholesky TSQR example
+
+    * Explain why we apply `Triangle` to the possibly transformed input matrix,
+        while the BLAS applies `UPLO` to the original input matrix
+
+    * Optimize `transposed` for all known layouts,
+        so as to avoid use of `layout_transpose` when not needed;
+        fix computation of strides for transposed layouts
+
+    * Fix matrix extents in constraints and mandates
+        for `symmetric_matrix_rank_k_update` and `hermitian_matrix_rank_k_update`
+        (thanks to Mikołaj Zuzek (NexGen Analytics, `mikolaj.zuzek@ng-analytics.com`) 
+        for reporting the issue)
+
+    * Resolve vagueness in `const`ness of return type of `transposed`
+
+    * Resolve vagueness in `const`ness of return type of `scaled`,
+        and make its element type the type of the product,
+        rather than forcing it back to the input `mdspan`'s element type
+
+    * Remove `decay` member function from `accessor_conjugate` and `accessor_scaled`,
+        as it is no longer part of `mdspan`'s accessor policy requirements
+
+    * Make sure `accessor_conjugate` and `conjugated` work correctly
+        for user-defined complex types,
+        introduce _`conj-if-needed`_ to simplify wording,
+        and resolve vagueness in `const`ness of return type of `conjugated`.
+        Make sure that _`conj-if-needed`_ works for custom types
+        where `conj` is not type-preserving.
+        (Thanks to Yu You (NVIDIA, yuyou@nvidia.com) and
+        Phil Miller (Intense Computing, `phil.miller@intensecomputing.com`)
+        for helpful discussions.)
+
+    * Fix typo in `givens_rotation_setup` for complex numbers, and other typos
+        (thanks to Phil Miller for reporting the issue)
+
+* Revision 9 (electronic), to be submitted 2022-06-15
+
+    * Apply to-be-submitted P0009R17 changes (see P2553 in particular)
+        to all layouts, accessors, and examples in this proposal.
+
+    * Improve `triangular_matrix_matrix_{left,right}_solve()`
+        "mathematical expression of the algorithm" wording.
+
+    * `layout_blas_packed`: Fix `required_span_size()` and `operator()` wording
+
+    * Make sure all definitions of lower and upper triangle are consistent.
+
+    * Changes to `layout_transpose`:
+
+        * Make `layout_transpose::mapping(const nested_mapping_type&)` constructor
+            `explicit`, to avoid inadvertent transposition.
+
+        * Remove the following Constraint on `layout_transpose::mapping`: 
+            "for all specializations `E` of `extents` with `E::rank()` equal to 2,
+            `typename Layout::template mapping<E>::is_always_unique()` is `true`."
+	    (This Constraint was not correct, because the underlying mapping
+	    is allowed to be nonunique.)
+
+        * Make `layout_transpose::mapping::stride` wording
+	    independent of `rank()` equals 2 constraint,
+	    to improve consistency with rest of `layout_transpose` wording.
+
+    * Changes to `scaled` and `conjugated`:
+
+        * Include and specify all the needed overloaded arithmetic operators
+	    for `scaled_scalar` and `conjugated_scalar`, and
+	    fix `accessor_scaled` and `accessor_conjugate` accordingly.
+
+        * Simplify `scaled` to ensure preservation of order of operations.
+
+        * Add missing `nested_accessor()` to `accessor_scaled`.
+
+        * Add hidden friends `abs`, `real`, `imag`, and `conj`
+	    to common subclass of `scaled_scalar` and `conjugated_scalar`.
+            Add wording to algorithms that use `abs`, `real`, and/or `imag`,
+	    to indicate that these functions are to be found
+	    by unqualified lookup.
+	    (Algorithms that use conjugation already use _`conj-if-needed`_
+	    in their wording.)
+
+    * Changes suggested by SG6 small group review on 2022/06/09
+
+        * Make existing exposition-only function `conj-if-needed`
+	          use `conj` if it can find it via unqualified (ADL-only) lookup,
+	          otherwise be the identity.
+	          Make it a function object instead of a function,
+	          to prevent ADL issues.
+
+        * Algorithms that mathematically need to do division
+	    can now distinguish left division and right division
+	    (for the case of noncommutative multiplication),
+	    by taking an optional `BinaryDivideOp`
+	    binary function object parameter.
+	    If none is given, binary `operator/` is used.
+
+    * Changes suggested by LEWG review of P1673R8 on 2022/05/24
+
+        * LEWG asked us to add a section to the paper
+            explaining why we don't define an interface
+            for customization of the "back-end" optimized BLAS operations.
+            This section already existed, but we rewrote it
+	          to improve clarity.  Please see the section titled
+            "We do not require using the BLAS library
+            or any particular 'back-end'."
+
+        * LEWG asked us to add a section to the paper
+            showing how BLAS 1 and ranges algorithms would coexist.
+            We added this section, titled
+            "Criteria for including BLAS 1 algorithms;
+            coexistence with ranges."
+
+        * Address LEWG feedback to defer support
+	          for custom complex number types
+	          (but see above SG6 small group response).
+
+    * Fix P1674 links to point to R2.
+
+* Revision 10 (electronic), to be submitted soon
+
+    * Revise `scaled` and `conjugated` wording.
+
+    * Make all matrix view functions `constexpr`.
+
+    * Rebase atop P2642R1.
+        Remove wording saying that we rebase atop P0009R17.
+        (We don't need that any more, because P0009
+        was merged into the current C++ draft.)
+
+    * Remove `layout_blas_general`, as it has been replaced
+        with the layouts proposed by P2642
+        (`layout_left_padded` and `layout_right_padded`).
+
+    * Update `layout_blas_packed` to match mdspan's other layout mappings
+        in the current C++ Standard draft.
+
+    * Update accessors to match mdspan's other accessors
+        in the current C++ Standard draft.
+
+    * Update non-wording to reflect current status of `mdspan`
+        (voted into C++ Standard draft) and `submdspan` (P2630).
+
+# Purpose of this paper
+
+This paper proposes a C++ Standard Library dense linear algebra
+interface based on the dense Basic Linear Algebra Subroutines (BLAS).
+This corresponds to a subset of the
+[BLAS Standard](http://www.netlib.org/blas/blast-forum/blas-report.pdf).
+Our proposal implements the following classes of algorithms on arrays that represent
+matrices and vectors:
+
+* elementwise vector sums;
+* multiplying all elements of a vector or matrix by a scalar;
+* 2-norms and 1-norms of vectors;
+* vector-vector, matrix-vector, and matrix-matrix products (contractions);
+* low-rank updates of a matrix;
+* triangular solves with one or more "right-hand side" vectors; and
+* generating and applying plane (Givens) rotations.
+
+Our algorithms work with most of the matrix storage formats that the BLAS
+Standard supports:
+
+* "general" dense matrices, in column-major or row-major format;
+* symmetric or Hermitian (for complex numbers only) dense matrices,
+    stored either as general dense matrices, or in a packed format; and
+* dense triangular matrices, stored either as general dense matrices
+    or in a packed format.
+
+Our proposal also has the following distinctive characteristics.
+
+* It uses free functions, not arithmetic operator overloading.
+
+* The interface is designed in the spirit of the C++ Standard Library's
+    algorithms.
+
+* It uses `mdspan` (P0009 and follow-on papers,
+    which have been adopted into the C++23 draft),
+    a multidimensional array view, to represent matrices and vectors.
+
+* The interface permits optimizations for matrices and vectors with
+    small compile-time dimensions; the standard BLAS interface does not.
+
+* Each of our proposed operations supports all element types for which
+    that operation makes sense, unlike the BLAS, which only supports
+    four element types.
+
+* Our operations permit "mixed-precision" computation with matrices
+    and vectors that have different element types.  This subsumes most
+    functionality of the Mixed-Precision BLAS specification,
+    comprising Chapter 4 of the
+    <a href="http://www.netlib.org/blas/blast-forum/blas-report.pdf">BLAS Standard</a>.
+
+* Like the C++ Standard Library's algorithms, our operations take an
+    optional execution policy argument.  This is a hook to support
+    parallel execution and hierarchical parallelism (through the
+    proposed executor extensions to execution policies; see
+    P1019R2).
+
+* Unlike the BLAS, our proposal can be expanded to support "batched"
+    operations (see P1417R0) with almost no
+    interface differences.  This will support machine learning and other
+    applications that need to do many small matrix or vector operations
+    at once.
+
+Here are some examples of what this proposal offers.
+In these examples, we ignore `std::` namespace qualification
+for anything in our proposal or for `mdspan`.
+We start with a "hello world" that scales the elements of a 1-D `mdspan`
+by a constant factor, first sequentially, then in parallel.
+
+```c++
+  constexpr size_t N = 40;
+  std::vector<double> x_vec(N);
+
+  mdspan x(x_vec.data(), N);
+  for(size_t i = 0; i < N; ++i) {
+    x[i] = double(i);
+  }
+
+  linalg::scale(2.0, x); // x = 2.0 * x
+  linalg::scale(std::execution::par_unseq, 3.0, x);
+  for(size_t i = 0; i < N; ++i) {
+    assert(x[i] == 6.0 * double(i));
+  }
+```
+
+Here is a matrix-vector product example.
+It illustrates the `scaled` function that makes our interface more concise,
+while still permitting the BLAS' performance optimization
+of fusing computations with multiplications by a scalar.
+It also shows the ability to exploit dimensions known at compile time,
+and to mix compile-time and run-time dimensions arbitrarily.
+
+```c++
+constexpr size_t N = 40;
+constexpr size_t M = 20;
+
+std::vector<double> A_vec(N*M);
+std::vector<double> x_vec(M);
+std::array<double, N> y_vec(N);
+
+mdspan A(A_vec.data(), N, M);
+mdspan x(x_vec.data(), M);
+mdspan y(y_vec.data(), N);
+
+for(int i = 0; i < A.extent(0); ++i) {
+  for(int j = 0; j < A.extent(1); ++j) {
+    A[i,j] = 100.0 * i + j;
+  }
+}
+for(int j = 0; j < x.extent(0); ++j) {
+  x[i] = 1.0 * j;
+}
+for(int i = 0; i < y.extent(0); ++i) {
+  y[i] = -1.0 * i;
+}
+
+linalg::matrix_vector_product(A, x, y); // y = A * x
+
+// y = 0.5 * y + 2 * A * x
+linalg::matrix_vector_product(std::execution::par,
+  linalg::scaled(2.0, A), x,
+  linalg::scaled(0.5, y), y);
+```
+
+This example illustrates the ability to perform mixed-precision computations,
+and the ability to compute on subviews of a matrix or vector
+by using `submdspan` (P2630).  (`submdspan` was separated from the rest of P0009
+as a way to avoid delaying the hopeful adoption of P0009 for C++23.
+The reference implementation of `mdspan` includes `submdspan`.)
+
+```c++
+constexpr size_t M = 40;
+
+std::vector<float> A_vec(M*8*4);
+std::vector<double> x_vec(M*4);
+std::vector<double> y_vec(M*8);
+
+mdspan<float, extents<size_t, dynamic_extent, 8, 4>> A(A_vec.data(), M);
+mdspan<double, extents<size_t, 4, dynamic_extent>> x(x_vec.data(), M);
+mdspan<double, extents<size_t, dynamic_extent, 8>> y(y_vec.data(), M);
+
+for(size_t m = 0; m < A.extent(0); ++m) {
+  for(size_t i = 0; i < A.extent(1); ++i) {
+    for(size_t j = 0; j < A.extent(2); ++j) {
+      A[m,i,j] = 1000.0 * m + 100.0 * i + j;
+    }
+  }
+}
+for(size_t i = 0; i < x.extent(0); ++i) {
+  for(size_t m = 0; m < x.extent(1); ++m) {
+    x[i,m] = 33. * i + 0.33 * m;
+  }
+}
+for(size_t m = 0; m < y.extent(0); ++m) {
+  for(size_t i = 0; i < y.extent(1); ++i) {
+    y[m,i] = 33. * m + 0.33 * i;
+  }
+}
+
+for(size_t m = 0; m < M; ++m) {
+  auto A_m = submdspan(A, m, full_extent, full_extent);
+  auto x_m = submdspan(x, full_extent, m);
+  auto y_m = submdspan(y, m, full_extent);
+  // y_m = A * x_m
+  linalg::matrix_vector_product(A_m, x_m, y_m);
+}
+```
+
+# Overview of contents
+
+Section <a href="#interoperable-with-other-linear-algebra-proposals"><span class="secno">5</span></a>
+explains how this proposal is interoperable with other linear algebra proposals currently under WG21 review.
+In particular, we believe this proposal is complementary to P1385R6,
+and the authors of P1385R6 have expressed the same view.
+
+Section <a href="#why-include-dense-linear-algebra-in-the-c-standard-library"><span class="secno">6</span></a>
+motivates considering *any* dense linear algebra proposal for the C++ Standard Library.
+
+Section <a href="#why-base-a-c-linear-algebra-library-on-the-blas"><span class="secno">7</span></a>
+shows why we chose the BLAS as a starting point for our proposed library.
+The BLAS is an existing standard with decades of use,
+a rich set of functions,
+and many optimized implementations.
+
+Section <a href="#criteria-for-including-algorithms"><span class="secno">8</span></a>
+lists what we consider general criteria for including algorithms in the C++ Standard Library.
+We rely on these criteria to justify the algorithms in this proposal.
+
+Section <a href="#notation-and-conventions"><span class="secno">9</span></a>
+describes BLAS notation and conventions in C++ terms.
+Understanding this will give readers context for algorithms,
+and show how our proposed algorithms expand on BLAS functionality.
+
+Section <a href="#what-we-exclude-from-the-design"><span class="secno">10</span></a>
+lists functionality that we intentionally exclude from our proposal.
+We imitate the BLAS in aiming to be a set of "performance primitives"
+on which external libraries or applications
+may build a more complete linear algebra solution.
+
+Section <a href="#design-justification"><span class="secno">11</span></a>
+elaborates on our design justification.
+This section explains
+
+* why we use `mdspan` to represent matrix and vector parameters;
+
+* how we translate the BLAS' Fortran-centric idioms into C++;
+
+* how the BLAS' different "matrix types" map to different algorithms,
+    rather than different `mdspan` layouts;
+
+* how we express quality-of-implementation recommendations
+    about avoiding undue overflow and underflow; and
+
+* how we impose requirements on algorithms' behavior
+    and on the various value types that algorithms encounter.
+
+Section <a href="#future-work"><span class="secno">12</span></a>
+lists future work, that is, ways future proposals could build on this one.
+
+Section <a href="#data-structures-and-utilities-borrowed-from-other-proposals"><span class="secno">13</span></a>
+gives the data structures and utilities from other proposals on which we depend.
+In particular, we rely heavily on `mdspan` (P0009),
+and add custom layouts and accessors.
+
+Section <a href="#acknowledgments"><span class="secno">14</span></a> credits funding agencies and contributors.
+
+Section <a href="#references"><span class="secno">15</span></a> is our bibliography.
+
+Section <a href="#wording"><span class="secno">16</span></a>
+is where readers will find the normative wording we propose.
+
+Finally, Section <a href="#examples"><span class="secno">17</span></a>
+gives some more elaborate examples of linear algebra algorithms that use our proposal.
+The examples show how `mdspan`'s features let users easily describe "submatrices" with `submdspan`,
+proposed in P2630 as a follow-on to mdspan.
+(The reference implementation of `mdspan` includes `submdspan`.)
+This integrates naturally with "block" factorizations of matrices.
+The resulting notation is concise, yet still computes in place,
+without unnecessary copies of any part of the matrix.
+
+Here is a table that maps between Reference BLAS function name,
+and algorithm or function name in our proposal.
+The mapping is not always one to one.
+"N/A" in the "BLAS name(s)" field means that the function is not in the BLAS.
+
+<table>
+  <tr>
+    <th>BLAS name(s)</th>
+    <th>Our name(s)</th>
+  </tr>
+  <tr>
+    <td>xLARTG</td>
+    <td>`givens_rotation_setup`</td>
+  </tr>
+  <tr>
+    <td>xROT</td>
+    <td>`givens_rotation_apply`</td>
+  </tr>
+  <tr>
+    <td>xSWAP</td>
+    <td>`swap_elements`</td>
+  </tr>
+  <tr>
+    <td>xSCAL</td>
+    <td>`scale`, `scaled`</td>
+  </tr>
+  <tr>
+    <td>xCOPY</td>
+    <td>`copy`</td>
+  </tr>
+  <tr>
+    <td>xAXPY</td>
+    <td>`add`, `scaled`</td>
+  </tr>
+  <tr>
+    <td>xDOT, xDOTU</td>
+    <td>`dot`</td>
+  </tr>
+  <tr>
+    <td>xDOTC</td>
+    <td>`dotc`</td>
+  </tr>
+  <tr>
+    <td>N/A</td>
+    <td>`vector_sum_of_squares`</td>
+  </tr>
+  <tr>
+    <td>xNRM2</td>
+    <td>`vector_norm2`</td>
+  </tr>
+  <tr>
+    <td>xASUM</td>
+    <td>`vector_abs_sum`</td>
+  </tr>
+  <tr>
+    <td>xIAMAX</td>
+    <td>`idx_abs_max`</td>
+  </tr>
+  <tr>
+    <td>N/A</td>
+    <td>`matrix_frob_norm`</td>
+  </tr>
+  <tr>
+    <td>N/A</td>
+    <td>`matrix_one_norm`</td>
+  </tr>
+  <tr>
+    <td>N/A</td>
+    <td>`matrix_inf_norm`</td>
+  </tr>
+  <tr>
+    <td>xGEMV</td>
+    <td>`matrix_vector_product`</td>
+  </tr>
+  <tr>
+    <td>xSYMV</td>
+    <td>`symmetric_matrix_vector_product`</td>
+  </tr>
+  <tr>
+    <td>xHEMV</td>
+    <td>`hermitian_matrix_vector_product`</td>
+  </tr>
+  <tr>
+    <td>xTRMV</td>
+    <td>`triangular_matrix_vector_product`</td>
+  </tr>
+  <tr>
+    <td>xTRSV</td>
+    <td>`triangular_matrix_vector_solve`</td>
+  </tr>
+  <tr>
+    <td>xGER, xGERU</td>
+    <td>`matrix_rank_1_update`</td>
+  </tr>
+  <tr>
+    <td>xGERC</td>
+    <td>`matrix_rank_1_update_c`</td>
+  </tr>
+  <tr>
+    <td>xSYR</td>
+    <td>`symmetric_matrix_rank_1_update`</td>
+  </tr>
+  <tr>
+    <td>xHER</td>
+    <td>`hermitian_matrix_rank_1_update`</td>
+  </tr>
+  <tr>
+    <td>xSYR2</td>
+    <td>`symmetric_matrix_rank_2_update`</td>
+  </tr>
+  <tr>
+    <td>xHER2</td>
+    <td>`hermitian_matrix_rank_2_update`</td>
+  </tr>
+  <tr>
+    <td>xGEMM</td>
+    <td>`matrix_product`</td>
+  </tr>
+  <tr>
+    <td>xSYMM</td>
+    <td>`symmetric_matrix_{left,right}_product`</td>
+  </tr>
+  <tr>
+    <td>xHEMM</td>
+    <td>`hermitian_matrix_{left,right}_product`</td>
+  </tr>
+  <tr>
+    <td>xTRMM</td>
+    <td>`triangular_matrix_{left,right}_product`</td>
+  </tr>
+  <tr>
+    <td>xSYRK</td>
+    <td>`symmetric_matrix_rank_k_update`</td>
+  </tr>
+  <tr>
+    <td>xHERK</td>
+    <td>`hermitian_matrix_rank_k_update`</td>
+  </tr>
+  <tr>
+    <td>xSYR2K</td>
+    <td>`symmetric_matrix_rank_2k_update`</td>
+  </tr>
+  <tr>
+    <td>xHER2K</td>
+    <td>`hermitian_matrix_rank_2k_update`</td>
+  </tr>
+  <tr>
+    <td>xTRSM</td>
+    <td>`triangular_matrix_matrix_{left,right}_solve`</td>
+  </tr>
+</table>
+
+# Interoperable with other linear algebra proposals
+
+We believe this proposal is complementary to P1385R6,
+a proposal for a C++ Standard linear algebra library
+that introduces matrix and vector classes with overloaded arithmetic operators.
+The P1385 authors and we have expressed together in a joint paper,
+<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1891r0.pdf">P1891</a>,
+that P1673 and P1385 "are orthogonal.
+They are not competing papers; ...
+there is no overlap of functionality."
+
+Many of us have had experience using and implementing
+matrix and vector operator arithmetic libraries like what P1385 proposes.
+We designed P1673 in part as a natural foundation or implementation layer for such libraries.
+Our view is that a free function interface like P1673's
+clearly separates algorithms from data structures,
+and more naturally allows for a richer set of operations such as what the BLAS provides.
+Our paper <a href="https://wg21.link/p1674">P1674</a>
+explains why we think our proposal is a minimal C++ "respelling" of the BLAS.
+
+A natural extension of the present proposal would include
+accepting P1385's matrix and vector objects as input
+for the algorithms proposed here.
+A straightforward way to do that would be for P1385's matrix and vector objects
+to make views of their data available as `mdspan`.
+
+# Why include dense linear algebra in the C++ Standard Library?
+
+1. "Direction for ISO C++" (P0939R4)
+    explicitly calls out "Linear Algebra" as a potential priority for C++23.
+
+2. C++ applications in "important application areas" (see P0939R4)
+    have depended on linear algebra for a long time.
+
+3. Linear algebra is like `sort`: obvious algorithms are slow, and the
+    fastest implementations call for hardware-specific tuning.
+
+4. Dense linear algebra is core functionality for most of linear
+    algebra, and can also serve as a building block for tensor
+    operations.
+
+5. The C++ Standard Library includes plenty of "mathematical
+    functions."  Linear algebra operations like matrix-matrix multiply
+    are at least as broadly useful.
+
+6. The set of linear algebra operations in this proposal are derived
+    from a well-established, standard set of algorithms that has
+    changed very little in decades.  It is one of the strongest
+    possible examples of standardizing existing practice that anyone
+    could bring to C++.
+
+7. This proposal follows in the footsteps of many recent successful
+    incorporations of existing standards into C++, including the UTC
+    and TAI standard definitions from the International
+    Telecommunications Union, the time zone database standard from the
+    International Assigned Numbers Authority, and the ongoing effort to
+    integrate the ISO unicode standard.
+
+Linear algebra has had wide use in C++ applications for nearly three
+decades (see P1417R0 for a historical survey).
+For much of that time, many third-party C++ libraries for linear
+algebra have been available.  Many different subject areas depend on
+linear algebra, including machine learning, data mining, web search,
+statistics, computer graphics, medical imaging, geolocation and
+mapping, engineering, and physics-based simulations.
+
+"Directions for ISO C++" (P0939R4)
+not only lists "Linear Algebra" explicitly as a potential C++23 priority,
+it also offers the following
+in support of adding linear algebra to the C++ Standard Library.
+
+* P0939R4 calls out "Support for demanding applications"
+    in "important application areas,
+    such as medical, finance, automotive, and games
+    (e.g., key libraries...)" as an "area of general concern" that "we
+    should not ignore."  All of these areas depend on linear algebra.
+
+* "Is my proposal essential for some important application domain?"
+    Many large and small private companies, science and engineering
+    laboratories, and academics in many different fields all depend on
+    linear algebra.
+
+* "We need better support for modern hardware": Modern hardware spends
+    many of its cycles in linear algebra.  For decades, hardware
+    vendors, some represented at WG21 meetings, have provided and
+    continue to provide features specifically to accelerate linear
+    algebra operations.  Some of them even implement specific linear
+    algebra operations directly in hardware.  Examples include NVIDIA's
+    <a href="https://www.nvidia.com/en-us/data-center/tensorcore/">Tensor Cores</a>
+    and Cerebras'
+    <a href="https://www.cerebras.net/product/#chip">Wafer Scale Engine</a>.
+    Several large computer system vendors offer optimized linear algebra libraries
+    based on or closely resembling the BLAS.  These include AMD's BLIS,
+    ARM's Performance Libraries, Cray's LibSci, Intel's Math Kernel
+    Library (MKL), IBM's Engineering and Scientific Subroutine Library
+    (ESSL), and NVIDIA's cuBLAS.
+
+Obvious algorithms for some linear algebra operations like dense
+matrix-matrix multiply are asymptotically slower than less-obvious
+algorithms.  (Please refer to a survey one of us coauthored,
+<a href="https://doi.org/10.1017/S0962492914000038">
+"Communication lower bounds and optimal algorithms
+for numerical linear algebra."</a>
+Furthermore, writing the fastest dense matrix-matrix multiply depends
+on details of a specific computer architecture.  This makes such
+operations comparable to `sort` in the C++ Standard Library: worth
+standardizing, so that Standard Library implementers can get them
+right and hardware vendors can optimize them.  In fact, almost all C++
+linear algebra libraries end up calling non-C++ implementations of
+these algorithms, especially the implementations in optimized BLAS
+libraries (see below).  In this respect, linear algebra is also
+analogous to standard library features like `random_device`: often
+implemented directly in assembly or even with special hardware, and
+thus an essential component of allowing no room for another language
+"below" C++ (see P0939R4)
+and Stroustrup's "The Design and Evolution of C++").
+
+Dense linear algebra is the core component of most algorithms and
+applications that use linear algebra, and the component that is most
+widely shared over different application areas.  For example, tensor
+computations end up spending most of their time in optimized dense
+linear algebra functions.  Sparse matrix computations get best
+performance when they spend as much time as possible in dense linear
+algebra.
+
+The C++ Standard Library includes many
+<a href="https://eel.is/c++draft/sf.cmath">"mathematical special functions"</a>
+(**[sf.cmath]**), like incomplete elliptic integrals,
+Bessel functions, and other polynomials and functions named after
+various mathematicians.  Any of them comes with its own theory and set
+of applications for which robust and accurate implementations are
+indispensible.  We think that linear algebra operations are at least
+as broadly useful, and in many cases significantly more so.
+
+# Why base a C++ linear algebra library on the BLAS?
+
+1. The BLAS is a standard that codifies decades of existing practice.
+
+2. The BLAS separates "performance primitives" for hardware
+    experts to tune, from mathematical operations that rely on those
+    primitives for good performance.
+
+3. Benchmarks reward hardware and system vendors for providing
+    optimized BLAS implementations.
+
+4. Writing a fast BLAS implementation for common element types is
+    nontrivial, but well understood.
+
+5. Optimized third-party BLAS implementations with liberal software
+    licenses exist.
+
+6. Building a C++ interface on top of the BLAS is a straightforward
+    exercise, but has pitfalls for unaware developers.
+
+Linear algebra has had a cross-language standard, the Basic Linear
+Algebra Subroutines (BLAS), since 2002.  The Standard came out of a
+<a href="http://www.netlib.org/blas/blast-forum/">standardization process</a>
+that started in 1995 and held meetings three times a year until 1999.
+Participants in the process came from industry, academia, and
+government research laboratories.  The dense linear algebra subset of
+the BLAS codifies forty years of evolving practice, and has existed in
+recognizable form since 1990 (see P1417R0).
+
+The BLAS interface was specifically designed as the distillation of
+the "computer science" or performance-oriented parts of linear algebra
+algorithms.  It cleanly separates operations most critical for
+performance, from operations whose implementation takes expertise in
+mathematics and rounding-error analysis.  This gives vendors
+opportunities to add value, without asking for expertise outside the
+typical required skill set of a Standard Library implementer.
+
+Well-established benchmarks such as the
+<a href="https://www.top500.org/project/linpack/">LINPACK benchmark</a>,
+reward computer hardware vendors for optimizing their BLAS implementations.
+Thus, many vendors provide an optimized BLAS library for their computer
+architectures.  Writing fast BLAS-like operations is not trivial, and
+depends on computer architecture.  However, it is a well-understood
+problem whose solutions could be parameterized for a variety of
+computer architectures.  See, for example,
+<a href="https://doi.org/10.1145/1356052.1356053">Goto and van de Geijn 2008</a>.
+There are optimized
+third-party BLAS implementations for common architectures, like
+<a href="http://math-atlas.sourceforge.net/">ATLAS</a> and
+<a href="https://www.tacc.utexas.edu/research-development/tacc-software/gotoblas2">GotoBLAS</a>.
+A (slow but correct)
+<a href="http://www.netlib.org/blas/#_reference_blas_version_3_8_0">reference implementation of the BLAS</a>
+exists and it has a liberal software license for easy reuse.
+
+We have experience in the exercise of wrapping a C or Fortran BLAS
+implementation for use in portable C++ libraries.  We describe this
+exercise in detail in our paper
+"Evolving a Standard C++ Linear Algebra Library from the BLAS"
+<a href="https://wg21.link/p1674">(P1674)</a>.
+It is straightforward for vendors, but has pitfalls for developers.  For
+example, Fortran's application binary interface (ABI) differs across
+platforms in ways that can cause run-time errors (even incorrect
+results, not just crashing).  Historical examples of vendors' C BLAS
+implementations have also had ABI issues that required work-arounds.
+This dependence on ABI details makes availability in a standard C++
+library valuable.
+
+# Criteria for including algorithms
+
+## Criteria for all the algorithms
+
+We include algorithms in our proposal based on the following criteria,
+ordered by decreasing importance.
+Many of our algorithms satisfy multiple criteria.
+
+1. Getting the desired asymptotic run time is nontrivial
+
+2. Opportunity for vendors to provide hardware-specific optimizations
+
+3. Opportunity for vendors to provide quality-of-implementation improvements,
+    especially relating to accuracy or reproducibility
+    with respect to floating-point rounding error
+
+4. User convenience (familiar name, or tedious to implement)
+
+Regarding (1), "nontrivial" means "at least for novices to the field."
+Dense matrix-matrix multiply is a good example.
+Getting close to the asymptotic lower bound on the number of memory reads and writes
+matters a lot for performance, and calls for a nonintuitive loop reordering.
+An analogy to the current C++ Standard Library is `sort`,
+where intuitive algorithms that many humans use are not asymptotically optimal.
+
+Regarding (2), a good example is copying multidimensional arrays.
+The <a href="https://github.com/kokkos/kokkos">Kokkos library</a>
+spends about 2500 lines of code on multidimensional array copy,
+yet still relies on system libraries for low-level optimizations.
+An analogy to the current C++ Standard Library is `copy` or even `memcpy`.
+
+Regarding (3), accurate floating-point summation is nontrivial.
+Well-meaning compiler optimizations might defeat even simple technqiues,
+like compensated summation.
+The most obvious way to compute a vector's Euclidean norm
+(square root of sum of squares) can cause overflow or underflow,
+even when the exact answer is much smaller than the overflow threshold,
+or larger than the underflow threshold.
+Some users care deeply about sums, even parallel sums,
+that always get the same answer, despite rounding error.
+This can help debugging, for example.
+It is possible to make floating-point sums completely independent
+of parallel evaluation order.
+See e.g., the
+<a href="https://bebop.cs.berkeley.edu/reproblas/">ReproBLAS</a>
+effort.
+Naming these algorithms and providing `ExecutionPolicy` customization hooks
+gives vendors a chance to provide these improvements.
+An analogy to the current C++ Standard Library is `hypot`,
+whose language in the C++ Standard alludes to the tighter POSIX requirements.
+
+Regarding (4), the C++ Standard Library is not entirely minimalist.
+One example is `std::string::contains`.
+Existing Standard Library algorithms already offered this functionality,
+but a member `contains` function is easy for novices to find and use,
+and avoids the tedium of comparing the result of `find` to `npos`.
+
+The BLAS exists mainly for the first two reasons.
+It includes functions that were nontrivial for compilers to optimize in its time,
+like scaled elementwise vector sums,
+as well as functions that generally require human effort to optimize,
+like matrix-matrix multiply.
+
+## Criteria for including BLAS 1 algorithms; coexistence with ranges
+
+The BLAS developed in three "levels": 1, 2, and 3.
+BLAS 1 includes "vector-vector" operations like dot products, norms, and vector addition.
+BLAS 2 includes "matrix-vector" operations like matrix-vector products and outer products.
+BLAS 3 includes "matrix-matrix" operations like matrix-matrix products
+and triangular solve with multiple "right-hand side" vectors.
+The BLAS level coincides with the number of nested loops
+in a naïve sequential implementation of the operation.
+Increasing level also comes with increasing potential for data reuse.
+For history of the BLAS "levels" and a bibliography,
+see <a href="https://wg21.link/p1417">P1417</a>.
+
+We mention this here because some reviewers have asked
+how the algorithms in our proposal would coexist
+with the existing ranges algorithms in the C++ Standard Library.
+This question actually encloses two questions.
+
+1. Will our proposed algorithms syntactically collide
+    with existing ranges algorithms?
+
+2. How much overlap do our proposed algorithms
+    have with the existing ranges algorithms?
+    (That is, do we really need these new algorithms?)
+
+### Low risk of synactic collision with ranges
+
+We think there is low risk of our proposal
+colliding syntactically with existing ranges algorithms,
+for the following reasons.
+
+* We propose our algorithms in a new namespace `std::linalg`.
+
+* None of the algorithms we propose share names with any existing ranges algorithms.
+
+* We take care not to use `_view` as a suffix,
+    in order to avoid confusion or name collisions
+    with "views" in the sense of ranges.
+
+* We specifically do not use the names `transpose` or `transpose_view`,
+    since LEWG has advised us that ranges algorithms may want to claim these names.
+    (One could imagine "transposing" a range of ranges.)
+
+* We constrain our algorithms only to take vector and matrix parameters as `mdspan`.
+    `mdspan` is not currently a range,
+    and there are currently no proposals in flight that would make it a range.
+    Changing `mdspan` of arbitrary rank to be a range
+    would require a design for multidimensional iterators.
+    P0009's coauthors have not proposed a design,
+    and it has proven challenging to get compilers to optimize
+    any existing design for multidimensional iterators.
+
+### Minimal overlap with ranges is justified by user convenience
+
+The rest of this section answers the second question.
+The BLAS 2 and 3 algorithms require multiple nested loops,
+and high-performing implementations generally need intermediate storage.
+This would make it unnatural and difficult to express them in terms of ranges.
+Only the BLAS 1 algorithms in our proposal
+might have a reasonable translation to ranges algorithms.
+There, we limit ourselves to the BLAS 1 algorithms in what follows.
+
+Any rank-1 `mdspan` `x` can be translated into the following range:
+
+```c++
+auto x_range = views::iota(size_t(0), x.extent(0)) |
+    views::transform([x] (auto k) { return x[k]; });
+```
+
+with specializations possible for `mdspan`
+whose layout mapping's range
+is a contiguous or fixed-stride set of offsets.
+However, just because code _could_ be written in a certain way
+doesn't mean that it _should_ be.
+We have ranges even though the language has `for` loops;
+we don't need to step in the Turing tar-pit on purpose
+(see Perlis 1982).
+Thus, we will analyze the BLAS 1 algorithms in this proposal
+in the context of the previous section's four general criteria.
+
+Our proposal would add 61 new unique names to the C++ Standard Library.
+Of those, 16 are BLAS 1 algorithms, while 24 are BLAS 2 and 3 algorithms.
+The 16 BLAS 1 algorithms fall into three categories:
+
+1. Optimization hooks, like `copy`.  As with `memcpy`,
+    the fastest implementation may depend closely on the computer architecture,
+    and may differ significantly from a straightforward implementation.
+    Some of these algorithms, like `copy`,
+    can operate on multidimensional arrays as well,
+    though it is traditional to list them as BLAS 1 algorithms.
+
+2. Floating-point quality-of-implementation hooks, like `vector_sum_of_squares`.
+    These give vendors opportunities
+    to avoid preventable floating-point underflow and overflow
+    (as with `hypot`),
+    improve accuracy, and reduce or even avoid parallel nondeterminism
+    and order dependence of floating-point sums.
+
+3. Uncomplicated elementwise algorithms like `add`, `idx_abs_max`, and `scale`.
+
+We included the first category mainly because of Criterion (2)
+"Opportunity for vendors to provide hardware-specific optimizations,"
+and the second mainly because of Criterion (3)
+("Opportunity for vendors to provide quality-of-implementation improvements").
+Fast implementations of algorithms in the first category
+are not likely to be simple uses of ranges algorithms.
+
+Algorithms in the second category could be presented as ranges algorithms,
+as `mdspan` algorithms, or as both.
+The "iterating over elements" part of those algorithms
+is not the most challenging part of their implementation,
+nor is it what makes an implementation "high quality."
+
+Algorithms in the third category could be replaced
+with a few lines of C++ that use ranges algorithms.
+For example, here is a parallel implementation of `idx_abs_max`,
+omitting constraints on template parameters for simplicity.
+(Here is a <a href="https://godbolt.org/z/7eW9ExsKM">Compiler Explorer link</a>
+to a working example.)
+
+```c++
+template<class Element, class Extents,
+  class Layout, class Accessor>
+typename Extents::size_type idx_abs_max(
+  std::mdspan<Element, Extents, Layout, Accessor> x)
+{
+  auto theRange = std::views::iota(size_t(0), x.extent(0)) |
+    std::views::transform([=] (auto k) { return std::abs(x[k]); });
+  auto iterOfMax =
+    std::max_element(std::execution::par_unseq, theRange.begin(), theRange.end());
+  auto indexOfMax = std::ranges::distance(theRange.begin(), iterOfMax);
+  // In GCC 12.1, the return type is __int128.
+  return static_cast<typename Extents::size_type>(indexOfMax);
+}
+```
+
+Even though the algorithms in the third category
+could be implemented straightforwardly with ranges,
+we provide them because of Criterion 4 ("User convenience").
+Criterion (4) applies to all the algorithms in this proposal,
+and particularly to the BLAS 1 algorithms.
+Matrix algorithm developers need BLAS 1 and 2 as well as BLAS 3,
+because matrix algorithms tend to decompose into vector algorithms.
+This is true even of so-called "block" matrix algorithms
+that have been optimized to use matrix-matrix operations wherever possible,
+in order to improve memory locality.
+Demmel et al. 1987 (p. 4) explains.
+
+> Block algorithms generally require an unblocked version
+> of the same algorithm to be available to operate on a single block.
+> Therefore, the development of the software will fall naturally into two phases:
+> first, develop unblocked versions of the routines,
+> calling the Level 2 BLAS wherever possible;
+> then develop blocked versions where possible,
+> calling the Level 3 BLAS.
+
+Dongarra et al. 1990 (pp. 12-15) outlines this development process
+for the specific example of Cholesky factorization.
+The Cholesky factorization algorithm (on p. 14)
+spends most of its time (for a sufficiently large input matrix)
+in matrix-matrix multiplies (`DGEMM`),
+rank-k symmetric matrices updates
+(`DSYRK`, a special case of matrix-matrix multiply),
+and triangular solves with multiple "right-hand side" vectors (`DTRSM`).
+However, it still needs an "unblocked" Cholesky factorization
+as the blocked factorization's "base case."
+This is called `DLLT` in Dongarra et al. 1990 (p. 15),
+and it uses `DDOT`, `DSCAL` (both BLAS2), and `DGEMV` (BLAS 2).
+In the case of Cholesky factorization,
+it's possible to express the "unblocked" case without using BLAS 1 or 2 operations,
+by using recursion.
+This is the approach that LAPACK takes with the blocked Cholesky factorization
+<a href="https://www.netlib.org/lapack/explore-html/d1/d7a/group__double_p_ocomputational_ga2f55f604a6003d03b5cd4a0adcfb74d6.html">`DPOTRF`</a>
+and its unblocked base case
+<a href="https://www.netlib.org/lapack/explore-html/d1/d7a/group__double_p_ocomputational_gad0718d061dc53c8b0fec6dc3710fab33.html">`DPOTRF2`</a>.
+However, even a recursive formulation of most matrix factorizations
+needs to use BLAS 1 or 2 operations.
+For example, the unblocked base case
+<a href="https://www.netlib.org/lapack/explore-html/dd/d9a/group__double_g_ecomputational_gabdd3af29e9f6bbaf4b352341a1e8b464.html">`DGETRF2`</a>
+of LAPACK's blocked LU factorization
+<a href="https://www.netlib.org/lapack/explore-html/d3/d6a/dgetrf_8f_source.html">`DGETRF`</a>
+needs to invoke vector-vector operations like `DSCAL`.
+
+In summary, matrix algorithm developers need vector algorithms,
+because matrix algorithms decompose into vector algorithms.
+If our proposal lacked BLAS 1 algorithms,
+even simple ones like `add` and `scale`,
+matrix algorithm developers would end up writing them anyway.
+
+# Notation and conventions
+
+## The BLAS uses Fortran terms
+
+The BLAS' "native" language is Fortran.  It has a C binding as well,
+but the BLAS Standard and documentation use Fortran terms.  Where
+applicable, we will call out relevant Fortran terms and highlight
+possibly confusing differences with corresponding C++ ideas.  Our
+paper <a href="https://wg21.link/p1674">P1674</a>
+("Evolving a Standard C++ Linear Algebra Library from the BLAS")
+goes into more detail on these issues.
+
+## We call "subroutines" functions
+
+Like Fortran, the BLAS distinguishes between functions that return a
+value, and subroutines that do not return a value.  In what follows,
+we will refer to both as "BLAS functions" or "functions."
+
+## Element types and BLAS function name prefix
+
+The BLAS implements functionality for four different matrix, vector,
+or scalar element types:
+
+* `REAL` (`float` in C++ terms)
+
+* `DOUBLE PRECISION` (`double` in C++ terms)
+
+* `COMPLEX` (`complex<float>` in C++ terms)
+
+* `DOUBLE COMPLEX` (`complex<double>` in C++ terms)
+
+The BLAS' Fortran 77 binding uses a function name prefix to
+distinguish functions based on element type:
+
+* `S` for `REAL` ("single")
+
+* `D` for `DOUBLE PRECISION`
+
+* `C` for `COMPLEX`
+
+* `Z` for `DOUBLE COMPLEX`
+
+For example, the four BLAS functions `SAXPY`, `DAXPY`, `CAXPY`, and
+`ZAXPY` all perform the vector update `Y = Y + ALPHA*X` for vectors
+`X` and `Y` and scalar `ALPHA`, but for different vector and scalar
+element types.
+
+The convention is to refer to all of these functions together as
+`xAXPY`.  In general, a lower-case `x` is a placeholder for all data
+type prefixes that the BLAS provides.  For most functions, the `x` is
+a prefix, but for a few functions like `IxAMAX`, the data type
+"prefix" is not the first letter of the function name.  (`IxAMAX` is a
+Fortran function that returns `INTEGER`, and therefore follows the old
+Fortran implicit naming rule that integers start with `I`, `J`, etc.)
+
+Not all BLAS functions exist for all four data types.  These come in
+three categories:
+
+1. The BLAS provides only real-arithmetic (`S` and `D`) versions of
+    the function, since the function only makes mathematical sense in
+    real arithmetic.
+
+2. The complex-arithmetic versions perform a slightly different
+    mathematical operation than the real-arithmetic versions, so
+    they have a different base name.
+
+3. The complex-arithmetic versions offer a choice between
+    nonconjugated or conjugated operations.
+
+As an example of the second category, the BLAS functions `SASUM` and
+`DASUM` compute the sums of absolute values of a vector's elements.
+Their complex counterparts `CSASUM` and `DZASUM` compute the sums of
+absolute values of real and imaginary components of a vector `v`, that
+is, the sum of `abs(real(v[i])) + abs(imag(v[i]))` for all `i` in the
+domain of `v`.  The latter operation is still useful as a vector norm,
+but it requires fewer arithmetic operations.
+
+Examples of the third category include the following:
+
+* nonconjugated dot product `xDOTU` and conjugated dot product
+    `xDOTC`; and
+
+* rank-1 symmetric (`xGERU`) vs. Hermitian (`xGERC`) matrix update.
+
+The conjugate transpose and the (nonconjugated) transpose are the
+same operation in real arithmetic (if one considers real arithmetic
+embedded in complex arithmetic), but differ in complex arithmetic.
+Different applications have different reasons to want either.  The C++
+Standard includes complex numbers, so a Standard linear algebra
+library needs to respect the mathematical structures that go along
+with complex numbers.
+
+# What we exclude from the design
+
+## Most functions not in the Reference BLAS
+
+The BLAS Standard includes functionality that appears neither in the
+[Reference BLAS](http://www.netlib.org/lapack/explore-html/d1/df9/group__blas.html)
+library, nor in the classic BLAS "level" 1, 2, and 3 papers.  (For
+history of the BLAS "levels" and a bibliography, see P1417R0.
+For a paper describing functions not in the Reference BLAS,
+see "An updated set of basic linear algebra subprograms (BLAS),"
+listed in "Other references" below.)
+For example, the BLAS Standard has
+
+* several new dense functions, like a fused vector update and dot
+    product;
+* sparse linear algebra functions, like sparse matrix-vector multiply
+    and an interface for constructing sparse matrices; and
+* extended- and mixed-precision dense functions (though we subsume
+    some of their functionality; see below).
+
+Our proposal only includes core Reference BLAS functionality, for the
+following reasons:
+
+1. Vendors who implement a new component of the C++ Standard Library
+    will want to see and test against an existing reference
+    implementation.
+
+2. Many applications that use sparse linear algebra also use dense,
+    but not vice versa.
+
+3. The Sparse BLAS interface is a stateful interface that is not
+    consistent with the dense BLAS, and would need more extensive
+    redesign to translate into a modern C++ idiom.
+    See discussion in P1417R0.
+
+4. Our proposal subsumes some dense mixed-precision functionality (see
+    below).
+
+We have included vector sum-of-squares and matrix norms as exceptions,
+for the same reason that we include vector 2-norm:
+to expose hooks for quality-of-implementation improvements
+that avoid underflow or overflow when computing with floating-point values.
+
+## LAPACK or related functionality
+
+The <a href="http://www.netlib.org/lapack/">LAPACK</a> Fortran library implements
+solvers for the following classes of mathematical problems:
+
+* linear systems,
+* linear least-squares problems, and
+* eigenvalue and singular value problems.
+
+It also provides matrix factorizations and related linear algebra
+operations.  LAPACK deliberately relies on the BLAS for good
+performance; in fact, LAPACK and the BLAS were designed together.  See
+history presented in P1417R0.
+
+Several C++ libraries provide slices of LAPACK functionality.  Here is
+a brief, noninclusive list, in alphabetical order, of some libraries
+actively being maintained:
+
+* [Armadillo](http://arma.sourceforge.net/),
+* [Boost.uBLAS](https://github.com/boostorg/ublas),
+* [Eigen](http://eigen.tuxfamily.org/index.php?title=Main_Page),
+* [Matrix Template Library](http://www.simunova.com/de/mtl4/), and
+* [Trilinos](https://github.com/trilinos/Trilinos/).
+
+<a href="https://wg21.link/p1417r0">P1417R0</a> gives some history of C++ linear
+algebra libraries.  The authors of this proposal have
+[designed](https://www.icl.utk.edu/files/publications/2017/icl-utk-1031-2017.pdf),
+[written](https://github.com/kokkos/kokkos-kernels), and
+[maintained](https://github.com/trilinos/Trilinos/tree/master/packages/teuchos/numerics/src)
+LAPACK wrappers in C++.  Some authors have LAPACK founders as PhD
+advisors.  Nevertheless, we have excluded LAPACK-like functionality
+from this proposal, for the following reasons:
+
+1. LAPACK is a Fortran library, unlike the BLAS, which is a
+    multilanguage standard.
+
+2. We intend to support more general element types, beyond the four
+    that LAPACK supports.  It's much more straightforward to make a C++
+    BLAS work for general element types, than to make LAPACK algorithms
+    work generically.
+
+First, unlike the BLAS, LAPACK is a Fortran library, not a standard.
+LAPACK was developed concurrently with the "level 3" BLAS functions,
+and the two projects share contributors.  Nevertheless, only the BLAS
+and not LAPACK got standardized.  Some vendors supply LAPACK
+implementations with some optimized functions, but most
+implementations likely depend heavily on "reference" LAPACK.  There
+have been a few efforts by LAPACK contributors to develop C++ LAPACK
+bindings, from [Lapack++](https://math.nist.gov/lapack++/) in
+pre-templates C++ circa 1993, to the recent ["C++ API for BLAS and
+LAPACK"](https://www.icl.utk.edu/files/publications/2017/icl-utk-1031-2017.pdf).
+(The latter shares coauthors with this proposal.)  However, these are
+still just C++ bindings to a Fortran library.  This means that if
+vendors had to supply C++ functionality equivalent to LAPACK, they
+would either need to start with a Fortran compiler, or would need to
+invest a lot of effort in a C++ reimplementation.  Mechanical
+translation from Fortran to C++ introduces risk, because many LAPACK
+functions depend critically on details of floating-point arithmetic
+behavior.
+
+Second, we intend to permit use of matrix or vector element types
+other than just the four types that the BLAS and LAPACK support.  This
+includes "short" floating-point types, fixed-point types, integers,
+and user-defined arithmetic types.  Doing this is easier for BLAS-like
+operations than for the much more complicated numerical algorithms in
+LAPACK.  LAPACK strives for a "generic" design (see Jack Dongarra
+interview summary in P1417R0), but only supports
+two real floating-point types and two complex floating-point types.
+Directly translating LAPACK source code into a "generic" version could
+lead to pitfalls.  Many LAPACK algorithms only make sense for number
+systems that aim to approximate real numbers (or their complex
+extentions).  Some LAPACK functions output error bounds that rely on
+properties of floating-point arithmetic.
+
+For these reasons, we have left LAPACK-like functionality for future
+work.  It would be natural for a future LAPACK-like C++ library to
+build on our proposal.
+
+## Extended-precision BLAS
+
+Our interface subsumes some functionality of the Mixed-Precision BLAS
+specification (Chapter 4 of the BLAS Standard).  For example, users
+may multiply two 16-bit floating-point matrices (assuming that a
+16-bit floating-point type exists) and accumulate into a 32-bit
+floating-point matrix, just by providing a 32-bit floating-point
+matrix as output.  Users may specify the precision of a dot product
+result.  If it is greater than the input vectors' element type
+precisions (e.g., `double` vs. `float`), then this effectively
+performs accumulation in higher precision.  Our proposal imposes
+semantic requirements on some functions, like `vector_norm2`, to
+behave in this way.
+
+However, we do not include the "Extended-Precision BLAS" in this
+proposal.  The BLAS Standard lets callers decide at run time whether
+to use extended precision floating-point arithmetic for internal
+evaluations.  We could support this feature at a later time.
+Implementations of our interface also have the freedom to use more
+accurate evaluation methods than typical BLAS implementations.  For
+example, it is possible to make floating-point sums completely
+[independent of parallel evaluation
+order](https://bebop.cs.berkeley.edu/reproblas/).
+
+## Arithmetic operators and associated expression templates
+
+Our proposal omits arithmetic operators on matrices and vectors.
+We do so for the following reasons:
+
+1. We propose a low-level, minimal interface.
+
+2. `operator*` could have multiple meanings for matrices and vectors.
+    Should it mean elementwise product (like `valarray`) or matrix
+    product?  Should libraries reinterpret "vector times vector" as a
+    dot product (row vector times column vector)?  We prefer to let a
+    higher-level library decide this, and make everything explicit at
+    our lower level.
+
+3. Arithmetic operators require defining the element type of the
+    vector or matrix returned by an expression.  Functions let users
+    specify this explicitly, and even let users use different output
+    types for the same input types in different expressions.
+
+4. Arithmetic operators may require allocation of temporary matrix or
+    vector storage.  This prevents use of nonowning data structures.
+
+5. Arithmetic operators strongly suggest expression templates.  These
+    introduce problems such as dangling references and aliasing.
+
+Our goal is to propose a low-level interface.  Other libraries, such
+as that proposed by <a href="https://wg21.link/p1385r6">P1385R6</a>, could use our
+interface to implement overloaded arithmetic for matrices and vectors.
+A constrained, function-based, BLAS-like
+interface builds incrementally on the many years of BLAS experience.
+
+Arithmetic operators on matrices and vectors would require the
+library, not necessarily the user, to specify the element type of an
+expression's result.  This gets tricky if the terms have mixed element
+types.  For example, what should the element type of the result of the
+vector sum `x + y` be, if `x` has element type `complex<float>` and
+`y` has element type `double`?  It's tempting to use `common_type_t`,
+but `common_type_t<complex<float>, double>` is `complex<float>`.  This
+loses precision.  Some users may want `complex<double>`; others may
+want `complex<long double>` or something else, and others may want to
+choose different types in the same program.
+
+P1385R6 lets users customize the return type
+of such arithmetic expressions.  However, different algorithms may
+call for the same expression with the same inputs to have different
+output types.  For example, iterative refinement of linear systems
+`Ax=b` can work either with an extended-precision intermediate
+residual vector `r = b - A*x`, or with a residual vector that has the
+same precision as the input linear system.  Each choice produces a
+different algorithm with different convergence characteristics,
+per-iteration run time, and memory requirements.  Thus, our library
+lets users specify the result element type of linear algebra
+operations explicitly, by calling a named function that takes an
+output argument explicitly, rather than an arithmetic operator.
+
+Arithmetic operators on matrices or vectors may also need to allocate
+temporary storage.  Users may not want that.  When LAPACK's developers
+switched from Fortran 77 to a subset of Fortran 90, their users
+rejected the option of letting LAPACK functions allocate temporary
+storage on their own.  Users wanted to control memory allocation.
+Also, allocating storage precludes use of nonowning input data
+structures like `mdspan`, that do not know how to allocate.
+
+Arithmetic expressions on matrices or vectors strongly suggest
+expression templates, as a way to avoid allocation of temporaries and
+to fuse computational kernels.  They do not *require* expression
+templates.  For example, `valarray` offers overloaded operators for
+vector arithmetic, but the Standard lets implementers decide whether
+to use expression templates.  However, all of the current C++ linear
+algebra libraries that we mentioned above have some form of expression
+templates for overloaded arithmetic operators, so users will expect
+this and rely on it for good performance.  This was, indeed, one of
+the major complaints about initial implementations of `valarray`: its
+lack of mandate for expression templates meant that initial
+implementations were slow, and thus users did not want to rely on it.
+(See Josuttis 1999, p. 547, and Vandevoorde and Josuttis 2003, p. 342,
+for a summary of the history.  Fortran has an analogous issue, in
+which (under certain conditions) it is implementation defined whether
+the run-time environment needs to copy noncontiguous slices of an
+array into contiguous temporary storage.)
+
+Expression templates work well, but have issues.  Our papers
+<a href="https://wg21.link/p1417r0">P1417R0</a> and
+"Evolving a Standard C++ Linear Algebra Library from the BLAS"
+<a href="https://wg21.link/p1674">(P1674)</a>
+give more detail on these concerns.
+A particularly troublesome one is that C++ `auto` type deduction
+makes it easy for users to capture expressions
+before the expression templates system
+has the chance to evaluate them and write the result into the output.
+For matrices and vectors with container semantics,
+this makes it easy to create dangling references.
+Users might not realize that they need to assign expressions to named
+types before actual work and storage happen.  [Eigen's
+documentation](https://eigen.tuxfamily.org/dox/TopicPitfalls.html)
+describes this common problem.
+
+Our `scaled`, `conjugated`, `transposed`, and `conjugate_transposed` functions
+make use of one aspect of expression templates, namely modifying the
+`mdspan` array access operator.  However, we intend these
+functions for use only as in-place modifications of arguments of a
+function call.  Also, when modifying `mdspan`, these functions
+merely view the same data that their input `mdspan` views.  They
+introduce no more potential for dangling references than
+`mdspan` itself.  The use of views like `mdspan` is
+self-documenting; it tells users that they need to take responsibility
+for scope of the viewed data.
+
+## Banded matrix layouts
+
+This proposal omits banded matrix types.  It would be easy to add the
+required layouts and specializations of algorithms later.  The packed
+and unpacked symmetric and triangular layouts in this proposal cover
+the major concerns that would arise in the banded case, like
+nonstrided and nonunique layouts, and matrix types that forbid access
+to some multi-indices in the Cartesian product of extents.
+
+## Tensors
+
+We exclude tensors from this proposal, for the following reasons.
+First, tensor libraries naturally build on optimized dense linear
+algebra libraries like the BLAS, so a linear algebra library is a good
+first step.  Second, `mdspan` has natural use as a
+low-level representation of dense tensors, so we are already partway
+there.  Third, even simple tensor operations that naturally generalize
+the BLAS have infintely many more cases than linear algebra.  It's not
+clear to us which to optimize.  Fourth, even though linear algebra is
+a special case of tensor algebra, users of linear algebra have
+different interface expectations than users of tensor algebra.  Thus,
+it makes sense to have two separate interfaces.
+
+## Explicit support for asynchronous return of scalar values
+
+After we presented revision 2 of this paper,
+LEWG asked us to consider support for discrete graphics processing units (GPUs).
+GPUs have two features of interest here.
+First, they might have memory that is not accessible from ordinary C++ code,
+but could be accessed in a standard algorithm
+(or one of our proposed algorithms)
+with the right implementation-specific `ExecutionPolicy`.
+(For instance, a policy could say "run this algorithm on the GPU.")
+Second, they might execute those algorithms asynchronously.
+That is, they might write to output arguments at some later time
+after the algorithm invocation returns.
+This would imply different interfaces in some cases.
+For instance, a hypothetical asynchronous vector 2-norm
+might write its scalar result via a pointer to GPU memory,
+instead of returning the result "on the CPU."
+
+Nothing in principle prevents `mdspan` from viewing memory
+that is inaccessible from ordinary C++ code.
+This is a major feature of the `Kokkos::View` class
+from the [Kokkos library](https://github.com/kokkos/kokkos),
+and `Kokkos::View` directly inspired `mdspan`.
+The C++ Standard does not currently define how such memory behaves,
+but implementations could define its behavior and make it work with `mdspan`.
+This would, in turn, let implementations define our algorithms
+to operate on such memory efficiently,
+if given the right implementation-specific `ExecutionPolicy`.
+
+Our proposal excludes algorithms that might write to their output arguments
+at some time after after the algorithm returns.
+First, LEWG insisted that our proposed algorithms that compute a scalar result,
+like `vector_norm2`,
+return that result in the manner of `reduce`,
+rather than writing the result to an output reference or pointer.
+(Previous revisions of our proposal used the latter interface pattern.)
+Second, it's not clear whether writing a scalar result to a pointer
+is the right interface for asynchronous algorithms.
+Follow-on proposals to [Executors (P0443R14)](https://wg21.link/p0443R14)
+include asynchronous algorithms,
+but none of these suggest returning results asynchronously by pointer.
+Our proposal deliberately imitates the existing standard algorithms.
+Right now, we have no standard asynchronous algorithms to imitate.
+
+# Design justification
+
+We take a step-wise approach.  We begin with core BLAS dense linear
+algebra functionality.  We then deviate from that only as much as
+necessary to get algorithms that behave as much as reasonable like the
+existing C++ Standard Library algorithms.  Future work or
+collaboration with other proposals could implement a higher-level
+interface.
+
+Please refer to our papers
+"Evolving a Standard C++ Linear Algebra Library from the BLAS"
+<a href="https://wg21.link/p1674">(P1674)</a>
+and "Historical lessons for C++ linear algebra library standardization"
+<a href="https://wg21.link/p1417">(P1417)</a>
+They will give details and references
+for many of the points that we summarize here.
+
+## We do not require using the BLAS library or any particular "back-end"
+
+Our proposal is inspired by and extends the dense BLAS interface.
+A natural implementation might look like this:
+
+1. wrap an existing C or Fortran BLAS library,
+
+2. hope that the BLAS library is optimized, and then
+
+3. extend the wrapper to include straightforward
+    Standard C++ implementations of P1673's algorithms
+    for matrix and vector value types and data layouts
+    that the BLAS does not support.
+
+P1674 describes the process of writing such an implementation.
+However, P1673 does not require implementations to wrap the BLAS.
+In particular, P1673 does not specify a "back-end" C-style interface
+that would let users or implementers "swap out" different BLAS libraries.
+Here are some reasons why we made this choice.
+
+First, it's possible to write an optimized implementation
+entirely in Standard C++, without calling external C or Fortran functions.
+For example, one can write a cache-blocked
+matrix-matrix multiply implementationen entirely in Standard C++.
+
+Second, different vendors may have their own libraries
+that support matrix and vector value types and/or layouts
+beyond what the standard dense BLAS supports.
+For example, they may have C functions
+for mixed-precision matrix-matrix multiply, like
+BLIS' `bli_gemm`
+<a href="https://github.com/flame/blis/blob/master/examples/oapi/11gemm_md.c">(example here)</a>,
+or NVIDIA's `cublasGemmEx`
+<a href="https://docs.nvidia.com/cuda/cublas/index.html#cublas-GemmEx">(example here)</a>.
+
+Third, just because a C or Fortran BLAS library can be found,
+doesn't mean that it's optimized at all or optimized well.
+For example, many Linux distributions have a BLAS software package
+that is built by compiling the Reference BLAS.
+This will give poor performance for BLAS 3 operations.
+Even "optimized" vendor BLAS libraries may not optimize all cases.
+Release notes even for recent versions show performance improvements.
+
+In summary: While a natural way to implement this proposal
+would be to wrap an existing C or Fortran BLAS library,
+we do not want to require this.
+Thus, we do not specify a "back-end" C-style interface.
+
+## Why use `mdspan`?
+
+### View of a multidimensional array
+
+The BLAS operates on what C++ programmers might call views of multidimensional arrays.
+Users of the BLAS can store their data in whatever data structures they like,
+and handle their allocation and lifetime as they see fit,
+as long as the data have a BLAS-compatible memory layout.
+
+The corresponding C++ data structure is `mdspan`.
+This class encapsulates the large number of pointer and integer arguments
+that BLAS functions take, that represent views of matrices and vectors.
+Using `mdspan` in the C++ interface reduce the number of arguments
+and avoids common errors, like mixing up the order of arguments.
+It supports all the array memory layouts that the BLAS supports,
+including row major and column major.
+It also expresses the same data ownership model that the BLAS expresses.
+Users may manage allocation and deallocation however they wish.
+In addition, `mdspan` lets our algorithms exploit any dimensions known at compile time.
+
+### Ease of use
+
+The `mdspan` class' layout and accessor policies
+let us simplify our interfaces,
+by encapsulating transpose, conjugate, and scalar arguments.
+Features of `mdspan` make implementing BLAS-like algorithms
+much less error prone and easier to read.
+These include its encapsulation of matrix indexing
+and its built-in "slicing" capabilities via `submdspan`.
+
+### BLAS and `mdspan` are low level
+
+The BLAS is low level; it imposes no mathematical meaning on multidimensional arrays.
+This gives users the freedom to develop mathematical libraries with the semantics they want.
+Similarly, `mdspan` is just a view of a multidimensional array;
+it has no mathematical meaning on its own.
+
+We mention this because "matrix," "vector," and "tensor"
+are mathematical ideas that mean more than just arrays of numbers.
+This is more than just a theoretical concern.
+Some BLAS functions operate on "triangular," "symmetric," or "Hermitian" matrices,
+but they do not assert that a matrix has any of these mathematical properties.
+Rather, they only read only one side of the matrix (the lower or upper triangle),
+and compute as if the other side of the matrix satisfies the mathematical property.
+A key feature of the BLAS and libraries that build on it, like LAPACK,
+is that they can operate on the matrix's data in place.
+These operations change both the matrix's mathematical properties and its representation in memory.
+For example, one might have an N x N array representing a matrix that is symmetric in theory,
+but computed and stored in a way that might not result in exactly symmetric data.
+In order to solve linear systems with this matrix,
+one might give the array to LAPACK's `xSYTRF` to compute an LDL^T factorization,
+asking `xSYTRF` only to access the array's lower triangle.
+If `xSYTRF` finishes successfully,
+it has overwritten the lower triangle of its input
+with a representation of both the lower triangular factor L
+and the block diagonal matrix D,
+as computed assuming that the matrix is the sum of the lower triangle
+and the transpose of the lower triangle.
+The resulting N x N array no longer represents a symmetric matrix.
+Rather, it contains part of the representation of a LDL^T factorization of the matrix.
+The upper triangle still contains the original input matrix's data.
+One may then solve linear systems by giving `xSYTRS` the lower triangle,
+along with other output of `xSYTRF`.
+
+The point of this example is that a "symmetric matrix class"
+is the wrong way to model this situation.
+There's an N x N array, whose mathematical interpretation changes
+with each in-place operation performed on it.
+The low-level `mdspan` data structure carries no mathematical properties in itself,
+so it models this situation better.
+
+### Hook for future expansion
+
+The `mdspan` class treats its layout as an extension point.
+This lets our interface support layouts beyond what the BLAS Standard permits.
+The accessor extension point offers us a hook for future expansion
+to support heterogeneous memory spaces.
+(This is a key feature of `Kokkos::View`,
+the data structure that inspired `mdspan`.)
+In addition, using `mdspan` will make it easier for us to add
+an efficient "batched" interface in future proposals.
+
+### Generic enough to replace a "multidimensional array concept"
+
+LEWGI requested in the 2019 Cologne meeting that we explore using a
+concept instead of `mdspan` to define the arguments for the
+linear algebra functions.
+This would mean that instead of having our functions take `mdspan` parameters,
+they would be generic on one or more suitably constrained multidimensional array types.
+The constraints would form a "multidimensional array concept."
+
+We investigated this option, and rejected it, for the following reasons.
+
+1. Our proposal uses enough features of `mdspan`
+    that any concept generally applicable to all functions we propose
+    would largely replicate the definition of `mdspan`.
+
+2. This proposal could support most multidimensional array types,
+    if the array types just made themselves convertible to `mdspan`.
+
+3. We could always generalize our algorithms later.
+
+4. Any multidimensional array concept would need revision
+    in the light of <a href="https://wg21.link/p2128r6">P2128R6</a>.
+
+This proposal refers to almost all of `mdspan`'s features,
+including `extents`, layouts, and accessors.
+We expect implementations to use all of them for optimizations,
+for example to extract the scaling factor from the return value of `scaled`
+in order to call an optimized BLAS library directly.
+
+Suppose that a general customization point `get_mdspan` exists,
+that takes a reference to a multidimensional array type
+and returns an `mdspan` that views the array.
+Then, our proposal could support most multidimensional array types.
+"Most" includes all such types that refer to a subset of a contiguous span of memory.
+
+Requiring that a multidimensional array refer to a subset of a contiguous span of memory
+would exclude multidimensional array types that have a noncontiguous backing store,
+such as a `map`.
+If we later wanted to support such types,
+we could always generalize our algorithms later.
+
+Finally, any existing multidimensional array concept would need revision
+in the light of <a href="https://wg21.link/p2128r6">P2128R6</a>,
+which has been voted into the C++ Standard draft.
+P2128 lets `operator[]` take multiple parameters.
+The version of mdspan which was voted into the C++ Standard draft
+uses `operator[]` instead of `operator()` as the array access operator.
+
+After further discussion at the 2019 Belfast meeting,
+LEWGI accepted our position that having our algorithms take `mdspan`
+instead of template parameters constrained by a multidimensional array concept
+would be fine for now.
+
+## Function argument aliasing and zero scalar multipliers
+
+Summary:
+
+1. The BLAS Standard forbids aliasing any input (read-only) argument
+    with any output (write-only or read-and-write) argument.
+
+2. The BLAS uses `INTENT(INOUT)` (read-and-write) arguments to express
+    "updates" to a vector or matrix.  By contrast, C++ Standard
+    algorithms like `transform` take input and output iterator ranges
+    as different parameters, but may let input and output ranges be the
+    same.
+
+3. The BLAS uses the values of scalar multiplier arguments ("alpha" or
+    "beta") of vectors or matrices at run time, to decide whether to
+    treat the vectors or matrices as write only.  This matters both for
+    performance and semantically, assuming IEEE floating-point
+    arithmetic.
+
+4. We decide separately, based on the category of BLAS function, how
+    to translate `INTENT(INOUT)` arguments into a C++ idiom:
+
+   a. For triangular solve and triangular multiply, in-place behavior
+      is essential for computing matrix factorizations in place,
+      without requiring extra storage proportional to the input
+      matrix's dimensions.  However, in-place functions may hinder
+      implementations' use of some forms of parallelism.
+      Thus, we have both not-in-place and in-place overloads.
+      Both take an optional `ExecutionPolicy&&`,
+      as some forms of parallelism (e.g., vectorization)
+      may still be effective with in-place operations.
+
+   b. Else, if the BLAS function unconditionally updates (like
+      `xGER`), we retain read-and-write behavior for that argument.
+
+   c. Else, if the BLAS function uses a scalar `beta` argument to
+      decide whether to read the output argument as well as write to
+      it (like `xGEMM`), we provide two versions: a write-only version
+      (as if `beta` is zero), and a read-and-write version (as if
+      `beta` is nonzero).
+
+For a detailed analysis, please see our paper
+"Evolving a Standard C++ Linear Algebra Library from the BLAS"
+<a href="https://wg21.link/p1674">(P1674)</a>.
+
+## Support for different matrix layouts
+
+Summary:
+
+1. The dense BLAS supports several different dense matrix "types."
+    Type is a mixture of "storage format" (e.g., packed, banded) and
+    "mathematical property" (e.g., symmetric, Hermitian, triangular).
+
+2. Some "types" can be expressed as custom `mdspan` layouts.
+    Other types actually represent algorithmic constraints: for
+    instance, what entries of the matrix the algorithm is allowed to
+    access.
+
+3. Thus, a C++ BLAS wrapper cannot overload on matrix "type" simply by
+    overloading on `mdspan` specialization.  The wrapper must use
+    different function names, tags, or some other way to decide what
+    the matrix type is.
+
+For more details, including a list and description of the matrix
+"types" that the dense BLAS supports, please see our paper
+"Evolving a Standard C++ Linear Algebra Library from the BLAS"
+<a href="https://wg21.link/p1674">(P1674)</a>.
+
+A C++ linear algebra library has a few possibilities for
+distinguishing the matrix "type":
+
+1. It could imitate the BLAS, by introducing different function names,
+    if the layouts and accessors do not sufficiently describe the
+    arguments.
+
+2. It could introduce a hierarchy of higher-level classes for
+    representing linear algebra objects, use `mdspan` (or
+    something like it) underneath, and write algorithms to those
+    higher-level classes.
+
+3. It could use the layout and accessor types in `mdspan` simply
+    as tags to indicate the matrix "type."  Algorithms could specialize
+    on those tags.
+
+We have chosen Approach 1.  Our view is that a BLAS-like interface
+should be as low-level as possible.  Approach 2 is more like a "Matlab
+in C++"; a library that implements this could build on our proposal's
+lower-level library.  Approach 3 *sounds* attractive.  However, most
+BLAS matrix "types" do not have a natural representation as layouts.
+Trying to hack them in would pollute `mdspan` -- a simple class
+meant to be easy for the compiler to optimize -- with extra baggage
+for representing what amounts to sparse matrices.  We think that BLAS
+matrix "type" is better represented with a higher-level library that
+builds on our proposal.
+
+## Interpretation of "lower / upper triangular"
+
+### Triangle refers to what part of the matrix is accessed
+
+The triangular, symmetric, and Hermitian algorithms in this proposal
+all take a `Triangle` tag that specifies whether the algorithm
+should access the upper or lower triangle of the matrix.
+This has the same function as the `UPLO` argument
+of the corresponding BLAS routines.
+The upper or lower triangular argument
+only refers to what part of the matrix the algorithm will access.
+The "other triangle" of the matrix need not contain useful data.
+For example, with the symmetric algorithms,
+`A[j, i]` need not equal `A[i, j]`
+for any `i` and `j` in the domain of `A` with `i` not equal to `j`.
+The algorithm just accesses one triangle and interprets the other triangle
+as the result of flipping the accessed triangle over the diagonal.
+
+This "interpretation" approach to representing triangular matrices
+is critical for matrix factorizations.
+For example, LAPACK's LU factorization (`xGETRF`)
+overwrites a matrix A with both its L (lower triangular,
+implicitly represented diagonal of all ones)
+and U (upper triangular, explicitly stored diagonal) factors.
+Solving linear systems Ax=b with this factorization,
+as LAPACK's `xGETRS` routine does,
+requires solving first a linear system with the upper triangular matrix U,
+and then solving a linear system with the lower triangular matrix L.
+If the BLAS required that the "other triangle"
+of a triangular matrix had all zero elements,
+then LU factorization would require at least twice the storage.
+For symmetric and Hermitian matrices,
+only accessing the matrix's elements nonredundantly
+ensures that the matrix remains mathematically symmetric resp. Hermitian,
+even in the presence of rounding error.
+
+### BLAS applies UPLO to original matrix; we apply Triangle to transformed matrix
+
+The BLAS routines that take an `UPLO` argument
+generally also take a `TRANS` argument.
+The `TRANS` argument says whether to apply the matrix,
+its transpose, or its conjugate transpose.
+The BLAS applies the `UPLO` argument to the "original" matrix,
+not to the transposed matrix.
+For example, if `TRANS='T'` or `TRANS='C'`,
+`UPLO='U'` means the routine will access the upper triangle of the matrix,
+not the upper triangle of the matrix's transpose.
+
+Our proposal takes the opposite approach.
+It applies `Triangle` to the input matrix,
+which may be the result of a transformation
+such as `transposed` or `conjugate_transposed`.
+For example, if `Triangle` is `upper_triangle_t`,
+the algorithm will always access the matrix
+for `i,j` in its domain with `i` ≤ `j`
+(or `i` strictly less than `j`,
+if the algorithm takes a `Diagonal` tag
+and `Diagonal` is `implicit_unit_diagonal_t`).
+If the input matrix is `transposed(A)` for a `layout_left` `mdspan` `A`,
+this means that the algorithm will access the upper triangle of `transposed(A)`,
+which is actually the *lower* triangle of `A`.
+
+We took this approach because our interface permits arbitrary layouts,
+with possibly arbitrary nesting of layout transformations.
+This comes from `mdspan`'s design itself, not even necessarily from our proposal.
+For example, users might define `antitranspose(A)`,
+that flips indices over the antidiagonal
+(the "other diagonal" that goes from the lower left to the upper right of the matrix,
+instead of from the upper left to the lower right).
+Layout transformations need not even be one-to-one,
+because layouts themselves need not be (hence `is_unique`).
+Since it's not possible to "undo" a general layout,
+there's no way to get back to the "original matrix."
+
+Our approach, while not consistent with the BLAS, is internally consistent.
+`Triangle` always has a clear meaning,
+no matter what transformations users apply to the input.
+Layout transformations like `transposed`
+have the same interpretation for all the matrix algorithms,
+whether for general, triangular, symmetric, or Hermitian matrices.
+This interpretation is consistent with the standard meaning of `mdspan` layouts.
+
+C BLAS implementations already apply layout transformations like this
+so that they can use an existing column-major Fortran BLAS
+to implement operations on matrices with different layouts.
+For example, the transpose of an `M` x `N` `layout_left` matrix
+is just the same data, viewed as an `N` x `M` `layout_right` matrix.
+Thus, `transposed` is consistent with current practice.
+In fact, `transposed` need not use a special `layout_transpose`,
+if it knows how to reinterpret the input layout.
+
+### Summary
+
+1. BLAS applies `UPLO` to the original matrix, before any transposition.
+    Our proposal applies `Triangle` to the transformed matrix,
+    after any transposition.
+
+2. Our approach is the only reasonable way to handle the full generality
+    of user-defined layouts and layout transformations.
+
+## Over- and underflow wording for vector 2-norm
+
+SG6 recommended to us at Belfast 2019 to change the special overflow /
+underflow wording for `vector_norm2` to imitate the BLAS Standard more
+closely.  The BLAS Standard does say something about overflow and
+underflow for vector 2-norms.  We reviewed this wording and conclude
+that it is either a nonbinding quality of implementation (QoI)
+recommendation, or too vaguely stated to translate directly into C++
+Standard wording.
+Thus, we removed our special overflow / underflow wording.
+However, the BLAS Standard clearly expresses the intent
+that implementations document their underflow and overflow guarantees
+for certain functions, like vector 2-norms.
+The C++ Standard requires documentation of "implementation-defined behavior."
+Therefore, we added language to our proposal that makes
+"any guarantees regarding overflow and underflow" of those certain functions
+"implementation-defined."
+
+Previous versions of this paper asked implementations to compute
+vector 2-norms "without undue overflow or underflow at intermediate
+stages of the computation."  "Undue" imitates existing C++ Standard
+wording for `hypot`.  This wording hints at the stricter requirements
+in F.9 (normative, but optional) of the C Standard for math library
+functions like `hypot`, without mandating those requirements.  In
+particular, paragraph 9 of F.9 says:
+
+> Whether or when library functions raise an undeserved "underflow"
+> floating-point exception is unspecified.  Otherwise, as implied by
+> F.7.6, the **&lt;math.h&gt;** functions do not raise spurious
+> floating-point exceptions (detectable by the user) [including the
+> "overflow" exception discussed in paragraph 6], other than the
+> "inexact" floating-point exception.
+
+However, these requirements are for math library functions like
+`hypot`, not for general algorithms that return floating-point values.
+SG6 did not raise a concern that we should treat `vector_norm2` like a
+math library function; their concern was that we imitate the BLAS
+Standard's wording.
+
+The BLAS Standard says of several operations, including vector 2-norm:
+"Here are the exceptional routines where we ask for particularly
+careful implementations to avoid unnecessary over/underflows, that
+could make the output unnecessarily inaccurate or unreliable" (p. 35).
+
+The BLAS Standard does not define phrases like "unnecessary
+over/underflows."  The likely intent is to avoid naïve implementations
+that simply add up the squares of the vector elements.  These would
+overflow even if the norm in exact arithmetic is significantly less
+than the overflow threshold.  The POSIX Standard (IEEE Std
+1003.1-2017) analogously says that `hypot` must "take precautions
+against overflow during intermediate steps of the computation."
+
+The phrase "precautions against overflow" is too vague for us to
+translate into a requirement.  The authors likely meant to exclude
+naïve implementations, but not require implementations to know whether
+a result computed in exact arithmetic would overflow or underflow.
+The latter is a special case of computing floating-point sums exactly,
+which is costly for vectors of arbitrary length.  While it would be a
+useful feature, it is difficult enough that we do not want to require
+it, especially since the BLAS Standard itself does not.
+The implementation of vector 2-norms in the Reference BLAS included with LAPACK 3.10.0
+partitions the running sum of squares into three different accumulators:
+one for big values (that might cause the sum to overflow without rescaling),
+one for small values (that might cause the sum to underflow without rescaling),
+and one for the remaining "medium" values.
+(See Anderson 2017.)
+Earlier implementations merely rescaled by the current maximum absolute value
+of all the vector entries seen thus far.
+(See Blue 1978.)
+Implementations could also just compute the sum of squares in a straightforward loop,
+then check floating-point status flags for underflow or overflow,
+and recompute if needed.
+
+For all of the functions listed on p. 35 of the BLAS Standard as
+needing "particularly careful implementations," *except* vector norm,
+the BLAS Standard has an "Advice to implementors" section with extra
+accuracy requirements.  The BLAS Standard does have an "Advice to
+implementors" section for matrix norms (see Section 2.8.7, p. 69),
+which have similar over- and underflow concerns as vector norms.
+However, the Standard merely states that "[h]igh-quality
+implementations of these routines should be accurate" and should
+document their accuracy, and gives examples of "accurate
+implementations" in LAPACK.
+
+The BLAS Standard never defines what "Advice to implementors" means.
+However, the BLAS Standard shares coauthors and audience with the
+Message Passing Interface (MPI) Standard, which defines "Advice to
+implementors" as "primarily commentary to implementors" and
+permissible to skip (see e.g., MPI 3.0, Section 2.1, p. 9).  We thus
+interpret "Advice to implementors" in the BLAS Standard as a
+nonbinding quality of implementation (QoI) recommendation.
+
+## Constraining matrix and vector element types and scalars
+
+### Introduction
+
+The BLAS only accepts four different types of scalars and matrix and vector elements.
+In C++ terms, these correspond to `float`, `double`, `complex<float>`, and `complex<double>`.
+The algorithms we propose generalize the BLAS
+by accepting any matrix, vector, or scalar element types that make sense for each algorithm.
+Those may be built-in types, like floating-point numbers or integers,
+or they may be custom types.
+Those custom types might not behave like conventional real or complex numbers.
+For example, quaternions have noncommutative multiplication (`a * b` might not equal `b * a`),
+polynomials in one variable over a field lack division,
+and some types might not even have subtraction defined.
+Nevertheless, many BLAS operations would make sense for all of these types.
+
+"Constraining matrix and vector element types and scalars"
+means defining how these types must behave
+in order for our algorithms to make sense.
+This includes both syntactic and semantic constraints.
+We have three goals:
+
+1. to help implementers implement our algorithms correctly;
+
+2. to give implementers the freedom to make quality of implementation (QoI) enhancements,
+    for both performance and accuracy; and
+
+3. to help users understand what types they may use with our algorithms.
+
+The whole point of the BLAS was to identify key operations
+for vendors to optimize.
+Thus, performance is a major concern.
+"Accuracy" here refers to either to rounding error or to approximation error
+(for matrix or vector element types where either makes sense).
+
+### Value type constraints do not suffice to describe algorithm behavior
+
+LEWG's 2020 review of P1673R2 asked us to investigate conceptification of its algorithms.
+"Conceptification" here refers to an effort like that of P1813R0
+("A Concept Design for the Numeric Algorithms"),
+to come up with concepts that could be used to constrain the template parameters
+of numeric algorithms like `reduce` or `transform`.
+(We are not referring to LEWGI's request for us to consider
+generalizing our algorithm's parameters from `mdspan`
+to a hypothetical multidimensional array concept.
+We discuss that above, in the "Why use `mdspan`?" section.)
+The numeric algorithms are relevant to P1673 because many of the algorithms proposed in P1673
+look like generalizations of `reduce` or `transform`.
+We intend for our algorithms to be generic on their matrix and vector element types,
+so these questions matter a lot to us.
+
+We agree that it is useful to set constraints
+that make it possible to reason about correctness of algorithms.
+However, we do not think constraints on value types suffice for this purpose.
+First, requirements like associativity are too strict to be useful for practical types.
+Second, what we really want to do is describe the behavior of algorithms,
+regardless of value types' semantics.
+"The algorithm may reorder sums" means something different
+than "addition on the terms in the sum is associative."
+
+### Associativity is too strict
+
+P1813R0 requires associative addition for many algorithms, such as `reduce`.
+However, many practical arithmetic systems that users might like to use
+with algorithms like `reduce` have non-associative addition.  These include
+
+* systems with rounding;
+
+* systems with an "infinity": e.g., if 10 is Inf, 3 + 8 - 7 could be either Inf or 4; and
+
+* saturating arithmetic: e.g., if 10 saturates, 3 + 8 - 7 could be either 3 or 4.
+
+Note that the latter two arithmetic systems have nothing to do with rounding error.
+With saturating integer arithmetic, parenthesizing a sum in different ways might give results
+that differ by as much as the saturation threshold.
+It's true that many non-associative arithmetic systems behave
+"associatively enough" that users don't fear parallelizing sums.
+However, a concept with an exact property (like "commutative semigroup")
+isn't the right match for "close enough,"
+just like `operator==` isn't the right match for describing "nearly the same."
+For some number systems, a rounding error bound might be more appropriate,
+or guarantees on when underflow or overflow may occur (as in POSIX's `hypot`).
+
+The problem is a mismatch between the requirement we want to express --
+that "the algorithm may reparenthesize addition" --
+and the constraint that "addition is associative."
+The former describes the algorithm's behavior,
+while the latter describes the types used with that algorithm.
+Given the huge variety of possible arithmetic systems,
+an approach like the Standard's use of *GENERALIZED_SUM* to describe `reduce` and its kin seems more helpful.
+If the Standard describes an algorithm in terms of *GENERALIZED_SUM*,
+then that tells the caller what the algorithm might do.
+The caller then takes responsibility for interpreting the algorithm's results.
+
+We think this is important both for adding new algorithms (like those in this proposal)
+and for defining behavior of an algorithm with respect to different `ExecutionPolicy` arguments.
+(For instance, `execution::par_unseq` could imply that the algorithm might change the order of terms in a sum,
+while `execution::par` need not.
+Compare to `MPI_Op_create`'s `commute` parameter,
+that affects the behavior of algorithms like `MPI_Reduce`
+when used with the resulting user-defined reduction operator.)
+
+### Generalizing associativity helps little
+
+Suppose we accept that associativity and related properties are not useful
+for describing our proposed algorithms.
+Could there be a generalization of associativity that *would* be useful?
+P1813R0's most general concept is a `magma`.
+Mathematically, a *magma* is a set M with a binary operation ×,
+such that if a and b are in M, then a × b is in M.
+The operation need not be associative or commutative.
+While this seems almost too general to be useful,
+there are two reasons why even a magma is too specific for our proposal.
+
+1. A magma only assumes one set, that is, one type.
+    This does not accurately describe what the algorithms do,
+    and it excludes useful features like mixed precision and types that use expression templates.
+
+2. A magma is too specific, because algorithms are useful even if the binary operation is not closed.
+
+First, even for simple linear algebra operations that "only" use plus and times,
+there is no one "set M" over which plus and times operate.
+There are actually three operations: plus, times, and assignment.
+Each operation may have completely heterogeneous input(s) and output.
+The sets (types) that may occur vary from algorithm to algorithm,
+depending on the input type(s),
+and the algebraic expression(s) that the algorithm is allowed to use.
+We might need several different concepts to cover all the expressions that algorithms use,
+and the concepts would end up being less useful to users than the expressions themselves.
+
+For instance, consider the Level 1 BLAS "AXPY" function.
+This computes `y[i] = alpha * x[i] + y[i]` elementwise.
+What type does the expression `alpha * x[i] + y[i]` have?
+It doesn't need to have the same type as `y[i]`;
+it just needs to be assignable to `y[i]`.
+The types of `alpha`, `x[i]`, and `y[i]` could all differ.
+As a simple example, `alpha` might be `int`,
+`x[i]` might be `float`, and `y[i]` might be `double`.
+The types of `x[i]` and `y[i]` might be more complicated;
+e.g., `x[i]` might be a polynomial with `double` coefficients,
+and `y[i]` a polynomial with `float` coefficients.
+If those polynomials use expression templates,
+then slightly different sum expressions involving `x[i]` and/or `y[i]`
+(e.g., `alpha * x[i] + y[i]`, `x[i] + y[i]`, or `y[i] + x[i]`)
+might all have different types,
+all of which differ from value type of `x` or `y`.
+All of these types must be assignable and convertible to the output value type.
+
+We could try to describe this with a concept that expresses a sum type.
+The sum type would include all the types that might show up in the expression.
+However, we do not think this would improve clarity over just the expression itself.
+Furthermore, different algorithms may need different expressions,
+so we would need multiple concepts, one for each expression.
+Why not just use the expressions to describe what the algorithms can do?
+
+Second, the magma concept is not helpful even if we only had one set M,
+because our algorithms would still be useful even if binary operations were not closed over that set.
+For example, consider a hypothetical user-defined rational number type,
+where plus and times throw if representing the result of the operation
+would take more than a given fixed amount of memory.
+Programmers might handle this exception by falling back to different algorithms.
+Neither plus or times on this type would satisfy the magma requirement,
+but the algorithms would still be useful for such a type.
+One could consider the magma requirement satisfied in a purely syntactic sense,
+because of the return type of plus and times.
+However, saying that would not accurately express the type's behavior.
+
+This point returns us to the concerns we expressed earlier about assuming associativity.
+"Approximately associative" or "usually associative" are not useful concepts without further refinement.
+The way to refine these concepts usefully is to describe the behavior of a type fully,
+e.g., the way that IEEE 754 describes the behavior of floating-point numbers.
+However, algorithms rarely depend on all the properties in a specification like IEEE 754.
+The problem, again, is that we need to describe
+what algorithms do -- e.g., that they can rearrange terms in a sum -- not how the types
+that go into the algorithms behave.
+
+In summary:
+
+* Many useful types have nonassociative or even non-closed arithmetic.
+
+* Lack of (e.g.,) associativity is not just a rounding error issue.
+
+* It can be useful to let algorithms do things like reparenthesize sums or products,
+    even for types that are not associative.
+
+* Permission for an algorithm to reparenthesize sums
+    is not the same as a concept constraining the terms in the sum.
+
+* We can and do use existing Standard language, like *GENERALIZED_SUM*,
+    for expressing permissions that algorithms have.
+
+In the sections that follow, we will describe a different way
+to constrain the matrix and vector element types and scalars in our algorithms.
+We will start by categorizing the different quality of implementation (QoI) enhancements
+that implementers might like to make.
+These enhancements call for changing algorithms in different ways.
+We will distinguish textbook from non-textbook ways of changing algorithms,
+explain that we only permit non-textbook changes for floating-point types,
+then develop constraints on types that permit textbook changes.
+
+### Categories of QoI enhancements
+
+An important goal of constraining our algorithms is
+to give implementers the freedom to make QoI enhancements.
+We categorize QoI enhancements in three ways:
+
+1. those that depend entirely on the computer architecture;
+
+2. those that might have architecture-dependent parameters,
+    but could otherwise be written in an architecture-independent way; and
+
+3. those that diverge from a textbook description of the algorithm,
+    and depend on element types having properties more specific
+    than what that description requires.
+
+An example of Category (1) would be special hardware instructions
+that perform matrix-matrix multiplications on small, fixed-size blocks.
+The hardware might only support a few types,
+such as integers, fixed-point reals, or floating-point types.
+Implementations might use these instructions for the entire algorithm,
+if the problem sizes and element types match the instruction's requirements.
+They might also use these instructions to solve subproblems.
+In either case, these instructions might reorder sums
+or create temporary values.
+
+Examples of Category (2) include blocking
+to increase cache or translation lookaside buffer (TLB) reuse,
+or using SIMD instructions (given the Parallelism TS' inclusion of SIMD).
+Many of these optimizations relate to memory locality or parallelism.
+For an overview, see (Goto 2008) or Section 2.6 of (Demmel 1997).
+All such optimizations reorder sums and create temporary values.
+
+Examples of Category (3) include Strassen's algorithm for matrix multiplication.
+The textbook formulation of matrix multiplication only uses additions and multiplies,
+but Strassen's algorithm also performs subtractions.
+A common feature of Category (3) enhancements
+is that their implementation diverges
+from a "textbook description of the algorithm"
+in ways beyond just reordering sums.
+As a "textbook," we recommend either (Strang 2016),
+or the concise mathematical description of operations in the BLAS Standard.
+In the next section, we will list properties of textbook descriptions,
+and explain some ways in which QoI enhancements might fail to adhere to those properties.
+
+### Properties of textbook algorithm descriptions
+
+"Textbook descriptions" of the algorithms we propose
+tend to have the following properties.
+For each property, we give an example of a "non-textbook" algorithm,
+and how it assumes something extra about the matrix's element type.
+
+a. They compute floating-point sums straightforwardly
+   (possibly reordered, or with temporary intermediate values),
+   rather than using any of several algorithms that improve accuracy
+   (e.g., compensated summation)
+   or even make the result independent of evaluation order (see Demmel 2013).
+   All such non-straightforward algorithms
+   depend on properties of floating-point arithmetic.
+   We will define below what "possibly reordered,
+   or with temporary intermediate values" means.
+
+b. They use only those arithmetic operations
+   on the matrix and vector element types
+   that the textbook description of the algorithm requires,
+   even if using other kinds of arithmetic operations
+   would improve performance
+   or give an asymptotically faster algorithm.
+
+c. They use exact algorithms (not considering rounding error),
+   rather than approximations
+   (that would not be exact even if computing with real numbers).
+
+d. They do not use parallel algorithms
+   that would give an asymptotically faster parallelization
+   in the theoretical limit of infinitely many available parallel processing units,
+   at the cost of likely unacceptable rounding error in floating-point arithmetic.
+
+As an example of (b), the textbook matrix multiplication algorithm
+only adds or multiplies the matrices' elements.
+In contrast, Strassen's algorithm for matrix-matrix multiply
+subtracts as well as adds and multiplies the matrices' elements.
+Use of subtraction assumes that arbitrary elements have an additive inverse,
+but the textbook matrix multiplication algorithm makes sense
+even for element types that lack additive inverses for all elements.
+Also, use of subtractions changes floating-point rounding behavior
+in a way that was only fully understood recently (see Demmel 2007).
+
+As an example of (c), the textbook substitution algorithm
+for solving triangular linear systems is exact.
+In contrast, one can approximate triangular solve with a stationary iteration.
+(See, e.g., Section 5 of (Chow 2015).
+That paper concerns the sparse matrix case;
+we cite it merely as an example of an approximate algorithm,
+not as a recommendation for dense triangular solve.)
+Approximation only makes sense for element types
+that have enough precision for the approximation to be accurate.
+If the approximation checks convergence,
+than the algorithm also requires less-than comparison
+of absolute values of differences.
+
+Multiplication by the reciprocal of a number,
+rather than division by that number,
+could fit into (b) or (c).
+As an example of (c), implementations for hardware
+where floating-point division is slow compared with multiplication
+could use an approximate reciprocal multiplication to implement division.
+
+As an example of (d), the textbook substitution algorithm
+for solving triangular linear systems has data dependencies
+that limit its theoretical parallelism.
+In contrast, one can solve a triangular linear system
+by building all powers of the matrix in parallel,
+then solving the linear system as with a Krylov subspace method.
+This approach is exact for real numbers,
+but commits too much rounding error to be useful in practice
+for all but the smallest linear systems.
+In fact, the algorithm requires that the matrix's element type
+have precision exponential in the matrix's dimension.
+
+Many of these non-textbook algorithms rely on properties of floating-point arithmetic.
+Strassen's algorithm makes sense for unsigned integer types,
+but it could lead to unwarranted and unexpected overflow for signed integer types.
+Thus, we think it best to limit implementers to textbook algorithms,
+unless all matrix and vector element types are floating-point types.
+We always forbid non-textbook algorithms of type (d).
+If all matrix and vector element types are floating-point types,
+we permit non-textbook algorithms of Types (a), (b), and (c),
+under two conditions:
+
+1. they satisfy the complexity requirements; and
+
+2. they result in a *logarithmically stable* algorithm,
+    in the sense of (Demmel 2007).
+
+We believe that Condition (2) is a reasonable interpretation of Section 2.7 of the BLAS Standard.
+This says that "no particular computational order is mandated by the function specifications.
+In other words, any algorithm that produces results 'close enough'
+to the usual algorithms presented in a standard book on matrix computations
+is acceptable."
+Examples of what the BLAS Standard considers "acceptable"
+include Strassen's algorithm, and implementing matrix multiplication as
+`C = (alpha * A) * B + (beta * C)`,
+`C = alpha * (A * B) + (beta * C)`, or
+`C = A * (alpha * B) + (beta * C)`.
+
+"Textbook algorithms" includes optimizations commonly found in BLAS implementations.
+This includes any available hardware acceleration,
+as well as the locality and parallelism optimizations we describe below.
+Thus, we think restricting generic implementations to textbook algorithms
+will not overly limit implementers.
+
+The set of floating-point types currently has three members:
+`float`, `double`, and `long double`.
+If a proposal like P1467R4 ("Extended floating-point types and standard names") is accepted,
+it will grow to include implementation-specific types,
+such as short or extended-precision floats.
+This "future-proofs" our proposal in some sense,
+though implementers will need to take care to avoid approximations
+if the element type lacks the needed precision.
+
+### Reordering sums and creating temporaries
+
+Even textbook descriptions of linear algebra algorithms
+presume the freedom to reorder sums and create temporary values.
+Optimizations for memory locality and parallelism depend on this.
+This freedom imposes requirements on algorithms' matrix and vector element types.
+
+We could get this freedom either by
+limiting our proposal to the Standard's current arithmetic types,
+or by forbidding reordering and temporaries for types other than arithmetic types.
+However, doing so would unnecessarily prevent straightforward optimizations
+for small and fast types that act just like arithmetic types.
+This includes so-called "short floats" such as bfloat16 or binary16,
+extended-precision floating-point numbers, and fixed-point reals.
+Some of these types may be implementation defined,
+and others may be user-specified.
+We intend to permit implementers to optimize for these types as well.
+This motivates us to describe our algorithms' type requirements in a generic way.
+
+#### Special case: Only one element type
+
+We find it easier to think about type requirements
+by starting with the assumption that
+all element and scalar types in algorithms are the same.
+One can then generalize to input element type(s) that might differ
+from the output element type and/or scalar result type.
+
+Optimizations for memory locality and parallelism
+both create temporary values, and change the order of sums.
+For example, reorganizing matrix data to reduce stride involves
+making a temporary copy of a subset of the matrix,
+and accumulating partial sums into the temporary copy.
+Thus, both kinds of optimizations impose
+a common set of requirements and assumptions on types.
+Let `value_type` be the output `mdspan`'s `value_type`.
+Implementations may:
+
+1. create arbitrarily many objects of type `value_type`,
+    value-initializing them or direct-initializing them
+    with any existing object of that type;
+
+2. perform sums in any order; or
+
+3. replace any value with the sum of that value
+    and a value-initialized `value_type` object.
+
+Assumption (1) implies that the output value type is `semiregular`.
+Contrast with **[algorithms.parallel.exec]**:
+"Unless otherwise stated,
+implementations may make arbitrary copies of elements of type `T`,
+from sequences where `is_trivially_copy_constructible_v<T>`
+and `is_trivially_destructible_v<T>` are true."
+We omit the trivially constructible and destructible requirements here
+and permit any `semiregular` type.
+Linear algebra algorithms assume mathematical properties
+that let us impose more specific requirements than general parallel algorithms.
+Nevertheless, implementations may want to enable optimizations
+that create significant temporary storage
+only if the value type is trivially constructible,
+trivially destructible, and not too large.
+
+Regarding Assumption (2):
+The freedom to compute sums in any order is not necessarily a type constraint.
+Rather, it's a right that the algorithm claims,
+regardless of whether the type's addition is associative or commutative.
+For example, floating-point sums are not associative,
+yet both parallelization and customary linear algebra optimizations
+rely on reordering sums.
+See the above "Value type constraints do not suffice to describe algorithm behavior" section
+for a more detailed explanation.
+
+Regarding Assumption (3),
+we do not actually say that
+value-initialization produces a two-sided additive identity.
+What matters is what the algorithm's implementation may do,
+not whether the type actually behaves in this way.
+
+#### General case: Multiple input element types
+
+An important feature of P1673 is the ability to compute
+with mixed matrix or vector element types.
+For instance, `add(y, scaled(alpha, x), z)` implements the operation z = y + alpha*x,
+an elementwise scaled vector sum.
+The element types of the vectors x, y, and z could be all different,
+and could differ from the type of alpha.
+
+##### Accumulate into output value type
+
+Generic algorithms would use the output `mdspan`'s `value_type`
+to accumulate partial sums, and for any temporary results.
+This is the analog of `std::reduce`'s scalar result type `T`.
+Implementations for floating-point types might accumulate into higher-precision temporaries,
+or use other ways to increase accuracy when accumulating partial sums,
+but the output `mdspan`'s `value_type` would still control accumulation behavior in general.
+
+##### Proxy references or expression templates
+
+1. Proxy references: The input and/or output `mdspan` might have an accessor
+    with a `reference` type other than `element_type&`.
+    For example, the output `mdspan` might have a value type `value_type`,
+    but its `reference` type might be `atomic_ref<value_type>`.
+
+2. Expression templates: The element types themselves might have arithmetic operations
+    that defer the actual computation until the expression is assigned.
+    These "expression template" types typically hold
+    some kind of reference or pointer to their input arguments.
+
+Neither proxy references nor expression template types are `semiregular`,
+because they behave like references, not like values.
+However, we can still require that their underlying value type be `semiregular`.
+For instance, the possiblity of proxy references just means that
+we need to use the output `mdspan`'s `value_type`
+when constructing or value-initializing temporary values,
+rather than trying to deduce the value type
+from the type of an expression that indexes into the output `mdspan`.
+Expression templates just mean that we need to use the output `mdspan`'s `value_type`
+to construct or value-initialize temporaries,
+rather than trying to deduce the temporaries' type
+from the right-hand side of the expression.
+
+The `z = y + alpha*x` example above shows that some of the algorithms we propose
+have multiple terms in a sum on the right-hand side of the expression
+that defines the algorithm.
+If algorithms have permission to rearrange the order of sums,
+then they need to be able to break up such expressions into separate terms,
+even if some of those expressions are expression templates.
+
+### "Textbook" algorithm description in semiring terms
+
+As we explain in the
+"Value type constraints do not suffice to describe algorithm behavior" section above,
+we deliberately constrain matrix and vector element types
+to require associative addition.
+This means that we do not, for instance, define concepts like "ring" or "group."
+We cannot even speak of a single set of values
+that would permit defining things like a "ring" or "group."
+This is because our algorithms must handle mixed value types,
+expression templates, and proxy references.
+However, it may still be helpful to use mathematical language
+to explain what we mean by "a textbook description of the algorithm."
+
+Most of the algorithms we propose only depend on addition and multiplication.
+We describe these algorithms in terms of one or more mathematical expressions
+on elements of a *semiring* with possibly noncommutative multiplication.
+The only difference between a semiring and a ring
+is that a semiring does not require all elements to have an additive inverse.
+That is, addition is allowed, but not subtraction.
+Implementers may apply any mathematical transformation to the expressions
+that would give the same result for any semiring.
+
+#### Why a semiring?
+
+We use a semiring because
+
+1. we generally want to reorder terms in sums,
+    but we do not want to order terms in products; and
+
+2. we do not want to assume that subtraction works.
+
+The first is because linear algebra computations are useful
+for matrix or vector element types with noncommutative multiplication,
+such as quaternions or matrices.
+The second is because algebra operations might be useful for signed integers,
+where a formulation using subtraction risks unexpected undefined behavior.
+
+#### Semirings and testing
+
+It's important that implementers be able to test our proposed algorithms
+for custom element types, not just the built-in arithmetic types.
+We don't want to require hypothetical "exact real arithmetic" types
+that take particular expertise to implement.
+Instead, we propose testing with simple classes built out of unsigned integers.
+This section is not part of our Standard Library proposal,
+but we include it to give guidance to implementers
+and to show that it's feasible to test our proposal.
+
+#### Commutative multiplication
+
+C++ unsigned integers implement commutative rings.
+(Rings always have commutative addition;
+a "commutative ring" has commutative multiplication as well.)
+We may transform (say) `uint32_t` into a commutative semiring
+by wrapping it in a class that does not provide unary or binary `operator-`.
+Adding a "tag" template parameter to this class
+would let implementers build tests for mixed element types.
+
+#### Noncommutative multiplication
+
+The semiring of 2x2 matrices with element type a commutative semiring
+is itself a semiring,
+but with noncommutative multiplication.
+This is a good way to build a noncommutative semiring for testing.
+
+### Summary
+
+* Constraining the matrix and vector element types and scalar types in our functions
+    gives implementers the freedom to make QoI enhancements
+    without risking correctness.
+
+* We think describing algorithms' behavior and implementation freedom
+    is more useful than mathematical concepts like "ring."
+    For example, we permit implementations to reorder sums,
+    but this does not mean that they assume sums are associative.
+    This is why we do not define a hierarchy of number concepts.
+
+* We categorize different ways that implementers might like to change algorithms,
+    list categories we exclude and categories we permit,
+    and use the permitted categories to derive constraints
+    on the types of matrix and vector elements and scalar results.
+
+* We explain how a semiring is a good way to talk about implementation freedom,
+    even though we do not think it is a good way to constrain types.
+    We then use the semiring description to explain how implementers
+    can test generic algorithms.
+
+## Support for user-defined complex number types
+
+### `conj` does not have the desired interface
+
+Based on precedence from the BLAS and LAPACK,
+generic linear algebra code that works for both complex and real numbers
+uses the "conjugate transpose" for both cases,
+and intends conjugation to be the identity for real numbers.
+P1673 users may thus want to apply `conjugate_transposed`
+to matrices of arbitrary value types.
+
+The Standard currently offers `conj`
+as the way to compute the conjugate of a number.
+However, there are two issues with `conj`.
+
+1. For arguments of arithmetic type, `conj` returns `complex`.
+    The resulting value type change is mathematically unexpected,
+    and it can hinder use of an optimized BLAS.
+
+2. P1673 users have good reasons to define their own complex number types,
+    but users cannot overload `conj` for these types.
+
+### Why users define their own complex number types
+
+1. `complex<R>` only permits `R` = `float`, `double`, and `long double`.
+
+2. `complex<R>` only has `sizeof(R)` alignment, not `2 * sizeof(R)`.
+
+3. Some C++ extensions cannot use `complex<R>`,
+    because they require annotations on a type's member functions.
+
+Users define their own complex number types for three reasons.
+First, the C++ Standard currently supports `complex<R>`
+only for `R` = `float`, `double`, and `long double`.
+This prevents use of other types, including
+
+* signed integers (the resulting complex numbers
+    represent the *Gaussian integers*);
+
+* "short" low-precision floating-point or fixed-point number types
+    that are critical for performance of machine learning applications;
+
+* extended-precision floating-point types like binary128
+    that can improve the accuracy of floating-point sums,
+    reduce parallel nondeterminism,
+    and make sums less dependent on evaluation order; and
+
+* custom number types such as "bigfloats"
+    (custom arbitrary-precision floating-point types).
+
+Second, the Standard explicitly specifies
+that `complex<R>` has the same alignment as `R[2]`.
+That is, it is aligned to `sizeof(R)`.
+Some systems would give better parallel or vectorized performance
+if complex numbers were aligned to `2 * sizeof(R)`.
+Some C++ extensions define their own complex number types
+partly for this reason.
+Software libraries that use these custom complex number types
+tempt users to alias between `complex<R>` and these custom types,
+which would have the same bit representation except for alignment.
+This has led to crashes or worse in software projects
+that the authors have worked on.
+Third, some C++ extensions cannot use `complex`,
+because they require types' member functions to have special annotations,
+in order to compile code to make use of accelerator hardware.
+
+These issues have led several software libraries and C++ extensions
+to define their own complex number types.
+These include CUDA, Kokkos, and Thrust.
+The SYCL standard is contemplating adding a custom complex number type.
+One of the authors wrote `Kokkos::complex` circa 2014
+to make it possible to build and run Trilinos' linear solvers
+with complex numbers on NVIDIA graphics processing units (GPUs).
+
+### Why users want to "conjugate" matrices of real numbers
+
+It's possible to describe many linear algebra algorithms
+in a way that works for both complex and real numbers,
+by treating conjugation as the identity for real numbers.
+This makes the "conjugate transpose" just the transpose
+for a matrix of real numbers.
+Matlab takes this approach, by defining the single quote operator
+to take the conjugate transpose if its argument is complex,
+and the transpose if its argument is real.
+The Fortran BLAS also supports this,
+by letting users specify the `'Conjugate Transpose'`
+(`TRANSA='C'`) even for real routines like `DGEMM`
+(double-precision general matrix-matrix multiply).
+Krylov subspace methods in Trilinos' Anasazi and Belos packages
+also follow a Matlab-like generic approach.
+
+Even though we think it should be possible to write
+"generic" (real or complex) linear algebra code using `conjugate_transposed`,
+we still need to distinguish between symmetric and Hermitian matrix algorithms.
+This is because symmetric does *not* mean the same thing as Hermitian
+for matrices of complex numbers.
+For example, a matrix whose off-diagonal elements are all `3 + 4i` is symmetric,
+but not Hermitian.  Complex symmetric matrices are useful in practice,
+for example when modeling damped vibrations (Craven 1969).
+
+### Effects of `conj`'s real-to-complex change
+
+The fact that `conj` for arithmetic-type arguments returns `complex`
+may complicate or prevent implementers
+from using an existing optimized BLAS library.
+If the user calls `matrix_product` with matrices all of value type `double`,
+use of the (mathematically harmless) `conjugate_transposed` function
+would make one matrix have value type `complex<double>`.
+Implementations could undo this value type change
+for known layouts and accessors,
+but would need to revert to generic code otherwise.
+
+For example, suppose that a custom real value type `MyReal`
+has arithmetic operators defined to permit
+all needed mixed-type expressions with `double`,
+where `double` times `MyReal` and `MyReal` times `double`
+both "promote" to `MyReal`.
+Users may then call `matrix_product(A, B, C)`
+with `A` having value type `double`,
+`B` having value type `MyReal`,
+and `C` having a value type `MyReal`.
+However, `matrix_product(conjugate_transposed(A), B, C)`
+would not compile,
+due to `complex<decltype(declval<double>() * declval<MyReal>())>`
+not being well formed.
+
+### LEWG feedback on R8 solution
+
+In R8 of this paper,
+we proposed an exposition-only function _`conj-if-needed`_.
+For arithmetic types, it would be the identity function.
+This would fix Issue (1).
+For all other types, it would call `conj`
+through argument-dependent lookup (ADL),
+just like how `iter_swap` calls `swap`.
+This would fix Issue (2).
+However, it would force users who define custom _real_ number types
+to define a trivial `conj` (in their own namespace) for their type.
+The alternative would be to make _`conj-if-needed`_ the identity
+if it could not find `conj` via ADL lookup.
+However, that would cause silently incorrect results
+for users who define a custom complex number type,
+but forget or misspell `conj`.
+
+When reviewing R8, LEWG expressed a preference for a different solution.
+
+1. Temporarily change P1673 to permit
+    use of `conjugated` and `conjugate_transposed`
+    only for value types that are either `complex` or arithmetic types.
+    Add a Note that reminds readers to look out for Steps (2) and (3) below.
+
+2. Write a separate paper which introduces
+    a user-visible customization point,
+    provisionally named `conjugate`.
+    The paper could use any of various proposed
+    library-only customization point mechanisms,
+    such as the customization point objects used by ranges
+    or `tag_invoke`
+    (see <a href="https://wg21.link/p1895r0">P1895R0</a>,
+    with the expectation that LEWG and perhaps also EWG
+    (see e.g., <a href="https://wg21.link/P2547">P2547</a>)
+    may express a preference for a different mechanism.
+
+3. If LEWG accepts the `conjugate` customization point,
+    then change P1673 again to use `conjugate`
+    (thus replacing R8's _`conj-if-needed`_).
+    This would thus reintroduce support for custom complex numbers.
+
+### SG6's response to LEWG's R8 feedback
+
+SG6 small group (there was no quorum) reviewed P1673 on 2022/06/09,
+after LEWG's R8 review on 2022/05/24.
+SG6 small group expressed the following:
+
+* Being able to write `conjugated(A)` or `conjugate_transposed(A)`
+    for a matrix or vector `A` of user-defined types
+    is reasonably integral to the proposal.
+    We generically oppose deferring it based on the hope
+    that we'll be able to specify it in a nicer way in the future,
+    with some new customization point syntax.
+
+* A simple, teachable rule: Do ADL-ONLY lookup
+    (preventing finding `std::conj` for primitive types)
+    for `conj` (as with ranges); if you find something you use it,
+    and if you don't, you do nothing (conjugation is the identity).
+    ("Primitives aren't that special.")
+    Benefit is that custom real types work out of the box.
+
+* The alternative: specify that if users choose to use
+    `conjugated` or `conjugate_transposed` with a user-defined type,
+    then they MUST supply the `conj` ADL-findable thing, else ill-formed.
+    This is a safety mechanism that may not have been considered previously by LEWG.
+    (Make primitives special, to regain safety.
+    The cost is that custom real types need to have a `conj` ADL-findable,
+    if users use `conjugated` or `conjugate_transposed`.)
+
+### Current solution
+
+We have adopted SG6 small group's recommendation,
+with a slight wording modification to make it obvious
+that the conjugate of an arithmetic type
+returns the same type as its input.
+
+We propose an exposition-only function object _`conj-if-needed`_.
+For arithmetic types, it would behave as the identity function.
+If it can call `conj` through ADL-only (unqualified) lookup,
+it does so.  Otherwise, it again would behave as the identity function.
+
+This approach has the following advantages.
+
+1. Most custom number types, noncomplex or complex,
+    will work "out of the box."
+    Custom complex number types would likely
+    already have an ADL-findable `conj` defined,
+    for interface compatibility with `std::complex`.
+
+2. Conjugation will preserve the type of its argument.
+
+3. It uses existing C++ idioms and interfaces for complex numbers.
+
+4. It does not depend on a future customization point syntax
+    or library convention.
+
+## Support for division with noncommutative multiplication
+
+An important feature of this proposal is its support for value types
+that have noncommutative multiplication.
+Examples include
+square matrices with a fixed number of rows and columns,
+and quaternions and their generalizations.
+Most of the algorithms in this proposal
+only add or multiply arbitrary value types,
+so preserving the order of multiplication arguments is straightforward.
+The various triangular solve algorithms are an exception,
+because they need to perform divisions as well.
+
+If multiplication commutes and if a type has division,
+then the division x ÷ y is just x times (the multiplicative inverse of y),
+assuming that the multiplicative inverse of y exists.
+However, if multiplication does not commute,
+"x times (the multiplicative inverse of y)"
+need not equal
+"(the multiplicative inverse of y) times x."
+The C++ binary `operator/` does not give callers
+a way to distinguish between these two cases.
+
+This suggests four ways to express "ordered division."
+
+1. Explicitly divide one by the quotient:
+    `x * (1/y)`, or `(1/y) * x`
+
+2. Like (2), but instead of using literal `1`,
+    get "one" as a `value_type` input to the algorithm:
+    `x * (one/y)`, or `(one/y) * x`
+
+3. `inverse` as a unary callable input to the algorithm:
+    `x * inverse(y)`, or `inverse(y) * x`
+
+4. `divide` as a binary callable input to the algorithm:
+    `divide(x, y)`, or `divide(y, x)`
+
+Both SG6 small group (in its review of this proposal on 2022/06/09)
+and the authors prefer Way (4), the `divide` binary callable input.
+The binary callable would be optional,
+and ordinary binary `operator/` would be used as the default.
+This would imitate existing Standard Library algorithms like `reduce`,
+with its optional `BinaryOp` that defaults to addition.
+For mixed-precision computation,
+users would need to avoid `std::divides`,
+as its two parameters and its return type all have the same types.
+However, the obvious
+`[] (const auto& x, const auto& y) { return x / y; }`
+would work just fine.
+Way (4) also preserves the original rounding behavior
+for types with commutative multiplication.
+
+The main disadvantage of the other approaches
+is that they would change rounding behavior for floating-point types.
+They also require two operations --
+computing an inverse, and multiplication --
+rather than one.
+"Ordered division" may actually be the operation users want,
+and the "inverse" might be just a byproduct.
+This is the case for square matrices,
+where users often "compute an inverse"
+only because they want to solve a linear system.
+Each of the other approaches has its own other disadvantages.
+
+* Way (1) would assume that an overloaded `operator/(int, value_type)` exists,
+    and that the literal `1` behaves like a multiplicative identity.
+    In practice, not all custom number types may have defined
+    mixed arithmetic with `int`.
+
+* Way (2) would complicate the interface.
+    Users might make the mistake of passing in literal `1` (of type `int`)
+    or `1.0` (of type `double`) as the value of one,
+    thus leading to Way (1)'s issues.
+
+* Way (3) would again complicate the interface.
+    Users would be tempted to use `[](const auto& y) { return 1 / y; }`
+    as the inverse function, thus leading back to Way (1)'s issues.
+
+# Future work
+
+Summary:
+
+1. Consider generalizing function parameters to take any type
+    that implements a customization point
+    for getting an `mdspan` viewing its elements.
+    This includes `mdarray` (see P1684).
+
+2. Add batched linear algebra overloads.
+
+## Generalize function parameters
+
+Our functions differ from the C++ Standard algorithms, in that they
+take a concrete type `mdspan` with template parameters, rather
+than any type that satisfies a concept.  We think that the template
+parameters of `mdspan` fully describe the multidimensional
+equivalent of a multipass iterator, and that "conceptification" of
+multidimensional arrays would unnecessarily delay this proposal.
+
+In a future proposal, we may consider generalizing our function's template
+parameters, to permit any type besides `mdspan` that implements
+the `get_mdspan` customization point, as long as the return value of
+`get_mdspan` satisfies the current requirements.  `get_mdspan` would
+return an `mdspan` that views its argument's data.
+
+The `mdarray` class, proposed in <a href="https://wg21.link/p1684">P1684</a>, is the
+container analog of `mdspan`.  It is a new kind of container,
+with the same copy behavior as containers like `vector`.
+It will be possible to get an `mdspan` that views an `mdarray`.
+Previous versions of this proposal included function overloads that
+took `mdarray` directly.  The goals were user convenience, and
+to avoid any potential overhead of conversion to `mdspan`,
+especially for very small matrices and vectors.  In a future revision
+of P1684, `mdarray` will implement a customization point `view`
+(final name yet to be decided),
+that returns an `mdspan` viewing the elements of the `mdarray`.
+This would let users use `mdarray` directly in our functions.
+This customization point approach would also simplify using our functions
+with other matrix and vector types, such as those proposed by P1385.
+Implementations may optionally add direct overloads of our functions
+for `mdarray` or other types.
+This would address any concerns about overhead
+of converting from `mdarray` to `mdspan`.
+
+## Batched linear algebra
+
+We plan to write a separate proposal that will add "batched" versions
+of linear algebra functions to this proposal.  "Batched" linear
+algebra functions solve many independent problems all at once, in a
+single function call.  For discussion, see Section 6.2 of our
+background paper <a href="https://wg21.link/p1417r0">P1417R0</a>.
+Batched interfaces have the following advantages:
+
+* They expose more parallelism and vectorization opportunities for
+    many small linear algebra operations.
+
+* They are useful for many different fields, including machine
+    learning.
+
+* Hardware vendors currently offer both hardware features and
+    optimized software libraries to support batched linear algebra.
+
+* There is an ongoing
+    <a href="http://icl.utk.edu/bblas/">interface standardization effort</a>,
+    in which we participate.
+
+The `mdspan` data structure makes it easy to represent a batch
+of linear algebra objects, and to optimize their data layout.
+
+With few exceptions, the extension of this proposal to support batched
+operations will not require new functions or interface changes.  Only
+the requirements on functions will change.  Output arguments can have
+an additional rank; if so, then the leftmost extent will refer to the
+batch dimension.  Input arguments may also have an additional rank to
+match; if they do not, the function will use ("broadcast") the same
+input argument for all the output arguments in the batch.
+
+# Data structures and utilities borrowed from other proposals
+
+## `mdspan`
+
+This proposal depends on P0009 and follow-on papers
+that were voted into the current C++ Standard draft.
+P0009's main class is `mdspan`, which is a "view"
+(in the sense of `span`) of a multidimensional array.  The rank
+(number of dimensions) is fixed at compile time.  Users may specify
+some dimensions at run time and others at compile time; the type of
+the `mdspan` expresses this.  `mdspan` also has two
+customization points:
+
+* `Layout` expresses the array's memory layout: e.g., row-major (C++
+    style), column-major (Fortran style), or strided.  We use a custom
+    `Layout` later in this paper to implement a "transpose view" of an
+    existing `mdspan`.
+
+* `Accessor` defines the storage handle (`data_handle_type`) stored in
+    the `mdspan`, as well as the reference type returned by its access
+    operator.  This is an extension point for modifying how access
+    happens, for example by using `atomic_ref` to get atomic access to
+    every element.  We use custom `Accessor`s later in this paper to
+    implement "scaled views" and "conjugated views" of an existing
+    `mdspan`.
+
+## New `mdspan` layouts in this proposal
+
+Our proposal uses the layout mapping policy of `mdspan` in order
+to represent different matrix and vector data layouts.
+The current C++ Standard draft includes three layouts:
+`layout_left`, `layout_right`, and `layout_stride`.
+<a href="https://isocpp.org/files/papers/P2642R1.html">P2642R1</a>
+includes `layout_left_padded` and `layout_right_padded`.
+These two layouts represent exactly the data layout assumed by
+the General (GE) matrix type in the BLAS' C and Fortran bindings.
+They have has two advantages:
+
+1. Unlike `layout_left` and `layout_right`, any "submatrix" (subspan
+    of consecutive rows and consecutive columns) of a matrix with
+    `layout_left_padded` resp. `layout_right_padded` layout 
+    also has `layout_left_padded` resp. `layout_right_padded` layout.
+
+2. Unlike `layout_stride`, the two layouts always have
+    compile-time unit stride in one of the matrix's two extents.
+
+BLAS functions call the possibly nonunit stride of the matrix the
+"leading dimension" of that matrix.  For example, a BLAS function
+argument corresponding to the leading dimension of the matrix `A` is
+called `LDA`, for "leading dimension of the matrix A."
+
+This proposal introduces a new layout, `layout_blas_packed`.
+This describes the layout used by the BLAS' Symmetric Packed (SP),
+Hermitian Packed (HP), and Triangular Packed (TP) "types."
+The `layout_blas_packed` class has a "tag" template parameter
+that controls its properties; see below.
+
+We do not include layouts for unpacked "types," such as Symmetric
+(SY), Hermitian (HE), and Triangular (TR).
+Our paper <a href="https://wg21.link/p1674">P1674</a>.
+explains our reasoning.
+In summary: Their actual layout -- the arrangement of
+matrix elements in memory -- is the same as General.  The only
+differences are constraints on what entries of the matrix algorithms
+may access, and assumptions about the matrix's mathematical
+properties.  Trying to express those constraints or assumptions as
+"layouts" or "accessors" violates the spirit (and sometimes the law)
+of `mdspan`.  We address these different matrix types with
+different function names.
+
+The packed matrix "types" do describe actual arrangements of matrix
+elements in memory that are not the same as in General.  This is why
+we provide `layout_blas_packed`.  Note that `layout_blas_packed` is
+the first addition to the existing layouts that is neither always
+unique, nor always strided.
+
+Algorithms cannot be written generically if they permit output
+arguments with nonunique layouts.  Nonunique output arguments require
+specialization of the algorithm to the layout, since there's no way to
+know generically at compile time what indices map to the same matrix
+element.  Thus, we will impose the following rule: Any `mdspan`
+output argument to our functions must always have unique layout
+(`is_always_unique()` is `true`), unless otherwise specified.
+
+Some of our functions explicitly require outputs with specific
+nonunique layouts.  This includes low-rank updates to symmetric or
+Hermitian matrices.
+
+# Acknowledgments
+
+Sandia National Laboratories is a multimission laboratory managed and
+operated by National Technology & Engineering Solutions of Sandia,
+LLC, a wholly owned subsidiary of Honeywell International, Inc., for
+the U.S. Department of Energy’s National Nuclear Security
+Administration under contract DE-NA0003525.
+
+Special thanks to Bob Steagall and Guy Davidson for boldly leading the
+charge to add linear algebra to the C++ Standard Library, and for many
+fruitful discussions.  Thanks also to Andrew Lumsdaine for his
+pioneering efforts and history lessons.
+In addition, I very much appreciate feedback from Davis Herring
+on constraints wording.
+
+# References
+
+## References by coathors
+
+* G. Ballard, E. Carson, J. Demmel, M. Hoemmen, N. Knight, and
+    O. Schwartz,
+    ["Communication lower bounds and optimal algorithms for numerical linear algebra,"](https://doi.org/10.1017/S0962492914000038),
+    *Acta Numerica*, Vol. 23, May 2014, pp. 1-155.
+
+* C. Trott, D. S. Hollman, D. Lebrun-Grande, M. Hoemmen, D. Sunderland,
+    H. C. Edwards, B. A. Lelbach, M. Bianco, B. Sander, A. Iliopoulos,
+    J. Michopoulos, and N. Liber,
+    "`mdspan`," <a href="https://wg21.link/p0009r16">P0009R16</a>,
+    Mar. 2022.  The authors anticipate release of R17 in the next mailing.
+
+* G. Davidson, M. Hoemmen, D. S. Hollman, B. Steagall, and C. Trott,
+    <a href="https://wg21.link/p1891r0">P1891R0</a>, Oct. 2019.
+
+* M. Hoemmen, D. S. Hollman, and C. Trott, "Evolving a Standard C++
+    Linear Algebra Library from the BLAS,"
+    <a href="https://wg21.link/p1674r2">P1674R2</a>,
+    May 2022.
+
+* M. Hoemmen, J. Badwaik, M. Brucher, A. Iliopoulos, and
+    J. Michopoulos, "Historical lessons for C++ linear algebra library
+    standardization," <a href="https://wg21.link/p1417r0">P1417R0</a>,
+    Jan. 2019.
+
+* M. Hoemmen, D. S. Hollman, C. Jabot, I. Muerte, and C. Trott,
+    "Multidimensional subscript operator,"
+    <a href="https://wg21.link/p2128r6">P2128R6</a>, Sep. 2021.
+
+* C. Trott, D. S. Hollman, M. Hoemmen, and D. Sunderland,
+    "`mdarray`: An Owning Multidimensional Array Analog of `mdspan`",
+    <a href="https://wg21.link/p1684r1">P1684R1</a>,
+    Mar. 2022.
+
+* D. S. Hollman, C. Kohlhoff, B. A. Lelbach, J. Hoberock, G. Brown, and
+    M. Dominiak, "A General Property Customization Mechanism,"
+    <a href="https://wg21.link/p1393r0">P1393R0</a>, Jan. 2019.
+
+## Other references
+
+* E. Anderson,
+    "Algorithm 978: Safe Scaling in the Level 1 BLAS,"
+    *ACM Transactions on Mathematical Software*,
+    Vol. 44, pp. 1-28, 2017.
+
+* ["Basic Linear Algebra Subprograms Technical (BLAST) Forum Standard,"](http://netlib.org/blas/blast-forum/blas-report.pdf)
+    *International Journal of High Performance Applications and Supercomputing*,
+    Vol. 16, No. 1, Spring 2002.
+
+* L. S. Blackford, J. Demmel, J. Dongarra, I. Duff, S. Hammarling,
+    G. Henry, M. Heroux, L. Kaufman, A. Lumsdaine, A. Petitet, R. Pozo,
+    K. Remington, and R. C. Whaley,
+    ["An updated set of basic linear algebra subprograms (BLAS),"](https://doi.org/10.1145/567806.567807)
+    *ACM Transactions on Mathematical Software*,
+    Vol. 28, No. 2, Jun. 2002, pp. 135-151.
+
+* J. L. Blue,
+    "A Portable Fortran Program to Find the Euclidean Norm of a Vector,"
+    *ACM Transactions on Mathematical Software*, Vol. 4, pp. 15-23, 1978.
+
+* B. D. Craven,
+    <a href="https://doi.org/10.1017/S1446788700007588">"Complex symmetric matrices"</a>,
+    *Journal of the Australian Mathematical Society*,
+    Vol. 10, No. 3-4, Nov. 1969, pp. 341--354.
+
+* E. Chow and A. Patel,
+    "Fine-Grained Parallel Incomplete LU Factorization",
+    *SIAM J. Sci. Comput.*, Vol. 37, No. 2, C169-C193, 2015.
+
+* G. Davidson and B. Steagall, "A proposal to add linear algebra
+    support to the C++ standard library,"
+    <a href="https://wg21.link/p1385r6">P1385R6</a>, Mar. 2020.
+
+* B. Dawes, H. Hinnant, B. Stroustrup, D. Vandevoorde, and M. Wong,
+    "Direction for ISO C++," <a href="https://wg21.link/p0939r4">P0939R4</a>,
+    Oct. 2019.
+
+* J. Demmel, "Applied Numerical Linear Algebra,"
+    Society for Industrial and Applied Mathematics,
+    Philadelphia, PA, 1997,
+    ISBN 0-89871-389-7.
+
+* J. Demmel, I. Dumitriu, and O. Holtz,
+    "Fast linear algebra is stable,"
+    *Numerische Mathematik* 108 (59-91), 2007.
+
+* J. Demmel and H. D. Nguyen,
+    "Fast Reproducible Floating-Point Summation,"
+    2013 IEEE 21st Symposium on Computer Arithmetic,
+    2013, pp. 163-172, doi: 10.1109/ARITH.2013.9.
+
+* J. Dongarra, J. Du Croz, S. Hammarling, and I. Duff,
+    <a href="https://dl.acm.org/doi/10.1145/77626.79170">"A set of level 3 basic linear algebra subprograms,"</a>
+    *ACM Transactions on Mathematical Software*,
+    Vol. 16, No. 1, pp. 1-17, Mar. 1990.
+
+* J. Dongarra, R. Pozo, and D. Walker, "LAPACK++: A Design Overview of
+    Object-Oriented Extensions for High Performance Linear Algebra," in
+    Proceedings of Supercomputing '93, IEEE Computer Society Press,
+    1993, pp. 162-171.
+
+* M. Gates, P. Luszczek, A. Abdelfattah, J. Kurzak, J. Dongarra,
+    K. Arturov, C. Cecka, and C. Freitag,
+    <a href="https://www.icl.utk.edu/files/publications/2017/icl-utk-1031-2017.pdf">"C++ API for BLAS and LAPACK,"</a>
+    SLATE Working Notes, Innovative Computing Laboratory,
+    University of Tennessee Knoxville, Feb. 2018.
+
+* K. Goto and R. A. van de Geijn,
+    ["Anatomy of high-performance matrix multiplication,"](https://doi.org/10.1145/1356052.1356053),
+    *ACM Transactions on Mathematical Software* (TOMS),
+    Vol. 34, No. 3, May 2008.
+
+* J. Hoberock, "Integrating Executors with Parallel Algorithms,"
+    <a href="https://wg21.link/p1019r2">P1019R2</a>, Jan. 2019.
+
+* N. A. Josuttis, "The C++ Standard Library: A Tutorial and Reference,"
+    Addison-Wesley, 1999.
+
+* M. Kretz, "Data-Parallel Vector Types & Operations,"
+    <a href="https://wg21.link/p0214r9">P0214R9</a>, Mar. 2018.
+
+* A. J. Perlis, "Epigrams on programming,"
+    SIGPLAN Notices, Vol. 17, No. 9, pp. 7-13, 1982.
+
+* G. Strang,
+    "Introduction to Linear Algebra," 5th Edition,
+    Wellesley - Cambridge Press, 2016, ISBN 978-0-9802327-7-6, x+574 pages.
+
+* D. Vandevoorde and N. A. Josuttis,
+    "C++ Templates: The Complete Guide," Addison-Wesley Professional, 2003.
+
+# Wording
+
+> Text in blockquotes is not proposed wording, but rather instructions for generating proposed wording.
+> The � character is used to denote a placeholder section number which the editor shall determine.
+> First, apply all wording from P2642R1.
+> (This proposal is a "rebase" atop the changes proposed by P2642R1.)
+> At the end of Table � ("Numerics library summary") in *[numerics.general]*, add the following: [linalg], Linear algebra, `<linalg>`.
+> At the end of *[numerics]*, add all the material that follows.
+
+## Header `<linalg>` synopsis [linalg.syn]
+
+```c++
+namespace std::linalg {
+// [linalg.tags.order], storage order tags
+struct column_major_t;
+inline constexpr column_major_t column_major;
+struct row_major_t;
+inline constexpr row_major_t row_major;
+
+// [linalg.tags.triangle], triangle tags
+struct upper_triangle_t;
+inline constexpr upper_triangle_t upper_triangle;
+struct lower_triangle_t;
+inline constexpr lower_triangle_t lower_triangle;
+
+// [linalg.tags.diagonal], diagonal tags
+struct implicit_unit_diagonal_t;
+inline constexpr implicit_unit_diagonal_t implicit_unit_diagonal;
+struct explicit_diagonal_t;
+inline constexpr explicit_diagonal_t explicit_diagonal;
+
+// [linalg.layouts.packed], class template layout_blas_packed
+template<class Triangle,
+         class StorageOrder>
+class layout_blas_packed;
+
+// [linalg.scaled.conj], exposition-only function object <it>conj-if-needed</it>
+
+/* see-below */ <it>conj-if-needed</it>;
+
+// [linalg.scaled.base], exposition-only function and class templates
+
+class proxy_reference_base; // <it>exposition only</it>
+
+template<class Reference, class Value, class Derived>
+class proxy_reference; // <it>exposition only</it>
+
+// [linalg.scaled.accessor_scaled], class template accessor_scaled
+
+template<class ScalingFactor,
+         class Accessor>
+class accessor_scaled;
+
+// [linalg.scaled.scaled], scaled in-place transformation
+template<class ScalingFactor,
+         class ElementType,
+         class Extents,
+         class Layout,
+         class Accessor>
+/* see-below */
+constexpr scaled(
+  ScalingFactor scaling_factor,
+  const mdspan<ElementType, Extents, Layout, Accessor>& x);
+
+// [linalg.conj.accessor_conjugate], class template accessor_conjugate
+template<class Accessor>
+class accessor_conjugate;
+
+// [linalg.conj.conjugated], conjugated in-place transformation
+template<class ElementType,
+         class Extents,
+         class Layout,
+         class Accessor>
+constexpr auto conjugated(
+  mdspan<ElementType, Extents, Layout, Accessor> a);
+
+// [linalg.transp.layout_transpose], class template layout_transpose
+template<class Layout>
+class layout_transpose;
+
+// [linalg.transp.transposed], transposed in-place transformation
+template<class ElementType,
+         class Extents,
+         class Layout,
+         class Accessor>
+constexpr auto transposed(
+  mdspan<ElementType, Extents, Layout, Accessor> a);
+
+// [linalg.conj_transp],
+// conjugated transposed in-place transformation
+template<class ElementType,
+         class Extents,
+         class Layout,
+         class Accessor>
+constexpr auto conjugate_transposed(
+  mdspan<ElementType, Extents, Layout, Accessor> a);
+
+// [linalg.algs.blas1.givens.lartg], compute Givens rotation
+template<class Real>
+void givens_rotation_setup(const Real a,
+                           const Real b,
+                           Real& c,
+                           Real& s,
+                           Real& r);
+template<class Real>
+void givens_rotation_setup(const complex<Real>& a,
+                           const complex<Real>& b,
+                           Real& c,
+                           complex<Real>& s,
+                           complex<Real>& r);
+
+// [linalg.algs.blas1.givens.rot], apply computed Givens rotation
+template<class inout_vector_1_t,
+         class inout_vector_2_t,
+         class Real>
+void givens_rotation_apply(
+  inout_vector_1_t x,
+  inout_vector_2_t y,
+  const Real c,
+  const Real s);
+template<class ExecutionPolicy,
+         class inout_vector_1_t,
+         class inout_vector_2_t,
+         class Real>
+void givens_rotation_apply(
+  ExecutionPolicy&& exec,
+  inout_vector_1_t x,
+  inout_vector_2_t y,
+  const Real c,
+  const Real s);
+template<class inout_vector_1_t,
+         class inout_vector_2_t,
+         class Real>
+void givens_rotation_apply(
+  inout_vector_1_t x,
+  inout_vector_2_t y,
+  const Real c,
+  const complex<Real> s);
+template<class ExecutionPolicy,
+         class inout_vector_1_t,
+         class inout_vector_2_t,
+         class Real>
+void givens_rotation_apply(
+  ExecutionPolicy&& exec,
+  inout_vector_1_t x,
+  inout_vector_2_t y,
+  const Real c,
+  const complex<Real> s);
+}
+
+// [linalg.algs.blas1.swap], swap elements
+template<class inout_object_1_t,
+         class inout_object_2_t>
+void swap_elements(inout_object_1_t x,
+                   inout_object_2_t y);
+template<class ExecutionPolicy,
+         class inout_object_1_t,
+         class inout_object_2_t>
+void swap_elements(ExecutionPolicy&& exec,
+                   inout_object_1_t x,
+                   inout_object_2_t y);
+
+// [linalg.algs.blas1.scal], multiply elements by scalar
+template<class Scalar,
+         class inout_object_t>
+void scale(const Scalar alpha,
+           inout_object_t obj);
+template<class ExecutionPolicy,
+         class Scalar,
+         class inout_object_t>
+void scale(ExecutionPolicy&& exec,
+           const Scalar alpha,
+           inout_object_t obj);
+
+// [linalg.algs.blas1.copy], copy elements
+template<class in_object_t,
+         class out_object_t>
+void copy(in_object_t x,
+          out_object_t y);
+template<class ExecutionPolicy,
+         class in_object_t,
+         class out_object_t>
+void copy(ExecutionPolicy&& exec,
+          in_object_t x,
+          out_object_t y);
+
+// [linalg.algs.blas1.add], add elementwise
+template<class in_object_1_t,
+         class in_object_2_t,
+         class out_object_t>
+void add(in_object_1_t x,
+         in_object_2_t y,
+         out_object_t z);
+template<class ExecutionPolicy,
+         class in_object_1_t,
+         class in_object_2_t,
+         class out_object_t>
+void add(ExecutionPolicy&& exec,
+         in_object_1_t x,
+         in_object_2_t y,
+         out_object_t z);
+
+// [linalg.algs.blas1.dot],
+// dot product of two vectors
+
+// [linalg.algs.blas1.dot.dotu],
+// nonconjugated dot product of two vectors
+template<class in_vector_1_t,
+         class in_vector_2_t,
+         class T>
+T dot(in_vector_1_t v1,
+      in_vector_2_t v2,
+      T init);
+template<class ExecutionPolicy,
+         class in_vector_1_t,
+         class in_vector_2_t,
+         class T>
+T dot(ExecutionPolicy&& exec,
+      in_vector_1_t v1,
+      in_vector_2_t v2,
+      T init);
+template<class in_vector_1_t,
+         class in_vector_2_t>
+auto dot(in_vector_1_t v1,
+         in_vector_2_t v2) -> /* see-below */;
+template<class ExecutionPolicy,
+         class in_vector_1_t,
+         class in_vector_2_t>
+auto dot(ExecutionPolicy&& exec,
+         in_vector_1_t v1,
+         in_vector_2_t v2) -> /* see-below */;
+
+// [linalg.algs.blas1.dot.dotc],
+// conjugated dot product of two vectors
+template<class in_vector_1_t,
+         class in_vector_2_t,
+         class T>
+T dotc(in_vector_1_t v1,
+       in_vector_2_t v2,
+       T init);
+template<class ExecutionPolicy,
+         class in_vector_1_t,
+         class in_vector_2_t,
+         class T>
+T dotc(ExecutionPolicy&& exec,
+       in_vector_1_t v1,
+       in_vector_2_t v2,
+       T init);
+template<class in_vector_1_t,
+         class in_vector_2_t>
+auto dotc(in_vector_1_t v1,
+          in_vector_2_t v2) -> /* see-below */;
+template<class ExecutionPolicy,
+         class in_vector_1_t,
+         class in_vector_2_t>
+auto dotc(ExecutionPolicy&& exec,
+          in_vector_1_t v1,
+          in_vector_2_t v2) -> /* see-below */;
+
+// [linalg.algs.blas1.ssq],
+// Scaled sum of squares of a vector's elements
+template<class T>
+struct sum_of_squares_result {
+  T scaling_factor;
+  T scaled_sum_of_squares;
+};
+template<class in_vector_t,
+         class T>
+sum_of_squares_result<T> vector_sum_of_squares(
+  in_vector_t v,
+  sum_of_squares_result<T> init);
+sum_of_squares_result<T> vector_sum_of_squares(
+  ExecutionPolicy&& exec,
+  in_vector_t v,
+  sum_of_squares_result<T> init);
+
+// [linalg.algs.blas1.nrm2],
+// Euclidean norm of a vector
+template<class in_vector_t,
+         class T>
+T vector_norm2(in_vector_t v,
+               T init);
+template<class ExecutionPolicy,
+         class in_vector_t,
+         class T>
+T vector_norm2(ExecutionPolicy&& exec,
+               in_vector_t v,
+               T init);
+template<class in_vector_t>
+auto vector_norm2(in_vector_t v) -> /* see-below */;
+template<class ExecutionPolicy,
+         class in_vector_t>
+auto vector_norm2(ExecutionPolicy&& exec,
+                  in_vector_t v) -> /* see-below */;
+
+// [linalg.algs.blas1.asum],
+// sum of absolute values of vector elements
+template<class in_vector_t,
+         class T>
+T vector_abs_sum(in_vector_t v,
+                 T init);
+template<class ExecutionPolicy,
+         class in_vector_t,
+         class T>
+T vector_abs_sum(ExecutionPolicy&& exec,
+                 in_vector_t v,
+                 T init);
+template<class in_vector_t>
+auto vector_abs_sum(in_vector_t v) -> /* see-below */;
+template<class ExecutionPolicy,
+         class in_vector_t>
+auto vector_abs_sum(ExecutionPolicy&& exec,
+                    in_vector_t v) -> /* see-below */;
+
+// [linalg.algs.blas1.iamax],
+// index of maximum absolute value of vector elements
+template<class in_vector_t>
+typename in_vector_t::extents_type idx_abs_max(in_vector_t v);
+template<class ExecutionPolicy,
+         class in_vector_t>
+typename in_vector_t::extents_type idx_abs_max(
+  ExecutionPolicy&& exec,
+  in_vector_t v);
+
+// [linalg.algs.blas1.matfrobnorm],
+// Frobenius norm of a matrix
+template<class in_matrix_t,
+         class T>
+T matrix_frob_norm(
+  in_matrix_t A,
+  T init);
+template<class ExecutionPolicy,
+         class in_matrix_t,
+         class T>
+T matrix_frob_norm(
+  ExecutionPolicy&& exec,
+  in_matrix_t A,
+  T init);
+template<class in_matrix_t>
+auto matrix_frob_norm(
+  in_matrix_t A) -> /* see-below */;
+template<class ExecutionPolicy,
+         class in_matrix_t>
+auto matrix_frob_norm(
+  ExecutionPolicy&& exec,
+  in_matrix_t A) -> /* see-below */;
+
+// [linalg.algs.blas1.matonenorm],
+// One norm of a matrix
+template<class in_matrix_t,
+         class T>
+T matrix_one_norm(
+  in_matrix_t A,
+  T init);
+template<class ExecutionPolicy,
+         class in_matrix_t,
+         class T>
+T matrix_one_norm(
+  ExecutionPolicy&& exec,
+  in_matrix_t A,
+  T init);
+template<class in_matrix_t>
+auto matrix_one_norm(
+  in_matrix_t A) -> /* see-below */;
+template<class ExecutionPolicy,
+         class in_matrix_t>
+auto matrix_one_norm(
+  ExecutionPolicy&& exec,
+  in_matrix_t A) -> /* see-below */;
+
+// [linalg.algs.blas1.matinfnorm],
+// Infinity norm of a matrix
+template<class in_matrix_t,
+         class T>
+T matrix_inf_norm(
+  in_matrix_t A,
+  T init);
+template<class ExecutionPolicy,
+         class in_matrix_t,
+         class T>
+T matrix_inf_norm(
+  ExecutionPolicy&& exec,
+  in_matrix_t A,
+  T init);
+template<class in_matrix_t>
+auto matrix_inf_norm(
+  in_matrix_t A) -> /* see-below */;
+template<class ExecutionPolicy,
+         class in_matrix_t>
+auto matrix_inf_norm(
+  ExecutionPolicy&& exec,
+  in_matrix_t A) -> /* see-below */;
+
+// [linalg.algs.blas2.gemv],
+// general matrix-vector product
+template<class in_vector_t,
+         class in_matrix_t,
+         class out_vector_t>
+void matrix_vector_product(in_matrix_t A,
+                           in_vector_t x,
+                           out_vector_t y);
+template<class ExecutionPolicy,
+         class in_vector_t,
+         class in_matrix_t,
+         class out_vector_t>
+void matrix_vector_product(ExecutionPolicy&& exec,
+                           in_matrix_t A,
+                           in_vector_t x,
+                           out_vector_t y);
+template<class in_vector_1_t,
+         class in_matrix_t,
+         class in_vector_2_t,
+         class out_vector_t>
+void matrix_vector_product(in_matrix_t A,
+                           in_vector_1_t x,
+                           in_vector_2_t y,
+                           out_vector_t z);
+template<class ExecutionPolicy,
+         class in_vector_1_t,
+         class in_matrix_t,
+         class in_vector_2_t,
+         class out_vector_t>
+void matrix_vector_product(ExecutionPolicy&& exec,
+                           in_matrix_t A,
+                           in_vector_1_t x,
+                           in_vector_2_t y,
+                           out_vector_t z);
+
+// [linalg.algs.blas2.symv],
+// symmetric matrix-vector product
+template<class in_matrix_t,
+         class Triangle,
+         class in_vector_t,
+         class out_vector_t>
+void symmetric_matrix_vector_product(in_matrix_t A,
+                                     Triangle t,
+                                     in_vector_t x,
+                                     out_vector_t y);
+template<class ExecutionPolicy,
+         class in_matrix_t,
+         class Triangle,
+         class in_vector_t,
+         class out_vector_t>
+void symmetric_matrix_vector_product(ExecutionPolicy&& exec,
+                                     in_matrix_t A,
+                                     Triangle t,
+                                     in_vector_t x,
+                                     out_vector_t y);
+template<class in_matrix_t,
+         class Triangle,
+         class in_vector_1_t,
+         class in_vector_2_t,
+         class out_vector_t>
+void symmetric_matrix_vector_product(
+  in_matrix_t A,
+  Triangle t,
+  in_vector_1_t x,
+  in_vector_2_t y,
+  out_vector_t z);
+
+template<class ExecutionPolicy,
+         class in_matrix_t,
+         class Triangle,
+         class in_vector_1_t,
+         class in_vector_2_t,
+         class out_vector_t>
+void symmetric_matrix_vector_product(
+  ExecutionPolicy&& exec,
+  in_matrix_t A,
+  Triangle t,
+  in_vector_1_t x,
+  in_vector_2_t y,
+  out_vector_t z);
+
+// [linalg.algs.blas2.hemv],
+// Hermitian matrix-vector product
+template<class in_matrix_t,
+         class Triangle,
+         class in_vector_t,
+         class out_vector_t>
+void hermitian_matrix_vector_product(in_matrix_t A,
+                                     Triangle t,
+                                     in_vector_t x,
+                                     out_vector_t y);
+template<class ExecutionPolicy,
+         class in_matrix_t,
+         class Triangle,
+         class in_vector_t,
+         class out_vector_t>
+void hermitian_matrix_vector_product(ExecutionPolicy&& exec,
+                                     in_matrix_t A,
+                                     Triangle t,
+                                     in_vector_t x,
+                                     out_vector_t y);
+template<class in_matrix_t,
+         class Triangle,
+         class in_vector_1_t,
+         class in_vector_2_t,
+         class out_vector_t>
+void hermitian_matrix_vector_product(in_matrix_t A,
+                                     Triangle t,
+                                     in_vector_1_t x,
+                                     in_vector_2_t y,
+                                     out_vector_t z);
+
+template<class ExecutionPolicy,
+         class in_matrix_t,
+         class Triangle,
+         class in_vector_1_t,
+         class in_vector_2_t,
+         class out_vector_t>
+void hermitian_matrix_vector_product(ExecutionPolicy&& exec,
+                                     in_matrix_t A,
+                                     Triangle t,
+                                     in_vector_1_t x,
+                                     in_vector_2_t y,
+                                     out_vector_t z);
+
+// [linalg.algs.blas2.trmv],
+// Triangular matrix-vector product
+
+// [linalg.algs.blas2.trmv.ov],
+// Overwriting triangular matrix-vector product
+template<class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_vector_t,
+         class out_vector_t>
+void triangular_matrix_vector_product(
+  in_matrix_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_vector_t x,
+  out_vector_t y);
+template<class ExecutionPolicy,
+         class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_vector_t,
+         class out_vector_t>
+void triangular_matrix_vector_product(
+  ExecutionPolicy&& exec,
+  in_matrix_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_vector_t x,
+  out_vector_t y);
+
+// [linalg.algs.blas2.trmv.in-place],
+// In-place triangular matrix-vector product
+template<class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class inout_vector_t>
+void triangular_matrix_vector_product(
+  in_matrix_t A,
+  Triangle t,
+  DiagonalStorage d,
+  inout_vector_t y);
+template<class ExecutionPolicy,
+         class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class inout_vector_t>
+void triangular_matrix_vector_product(
+  ExecutionPolicy&& exec,
+  in_matrix_t A,
+  Triangle t,
+  DiagonalStorage d,
+  inout_vector_t y);
+
+// [linalg.algs.blas2.trmv.up],
+// Updating triangular matrix-vector product
+template<class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_vector_1_t,
+         class in_vector_2_t,
+         class out_vector_t>
+void triangular_matrix_vector_product(in_matrix_t A,
+                                      Triangle t,
+                                      DiagonalStorage d,
+                                      in_vector_1_t x,
+                                      in_vector_2_t y,
+                                      out_vector_t z);
+template<class ExecutionPolicy,
+         class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_vector_1_t,
+         class in_vector_2_t,
+         class out_vector_t>
+void triangular_matrix_vector_product(ExecutionPolicy&& exec,
+                                      in_matrix_t A,
+                                      Triangle t,
+                                      DiagonalStorage d,
+                                      in_vector_1_t x,
+                                      in_vector_2_t y,
+                                      out_vector_t z);
+
+// [linalg.algs.blas2.trsv],
+// Solve a triangular linear system
+
+// [linalg.algs.blas2.trsv.not-in-place],
+// Solve a triangular linear system, not in place
+template<class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_vector_t,
+         class out_vector_t,
+         class BinaryDivideOp>
+void triangular_matrix_vector_solve(
+  in_matrix_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_vector_t b,
+  out_vector_t x,
+  BinaryDivideOp divide);
+template<class ExecutionPolicy,
+         class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_vector_t,
+         class out_vector_t,
+         class BinaryDivideOp>
+void triangular_matrix_vector_solve(
+  ExecutionPolicy&& exec,
+  in_matrix_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_vector_t b,
+  out_vector_t x,
+  BinaryDivideOp divide);
+template<class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_vector_t,
+         class out_vector_t>
+void triangular_matrix_vector_solve(
+  in_matrix_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_vector_t b,
+  out_vector_t x);
+template<class ExecutionPolicy,
+         class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_vector_t,
+         class out_vector_t>
+void triangular_matrix_vector_solve(
+  ExecutionPolicy&& exec,
+  in_matrix_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_vector_t b,
+  out_vector_t x);
+
+// [linalg.algs.blas2.trsv.in-place],
+// Solve a triangular linear system, in place
+template<class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class inout_vector_t,
+         class BinaryDivideOp>
+void triangular_matrix_vector_solve(
+  in_matrix_t A,
+  Triangle t,
+  DiagonalStorage d,
+  inout_vector_t b,
+  BinaryDivideOp divide);
+template<class ExecutionPolicy,
+         class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class inout_vector_t,
+         class BinaryDivideOp>
+void triangular_matrix_vector_solve(
+  ExecutionPolicy&& exec,
+  in_matrix_t A,
+  Triangle t,
+  DiagonalStorage d,
+  inout_vector_t b,
+  BinaryDivideOp divide);
+template<class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class inout_vector_t>
+void triangular_matrix_vector_solve(
+  in_matrix_t A,
+  Triangle t,
+  DiagonalStorage d,
+  inout_vector_t b);
+template<class ExecutionPolicy,
+         class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class inout_vector_t>
+void triangular_matrix_vector_solve(
+  ExecutionPolicy&& exec,
+  in_matrix_t A,
+  Triangle t,
+  DiagonalStorage d,
+  inout_vector_t b);
+
+// [linalg.algs.blas2.rank1.geru],
+// nonconjugated rank-1 matrix update
+template<class in_vector_1_t,
+         class in_vector_2_t,
+         class inout_matrix_t>
+void matrix_rank_1_update(
+  in_vector_1_t x,
+  in_vector_2_t y,
+  inout_matrix_t A);
+template<class ExecutionPolicy,
+         class in_vector_1_t,
+         class in_vector_2_t,
+         class inout_matrix_t>
+void matrix_rank_1_update(
+  ExecutionPolicy&& exec,
+  in_vector_1_t x,
+  in_vector_2_t y,
+  inout_matrix_t A);
+
+// [linalg.algs.blas2.rank1.gerc],
+// conjugated rank-1 matrix update
+template<class in_vector_1_t,
+         class in_vector_2_t,
+         class inout_matrix_t>
+void matrix_rank_1_update_c(
+  in_vector_1_t x,
+  in_vector_2_t y,
+  inout_matrix_t A);
+template<class ExecutionPolicy,
+         class in_vector_1_t,
+         class in_vector_2_t,
+         class inout_matrix_t>
+void matrix_rank_1_update_c(
+  ExecutionPolicy&& exec,
+  in_vector_1_t x,
+  in_vector_2_t y,
+  inout_matrix_t A);
+
+// [linalg.algs.blas2.rank1.syr],
+// symmetric rank-1 matrix update
+template<class in_vector_t,
+         class inout_matrix_t,
+         class Triangle>
+void symmetric_matrix_rank_1_update(
+  in_vector_t x,
+  inout_matrix_t A,
+  Triangle t);
+template<class ExecutionPolicy,
+         class in_vector_t,
+         class inout_matrix_t,
+         class Triangle>
+void symmetric_matrix_rank_1_update(
+  ExecutionPolicy&& exec,
+  in_vector_t x,
+  inout_matrix_t A,
+  Triangle t);
+template<class T,
+         class in_vector_t,
+         class inout_matrix_t,
+         class Triangle>
+void symmetric_matrix_rank_1_update(
+  T alpha,
+  in_vector_t x,
+  inout_matrix_t A,
+  Triangle t);
+template<class ExecutionPolicy,
+         class T,
+         class in_vector_t,
+         class inout_matrix_t,
+         class Triangle>
+void symmetric_matrix_rank_1_update(
+  ExecutionPolicy&& exec,
+  T alpha,
+  in_vector_t x,
+  inout_matrix_t A,
+  Triangle t);
+
+// [linalg.algs.blas2.rank1.her],
+// Hermitian rank-1 matrix update
+template<class in_vector_t,
+         class inout_matrix_t,
+         class Triangle>
+void hermitian_matrix_rank_1_update(
+  in_vector_t x,
+  inout_matrix_t A,
+  Triangle t);
+template<class ExecutionPolicy,
+         class in_vector_t,
+         class inout_matrix_t,
+         class Triangle>
+void hermitian_matrix_rank_1_update(
+  ExecutionPolicy&& exec,
+  in_vector_t x,
+  inout_matrix_t A,
+  Triangle t);
+template<class T,
+         class in_vector_t,
+         class inout_matrix_t,
+         class Triangle>
+void hermitian_matrix_rank_1_update(
+  T alpha,
+  in_vector_t x,
+  inout_matrix_t A,
+  Triangle t);
+template<class ExecutionPolicy,
+         class T,
+         class in_vector_t,
+         class inout_matrix_t,
+         class Triangle>
+void hermitian_matrix_rank_1_update(
+  ExecutionPolicy&& exec,
+  T alpha,
+  in_vector_t x,
+  inout_matrix_t A,
+  Triangle t);
+
+// [linalg.algs.blas2.rank2.syr2],
+// symmetric rank-2 matrix update
+template<class in_vector_1_t,
+         class in_vector_2_t,
+         class inout_matrix_t,
+         class Triangle>
+void symmetric_matrix_rank_2_update(
+  in_vector_1_t x,
+  in_vector_2_t y,
+  inout_matrix_t A,
+  Triangle t);
+template<class ExecutionPolicy,
+         class in_vector_1_t,
+         class in_vector_2_t,
+         class inout_matrix_t,
+         class Triangle>
+void symmetric_matrix_rank_2_update(
+  ExecutionPolicy&& exec,
+  in_vector_1_t x,
+  in_vector_2_t y,
+  inout_matrix_t A,
+  Triangle t);
+
+// [linalg.algs.blas2.rank2.her2],
+// Hermitian rank-2 matrix update
+template<class in_vector_1_t,
+         class in_vector_2_t,
+         class inout_matrix_t,
+         class Triangle>
+void hermitian_matrix_rank_2_update(
+  in_vector_1_t x,
+  in_vector_2_t y,
+  inout_matrix_t A,
+  Triangle t);
+template<class ExecutionPolicy,
+         class in_vector_1_t,
+         class in_vector_2_t,
+         class inout_matrix_t,
+         class Triangle>
+void hermitian_matrix_rank_2_update(
+  ExecutionPolicy&& exec,
+  in_vector_1_t x,
+  in_vector_2_t y,
+  inout_matrix_t A,
+  Triangle t);
+
+// [linalg.algs.blas3.gemm],
+// general matrix-matrix product
+template<class in_matrix_1_t,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void matrix_product(in_matrix_1_t A,
+                    in_matrix_2_t B,
+                    out_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void matrix_product(ExecutionPolicy&& exec,
+                    in_matrix_1_t A,
+                    in_matrix_2_t B,
+                    out_matrix_t C);
+template<class in_matrix_1_t,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void matrix_product(in_matrix_1_t A,
+                    in_matrix_2_t B,
+                    in_matrix_3_t E,
+                    out_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void matrix_product(ExecutionPolicy&& exec,
+                    in_matrix_1_t A,
+                    in_matrix_2_t B,
+                    in_matrix_3_t E,
+                    out_matrix_t C);
+
+// [linalg.algs.blas3.symm],
+// symmetric matrix-matrix product
+
+// [linalg.algs.blas3.symm.ov.left],
+// overwriting symmetric matrix-matrix left product
+template<class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void symmetric_matrix_left_product(
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  out_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void symmetric_matrix_left_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  out_matrix_t C);
+
+// [linalg.algs.blas3.symm.ov.right],
+// overwriting symmetric matrix-matrix right product
+template<class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void symmetric_matrix_right_product(
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  out_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void symmetric_matrix_right_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  out_matrix_t C);
+
+// [linalg.algs.blas3.symm.up.left],
+// updating symmetric matrix-matrix left product
+template<class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void symmetric_matrix_left_product(
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void symmetric_matrix_left_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+
+// [linalg.algs.blas3.symm.up.right],
+// updating symmetric matrix-matrix right product
+template<class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void symmetric_matrix_right_product(
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void symmetric_matrix_right_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+
+// [linalg.algs.blas3.hemm],
+// Hermitian matrix-matrix product
+
+// [linalg.algs.blas3.hemm.ov.left],
+// overwriting Hermitian matrix-matrix left product
+template<class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void hermitian_matrix_left_product(
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  out_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void hermitian_matrix_left_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  out_matrix_t C);
+
+// [linalg.algs.blas3.hemm.ov.right],
+// overwriting Hermitian matrix-matrix right product
+template<class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void hermitian_matrix_right_product(
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  out_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void hermitian_matrix_right_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  out_matrix_t C);
+
+// [linalg.algs.blas3.hemm.up.left],
+// updating Hermitian matrix-matrix left product
+template<class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void hermitian_matrix_left_product(
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void hermitian_matrix_left_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+
+// [linalg.algs.blas3.hemm.up.right],
+// updating Hermitian matrix-matrix right product
+template<class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void hermitian_matrix_right_product(
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void hermitian_matrix_right_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+
+// [linalg.algs.blas3.trmm],
+// triangular matrix-matrix product
+
+// [linalg.algs.blas3.trmm.ov.left],
+// overwriting triangular matrix-matrix left product
+template<class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void triangular_matrix_left_product(
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_matrix_2_t B,
+  out_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void triangular_matrix_left_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_matrix_2_t B,
+  out_matrix_t C);
+template<class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class inout_matrix_t>
+void triangular_matrix_left_product(
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  inout_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class inout_matrix_t>
+void triangular_matrix_left_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  inout_matrix_t C);
+
+// [linalg.algs.blas3.trmm.ov.right],
+// overwriting triangular matrix-matrix right product
+template<class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void triangular_matrix_right_product(
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_matrix_2_t B,
+  out_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void triangular_matrix_right_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_matrix_2_t B,
+  out_matrix_t C);
+template<class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class inout_matrix_t>
+void triangular_matrix_right_product(
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  inout_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class inout_matrix_t>
+void triangular_matrix_right_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  inout_matrix_t C);
+
+// [linalg.algs.blas3.trmm.up.left],
+// updating triangular matrix-matrix left product
+template<class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void triangular_matrix_left_product(
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void triangular_matrix_left_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+
+// [linalg.algs.blas3.trmm.up.right],
+// updating triangular matrix-matrix right product
+template<class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void triangular_matrix_right_product(
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void triangular_matrix_right_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+
+// [linalg.alg.blas3.rank-k.syrk],
+// rank-k symmetric matrix update
+template<class T,
+         class in_matrix_1_t,
+         class inout_matrix_t,
+         class Triangle>
+void symmetric_matrix_rank_k_update(
+  T alpha,
+  in_matrix_1_t A,
+  inout_matrix_t C,
+  Triangle t);
+template<class T,
+         class ExecutionPolicy,
+         class in_matrix_1_t,
+         class inout_matrix_t,
+         class Triangle>
+void symmetric_matrix_rank_k_update(
+  ExecutionPolicy&& exec,
+  T alpha,
+  in_matrix_1_t A,
+  inout_matrix_t C,
+  Triangle t);
+
+// [linalg.alg.blas3.rank-k.herk],
+// rank-k Hermitian matrix update
+template<class T,
+         class in_matrix_1_t,
+         class inout_matrix_t,
+         class Triangle>
+void hermitian_matrix_rank_k_update(
+  T alpha,
+  in_matrix_1_t A,
+  inout_matrix_t C,
+  Triangle t);
+template<class ExecutionPolicy,
+         class T,
+         class in_matrix_1_t,
+         class inout_matrix_t,
+         class Triangle>
+void hermitian_matrix_rank_k_update(
+  ExecutionPolicy&& exec,
+  T alpha,
+  in_matrix_1_t A,
+  inout_matrix_t C,
+  Triangle t);
+
+// [linalg.alg.blas3.rank2k.syr2k],
+// rank-2k symmetric matrix update
+template<class in_matrix_1_t,
+         class in_matrix_2_t,
+         class inout_matrix_t,
+         class Triangle>
+void symmetric_matrix_rank_2k_update(
+  in_matrix_1_t A,
+  in_matrix_2_t B,
+  inout_matrix_t C,
+  Triangle t);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class in_matrix_2_t,
+         class inout_matrix_t,
+         class Triangle>
+void symmetric_matrix_rank_2k_update(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  in_matrix_2_t B,
+  inout_matrix_t C,
+  Triangle t);
+
+// [linalg.alg.blas3.rank2k.her2k],
+// rank-2k Hermitian matrix update
+template<class in_matrix_1_t,
+         class in_matrix_2_t,
+         class inout_matrix_t,
+         class Triangle>
+void hermitian_matrix_rank_2k_update(
+  in_matrix_1_t A,
+  in_matrix_2_t B,
+  inout_matrix_t C,
+  Triangle t);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class in_matrix_2_t,
+         class inout_matrix_t,
+         class Triangle>
+void hermitian_matrix_rank_2k_update(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  in_matrix_2_t B,
+  inout_matrix_t C,
+  Triangle t);
+
+// [linalg.alg.blas3.trsm],
+// solve multiple triangular linear systems
+
+// [linalg.alg.blas3.trsm.left],
+// solve multiple triangular linear systems
+// with triangular matrix on the left
+template<class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class out_matrix_t,
+         class BinaryDivideOp>
+void triangular_matrix_matrix_left_solve(
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_matrix_2_t B,
+  out_matrix_t X,
+  BinaryDivideOp divide);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class out_matrix_t,
+         class BinaryDivideOp>
+void triangular_matrix_matrix_left_solve(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_matrix_2_t B,
+  out_matrix_t X,
+  BinaryDivideOp divide);
+template<class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class inout_matrix_t,
+         class BinaryDivideOp>
+void triangular_matrix_matrix_left_solve(
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  inout_matrix_t B,
+  BinaryDivideOp divide);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class inout_matrix_t,
+         class BinaryDivideOp>
+void triangular_matrix_matrix_left_solve(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  inout_matrix_t B,
+  BinaryDivideOp divide);
+
+template<class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void triangular_matrix_matrix_left_solve(
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_matrix_2_t B,
+  out_matrix_t X);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void triangular_matrix_matrix_left_solve(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_matrix_2_t B,
+  out_matrix_t X);
+template<class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class inout_matrix_t>
+void triangular_matrix_matrix_left_solve(
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  inout_matrix_t B);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class inout_matrix_t>
+void triangular_matrix_matrix_left_solve(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  inout_matrix_t B);
+
+// [linalg.alg.blas3.trsm.right],
+// solve multiple triangular linear systems
+// with triangular matrix on the right
+template<class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class out_matrix_t,
+         class BinaryDivideOp>
+void triangular_matrix_matrix_right_solve(
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_matrix_2_t B,
+  out_matrix_t X,
+  BinaryDivideOp divide);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class out_matrix_t,
+         class BinaryDivideOp>
+void triangular_matrix_matrix_right_solve(
+  ExecutionPolicy&& exec,
+  in_matrix_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_matrix_t B,
+  out_matrix_t X,
+  BinaryDivideOp divide);
+template<class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class inout_matrix_t,
+         class BinaryDivideOp>
+void triangular_matrix_matrix_right_solve(
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  inout_matrix_t B,
+  BinaryDivideOp divide);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class inout_matrix_t,
+         class BinaryDivideOp>
+void triangular_matrix_matrix_right_solve(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  inout_matrix_t B,
+  BinaryDivideOp divide);
+
+template<class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void triangular_matrix_matrix_right_solve(
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_matrix_2_t B,
+  out_matrix_t X);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void triangular_matrix_matrix_right_solve(
+  ExecutionPolicy&& exec,
+  in_matrix_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_matrix_t B,
+  out_matrix_t X);
+template<class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class inout_matrix_t>
+void triangular_matrix_matrix_right_solve(
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  inout_matrix_t B);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class inout_matrix_t>
+void triangular_matrix_matrix_right_solve(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  inout_matrix_t B);
+}
+```
+
+## Requirements [linalg.reqs]
+
+### Value and reference requirements [linalg.reqs.val]
+
+This clause lists the minimum requirements for all algorithms and classes in **[linalg]**,
+and for the following types:
+
+* for any input or output `mdspan` parameter(s) of any algorithm or method in **[linalg]**,
+    the parameter(s)' `value_type` and `reference` type aliases;
+
+* the `Scalar` template parameter (if any) of any algorithm or class in **[linalg]**;
+
+* the `T` template parameter of any algorithm in **[linalg]** with a `T init` parameter; and
+
+* the template parameter of `sum_of_squares_result`.
+
+In this clause, we refer to these types as *linear algebra value types*.
+These type requirements are parameterized by the algorithm or method using the type.
+Each algorithm or method using the type has one or more associated mathematical expressions
+that defines the algorithm's or method's behavior.
+For each algorithm or method,
+its mathematical expression(s) are either explicitly stated as such,
+or are implicitly stated in the algorithm's or method's description.
+The requirements below will refer to those mathematical expression(s).
+
+*[Note:*
+This notion of parameterizing requirements on a mathematical expression
+generalizes *GENERALIZED_SUM*.
+--*end note]*
+
+All of the following requirements presume that the algorithm's
+asymptotic complexity requirements, if any, are satisfied.
+
+1. Any linear algebra value type
+    meets the requirements of `semiregular`.
+
+2. The algorithm or method may perform read-only access
+    on any input or output `mdspan` arbitrarily many times.
+
+3. The algorithm or method may make arbitrary many objects
+    of any linear algebra value type,
+    value-initializing or direct-initializing them
+    with any existing object of that type.
+
+4. The algorithm or method may assign arbitrarily many times
+    to any reference
+    resulting from a valid output `mdspan` access.
+
+5. If the algorithm's or method's mathematical expression
+    uses division and possibly also
+    addition, subtraction, and multiplication,
+    then the algorithm or method
+    evaluates the mathematical expression
+    using a sequence of evaluations of
+    `*`, `*=`, `/`, `/=`,
+    `+`, `+=`, unary `-`, binary `-`, `-=`,
+    and `=` operators
+    that would produce the correct result
+    when operating on elements of a field
+    with noncommutative multiplication.
+    (We interpret `a / b` as `a` times the multiplicative inverse of `b`.)
+    Any addend,
+    any subtrahend,
+    any partial sum of addends in any order
+    (treating any difference as a sum with the second term negated),
+    any factor,
+    any partial product of factors respecting their order in the mathematical expression,
+    any numerator,
+    any denominator,
+    and any assignment in the mathematical expression
+    shall be well formed.
+
+6. Otherwise, if the algorithm's or method's mathematical expression
+    uses subtraction and possibly also
+    addition and multiplication,
+    then the algorithm or method
+    evaluates the mathematical expression
+    using a sequence of evaluations of
+    `*`, `*=`, `+`, `+=`,
+    unary `-`, binary `-`, `-=`,
+    and `=` operators
+    that would produce the correct result
+    when operating on elements of a ring
+    with noncommutative multiplication.
+    Any addend,
+    any subtrahend,
+    any partial sum of addends in any order
+    (treating any difference as a sum with the second term negated),
+    any factor,
+    any partial product of factors respecting their order in the mathematical expression,
+    and any assignment in the mathematical expression
+    shall be well formed.
+
+7. Otherwise, if the algorithm's or method's mathematical expression
+    uses multiplication and possibly also addition,
+    then the algorithm or method
+    evaluates the mathematical expression
+    using a sequence of evaluations of
+    `*`, `*=`, `+`, `+=`, and `=` operators
+    that would produce the correct result
+    when operating on elements of a semiring
+    with noncommutative multiplication.
+    Any addend,
+    any partial sum of addends in any order,
+    any factor,
+    any partial product of factors respecting their order in the mathematical expression,
+    and any assignment in the mathematical expression
+    shall be well formed.
+
+8. Otherwise, if the algorithm's or method's mathematical expression
+    uses addition,
+    then the algorithm or method evaluates the mathematical expression
+    using a sequence of evaluations of
+    `+`, `+=`, and `=` operators
+    that would produce the correct result
+    when operating on elements of a commutative semigroup.
+    Any addend,
+    any partial sum of addends in any order,
+    and any assignment in the mathematical expression
+    shall be well formed.
+
+9. If the algorithm's or method's mathematical expression includes any of the following:
+
+    a. _`conj-if-needed`_`(z)` for some expression `z`,
+
+    b. `abs(x)` for some expression `x`, or
+
+    c. `sqrt(x)` for some expression `x`,
+
+    but otherwise conforms to case (5), (6), (7), or (8),
+    then the relevant case (5), (6), (7), or (8) applies.
+    In addition, any of the above subexpressions that appear
+    in the algorithm's or method's mathematical expression
+    shall be well formed.
+
+10. If the algorithm or method has an output `mdspan`,
+    then all addends (or subtrahends, if applicable)
+    in the algorithm's or method's mathematical expression
+    are assignable and convertible to the output `mdspan`'s `value_type`.
+
+11. The algorithm or method may reorder addends and partial sums
+    in its mathematical expression arbitrarily.
+    *[Note:*
+    Factors in each product are not reordered;
+    multiplication is not necessarily commutative.
+    --*end note]*
+
+12. The algorithm or method may replace any value
+    with the sum of that value
+    and a value-initialized object
+    of any input or output `mdspan`'s `value_type`.
+
+13. If the algorithm or method has a `T init` parameter,
+    then the algorithm or method may replace any value
+    with the sum of that value
+    and a value-initialized object of type `T`.
+
+### Requirements for algorithms and methods on floating-point values [linalg.reqs.flpt]
+
+For all algorithms and classes in **[linalg]**, suppose that
+
+* all input and output `mdspan` have `value_type` a floating-point type,
+
+* any `Scalar` template argument has a floating-point type, and
+
+* any argument corresponding to the `T init` parameter has a floating-point type.
+
+Then, algorithms and classes' methods may do the following:
+
+1. compute floating-point sums in any way that improves their accuracy for arbitrary input;
+
+2. perform arithmetic operations other than those
+    in the algorithm's or method's mathematical expression,
+    in order to improve performance or accuracy; and
+
+3. use approximations (that might not be exact even if computing with real numbers),
+    instead of computations that would be exact
+    if it were possible to compute without rounding error;
+
+as long as
+
+1. the algorithm or method satisfies the complexity requirements; and
+
+2. the algorithm or method is *logarithmically stable*,
+    in the sense of (Demmel 2007).
+
+*[Note:*
+Strassen's algorithm for matrix-matrix multiply is an example of a logarithmically stable algorithm.
+--*end note]*
+
+## Tag classes [linalg.tags]
+
+### Storage order tags [linalg.tags.order]
+
+```c++
+struct column_major_t { };
+inline constexpr column_major_t column_major = { };
+
+struct row_major_t { };
+inline constexpr row_major_t row_major = { };
+```
+
+`column_major_t` indicates a column-major order, and `row_major_t`
+indicates a row-major order.  The interpretation of each depends on
+the specific layout that uses the tag.  See `layout_blas_packed` below.
+
+### Triangle tags [linalg.tags.triangle]
+
+Some linear algebra algorithms distinguish between the "upper
+triangle," "lower triangle," and "diagonal" of a matrix.
+
+* The *diagonal* is the set of all elements of `A` accessed by
+    `A[i,i]` for 0 ≤ `i` < min(`A.extent(0)`, `A.extent(1)`).
+
+* The *upper triangle* of a matrix `A` is the set of all elements of
+    `A` accessed by `A[i,j]` with `i` ≤ `j`.  It includes the diagonal.
+
+* The *lower triangle* of `A` is the set of all elements of `A`
+    accessed by `A[i,j]` with `i` ≥ `j`.  It includes the diagonal.
+
+```c++
+struct upper_triangle_t { };
+inline constexpr upper_triangle_t upper_triangle = { };
+
+struct lower_triangle_t { };
+inline constexpr lower_triangle_t lower_triangle = { };
+```
+
+These tag classes specify whether algorithms and other users of a
+matrix (represented as an `mdspan`) should
+access the upper triangle (`upper_triangular_t`) or lower triangle
+(`lower_triangular_t`) of the matrix.  This is also subject to the
+restrictions of `implicit_unit_diagonal_t` if that tag is also
+applied; see below.
+
+*[Note:*
+The `conjugate_transposed` and `transposed` functions in this section
+return a view of an input `mdspan`
+with its rightmost two indices effectively reversed.
+Regardless, when we refer to the upper triangle of `B = transposed(A)`,
+we still mean the elements of `B` accessed by `B[i,j]` with `i` ≤ `j`.
+For all algorithms in this section that take a triangle tag parameter,
+the triangle tag refers to the actual input matrix,
+*after* any transformations like `transposed`.
+This differs from the BLAS' `UPLO` argument,
+which refers to the pre-transformed "original" matrix.
+--*end note]*
+
+### Diagonal tags [linalg.tags.diagonal]
+
+```c++
+struct implicit_unit_diagonal_t { };
+inline constexpr implicit_unit_diagonal_t
+  implicit_unit_diagonal = { };
+
+struct explicit_diagonal_t { };
+inline constexpr explicit_diagonal_t explicit_diagonal = { };
+```
+
+These tag classes specify whether algorithms
+should access the matrix's diagonal entries, and if not,
+then how algorithms should interpret
+the matrix's implicitly represented diagonal values.
+
+The `implicit_unit_diagonal_t` tag indicates two things:
+
+  * the algorithm will never access the `i,i` element
+      of the matrix for any `i`; and
+
+  * the algorithm will interpret the matrix as if it has a "unit diagonal,"
+      a diagonal each of whose elements behaves
+      as a two-sided multiplicative identity
+      (even if the matrix's value type does not have
+      a two-sided multiplicative identity).
+
+The tag `explicit_diagonal_t` indicates that algorithms
+may access the matrix's diagonal entries directly.
+
+## Layouts for packed matrix types [linalg.layouts]
+
+### `layout_blas_packed` [linalg.layouts.packed]
+
+`layout_blas_packed` is an `mdspan` layout mapping policy that
+represents a square matrix that stores only the entries in one
+triangle, in a packed contiguous format.  Its `Triangle` template
+parameter determines whether an `mdspan` with this layout stores
+the upper or lower triangle of the matrix.  Its `StorageOrder`
+template parameter determines whether the layout packs the matrix's
+elements in column-major or row-major order.
+
+A `StorageOrder` of `column_major_t` indicates column-major ordering.
+This packs matrix elements starting with the leftmost (least column
+index) column, and proceeding column by column, from the top entry
+(least row index).
+
+A `StorageOrder` of `row_major_t` indicates row-major ordering.  This
+packs matrix elements starting with the topmost (least row index) row,
+and proceeding row by row, from the leftmost (least column index)
+entry.
+
+*[Note:*
+
+`layout_blas_packed` describes the data layout used by the BLAS'
+Symmetric Packed (SP), Hermitian Packed (HP), and Triangular Packed
+(TP) matrix types.
+
+--*end note]*
+
+```c++
+template<class Triangle,
+         class StorageOrder>
+class layout_blas_packed {
+public:
+  template<class Extents>
+  struct mapping {
+  public:
+    using extents_type = Extents;
+    using index_type = typename extents_type::index_type;
+    using size_type = typename extents_type::size_type;
+    using rank_type = typename extents_type::rank_type;
+    using layout_type = layout_blas_packed<Triangle, StorageOrder>;
+
+  private:
+    Extents <it>extents_</it>{}; // exposition only
+
+  public:
+    constexpr mapping() noexcept = default;
+    constexpr mapping(const mapping&) noexcept = default;
+    constexpr mapping(const extents_type& e) noexcept;
+    template<class OtherExtents>
+      constexpr explicit(! is_convertible_v<OtherExtents, extents_type>)
+        mapping(const mapping<OtherExtents>& other) noexcept;
+
+    constexpr mapping& operator=(const mapping&) noexcept = default;
+
+    constexpr extents_type extents() const noexcept { return <it>extents_</it>; }
+
+    constexpr size_type required_span_size() const noexcept;
+
+    template<class... Indices>
+      constexpr index_type operator() (Indices...) const noexcept;
+
+    static constexpr bool is_always_unique() {
+      return extents_type::static_extent(0) != dynamic_extent &&
+        extents_type::static_extent(0) < 2;
+    }
+    static constexpr bool is_always_exhaustive() { return true; }
+    static constexpr bool is_always_strided() {
+      return extents_type::static_extent(0) != dynamic_extent &&
+        extents_type::static_extent(0) < 2;
+    }
+
+    constexpr bool is_unique() const noexcept {
+      return extent(0) < 2;
+    }
+    constexpr bool is_exhaustive() const noexcept { return true; }
+    constexpr bool is_strided() const noexcept {
+      return extent(0) < 2;
+    }
+
+    constexpr index_type stride(rank_type) const noexcept;
+
+    template<class OtherExtents>
+      friend constexpr bool
+        operator==(const mapping&, const mapping<OtherExtents>&) noexcept;
+};
+```
+
+* *Constraints:*
+
+    * `Triangle` is either `upper_triangle_t` or `lower_triangle_t`.
+
+    * `StorageOrder` is either `column_major_t` or `row_major_t`.
+
+    * `Extents` is a specialization of `extents`.
+
+    * `Extents::rank()` equals 2.
+
+```c++
+constexpr mapping(const extents_type& e) noexcept;
+```
+
+*Preconditions:*
+
+    * The size of the multidimensional index space `e` is representable
+        as a value of type `index_type` (**[basic.fundamental]**), and
+
+    * `e.extent(0)` equals `e.extent(1)`.
+
+* *Effects:* Direct-non-list-initializes <it>`extents_`</it> with `e`.
+
+```c++
+template<class OtherExtents>
+  explicit(! is_convertible_v<OtherExtents, extents_type>)
+    constexpr mapping(const mapping<OtherExtents>& other) noexcept;
+```
+
+*Constraints:* `is_constructible_v<extents_type, OtherExtents>` is `true`.
+
+*Preconditions:* `other.required_span_size()` is representable as a value
+    of type `index_type` (**[basic.fundamental]**).
+
+*Effects:* Direct-non-list-initializes <it>`extents_`</it> with `other.extents()`.
+
+```c++
+constexpr index_type required_span_size() const noexcept;
+```
+
+*Returns:* `extent(0)` * (`extent(0)` + 1)/2.
+
+*[Note:* For example, a 5 x 5 packed matrix
+only stores 15 matrix elements. --*end note]*
+
+```c++
+template<class ... Indices>
+  constexpr index_type operator() (Indices... k) const noexcept;
+```
+
+*Constraints*:
+
+    * `sizeof...(Indices)` equals `extents_type::rank()`,
+
+    * `(is_convertible_v<Indices, index_Type> && ...)` is `true`, and
+
+    * `(is_nothrow_constructible_v<index_type, Indices>)` is `true`.
+
+*Preconditions:* `extents_type::`<it>`index-cast`</it>`(k)` is
+    a multidimensional index in <it>`extents_`</it> (**[mdspan.overview]**).
+
+*Returns:* Let `N` equal `extent(0)`, let `i` be the zeroth element of `k`,
+    and let `j` be the first element of `k`.  Then:
+
+    * If `StorageOrder` is `column_major_t` and
+
+        * if `Triangle` is `upper_triangle_t`,
+            then `i` + `j` * (`j` + 1)/2 if `i` ≤ `j`,
+            else `j` + `i` * (`i` + 1)/2;
+
+        * else, if `Triangle` is `lower_triangle_t`,
+            then `i` + `N` * `j` - `j` * (`j` + 1)/2 if `i` ≥ `j`,
+            else `j` + `N` * `i` - `i` * (`i` + 1)/2;
+
+    * else, if `StorageOrder` is `row_major_t` and
+
+        * if `Triangle` is `upper_triangle_t`,
+            then `j` + `N` * `i` - `i` * (`i` + 1)/2 if `i` ≤ `j`,
+            else `i` + `N` * `j` - `j` * (`j` + 1)/2;
+
+        * else, if `Triangle` is `lower_triangle_t`,
+            then `j` + `i` * (`i` + 1)/2 if `i` ≥ `j`,
+            else `i` + `j` * (`j` + 1)/2.
+
+*[Note:*
+
+An `mdspan` layout mapping must permit access
+for all multidimensional indices in the cross product of the extents,
+so the above definition cannot exclude indices outside the matrix's triangle.
+Instead, it interprets such indices as if the matrix were symmetric.
+
+--*end note]*
+
+```c++
+template<class OtherExtents>
+  friend constexpr bool
+    operator==(const mapping&, const mapping<OtherExtents>&) noexcept;
+```
+
+*Constraints:* `OtherExtents::rank()` equals `rank()`.
+
+*Returns:* `true` if and only if
+    for 0 ≤ `r` < `rank()`,
+    `m.extent(r)` equals `extent(r)`.
+
+```c++
+constexpr index_type stride(rank_type) const noexcept;
+```
+
+*Returns:* 1 if `extent(0)` is less than 2, else 0.
+
+## Scaled in-place transformation [linalg.scaled]
+
+The `scaled` function takes a value `alpha` and an `mdspan`
+`x`, and returns a new read-only `mdspan` with the same domain
+as `x`, that represents the elementwise product of `alpha` with each
+element of `x`.
+
+[*Example:*
+```c++
+// z = alpha * x + y
+void z_equals_alpha_times_x_plus_y(
+  mdspan<double, dextents<size_t, 1>> z,
+  const double alpha,
+  mdspan<double, dextents<size_t, 1>> x,
+  mdspan<double, dextents<size_t, 1>> y)
+{
+  add(scaled(alpha, x), y, y);
+}
+
+// w = alpha * x + beta * y
+void w_equals_alpha_times_x_plus_beta_times_y(
+  mdspan<double, dextents<size_t, 1>> w,
+  const double alpha,
+  mdspan<double, dextents<size_t, 1>> x,
+  const double beta,
+  mdspan<double, dextents<size_t, 1>> y)
+{
+  add(scaled(alpha, x), scaled(beta, y), w);
+}
+```
+--*end example*]
+
+*[Note:*
+
+An implementation could dispatch to a function in the BLAS library, by
+noticing that the first argument has an `accessor_scaled` `Accessor`
+type.  It could use this information to extract the appropriate
+run-time value(s) of the relevant BLAS function arguments (e.g.,
+`ALPHA` and/or `BETA`), by calling `accessor_scaled::scaling_factor`.
+
+--*end note]*
+
+### Exposition-only function object _`conj-if-needed`_ [linalg.scaled.conj]
+
+The name `_conj-if-needed_` denotes an exposition-only function object.
+The expression _`conj-if-needed`_`(E)` for subexpression `E`
+is expression-equivalent to:
+
+    * `E`, if `T` is an arithmetic type;
+
+    * else, `conj(E)`, if that expression is valid
+        with overload resolution performed in a context
+	that includes the declaration
+	`template<class T> T conj(const T&) = delete;`
+	and does not include a declaration of
+	`linalg::impl::`_`conj_if_needed`_;
+
+    * else, `E`.
+
+*[Note:*
+The special case for arithmetic types
+preserves the type of its argument, unlike `std::conj`.
+The `conj(E)` case invokes `conj` via unqualified lookup.
+The `E` case presumes that a type without a `conj` function is noncomplex,
+so that the conjugate is the identity.
+--*end note]*
+
+### Exposition-only class templates `proxy_reference_base` and `proxy_reference` [linalg.scaled.base]
+
+The exposition-only class `proxy_reference_base` is a tag
+to identify whether a class is a specialization of either
+`scaled_scalar` **[linalg.scaled.accessor_scaled]** or
+`conjugated_scalar` **[linalg.scaled.accessor_conjugated]**.
+
+The exposition-only class template `proxy_reference`
+is part of the implementation of 
+`scaled_scalar` **[linalg.scaled.accessor_scaled]** and
+`conjugated_scalar` **[linalg.scaled.accessor_conjugated]**.
+
+```c++
+class proxy_reference_base {}; // exposition only
+
+template<class Reference, class Value, class Derived>
+class proxy_reference : public proxy_reference_base { // exposition only
+private:
+  using this_type = proxy_reference<Reference, Value, Derived>;
+  
+  Reference reference_;
+
+public:
+  using reference_type = Reference;
+  using value_type = Value;
+  using derived_type = Derived;
+
+  constexpr explicit proxy_reference(Reference reference) : reference_(reference) {}
+
+  constexpr operator value_type() const {
+    return static_cast<const Derived&>(*this).to_value(reference_);
+  }
+
+  constexpr friend auto operator-(const derived_type& cs)
+  {
+    return -value_type(cs);
+  }
+
+  template<class Rhs, enable_if_t<is_base_of_v<proxy_reference_base, Rhs>, bool> = true>
+  constexpr friend auto operator+ (derived_type lhs, Rhs rhs)
+  {
+    using rhs_value_type = typename Rhs::value_type; // exposition only
+    return value_type(lhs) + rhs_value_type(rhs);
+  }
+  template<class Rhs, enable_if_t<! is_base_of_v<proxy_reference_base, Rhs>, bool> = true>
+  constexpr friend auto operator+ (derived_type lhs, Rhs rhs)
+  {
+    return value_type(lhs) + rhs;
+  }
+  template<class Lhs, enable_if_t<! is_base_of_v<proxy_reference_base, Lhs>, bool> = true>
+  constexpr friend auto operator+ (Lhs lhs, derived_type rhs)
+  {
+    return lhs + value_type(rhs);
+  }
+
+  template<class Rhs, enable_if_t<is_base_of_v<proxy_reference_base, Rhs>, bool> = true>
+  constexpr friend auto operator- (derived_type lhs, Rhs rhs)
+  {
+    using rhs_value_type = typename Rhs::value_type; // exposition only
+    return value_type(lhs) - rhs_value_type(rhs);
+  }
+  template<class Rhs, enable_if_t<! is_base_of_v<proxy_reference_base, Rhs>, bool> = true>
+  constexpr friend auto operator- (derived_type lhs, Rhs rhs)
+  {
+    return value_type(lhs) - rhs;
+  }
+  template<class Lhs, enable_if_t<! is_base_of_v<proxy_reference_base, Lhs>, bool> = true>
+  constexpr friend auto operator- (Lhs lhs, derived_type rhs)
+  {
+    return lhs - value_type(rhs);
+  }
+
+  template<class Rhs, enable_if_t<is_base_of_v<proxy_reference_base, Rhs>, bool> = true>
+  constexpr friend auto operator* (derived_type lhs, Rhs rhs)
+  {
+    using rhs_value_type = typename Rhs::value_type; // exposition only
+    return value_type(lhs) * rhs_value_type(rhs);
+  }
+  template<class Rhs, enable_if_t<! is_base_of_v<proxy_reference_base, Rhs>, bool> = true>
+  constexpr friend auto operator* (derived_type lhs, Rhs rhs)
+  {
+    return value_type(lhs) * rhs;
+  }
+  template<class Lhs, enable_if_t<! is_base_of_v<proxy_reference_base, Lhs>, bool> = true>
+  constexpr friend auto operator* (Lhs lhs, derived_type rhs)
+  {
+    return lhs * value_type(rhs);
+  }
+
+  template<class Rhs, enable_if_t<is_base_of_v<proxy_reference_base, Rhs>, bool> = true>
+  constexpr friend auto operator/ (derived_type lhs, Rhs rhs)
+  {
+    using rhs_value_type = typename Rhs::value_type; // exposition only
+    return value_type(lhs) / rhs_value_type(rhs);
+  }
+  template<class Rhs, enable_if_t<! is_base_of_v<proxy_reference_base, Rhs>, bool> = true>
+  constexpr friend auto operator/ (derived_type lhs, Rhs rhs)
+  {
+    return value_type(lhs) / rhs;
+  }
+  template<class Lhs, enable_if_t<! is_base_of_v<proxy_reference_base, Lhs>, bool> = true>
+  constexpr friend auto operator/ (Lhs lhs, derived_type rhs)
+  {
+    return lhs / value_type(rhs);
+  }
+
+  constexpr friend auto abs(const derived_type& x);
+
+  constexpr friend auto real(const derived_type& x);
+
+  constexpr friend auto imag(const derived_type& x);
+
+  constexpr friend auto conj(const derived_type& x);
+
+  <!-- TODO (mfh 2022/07/06) Do we need sqrt here? -->
+};
+```
+
+```c++
+constexpr friend auto abs(const derived_type& x);
+```
+
+The expression `abs(E)` for subexpression `E` whose type is `derived_type`
+is expression-equivalent to:
+
+    * `value_type(static_cast<const this_type&>(E))`,
+        if `value_type` is an unsigned integer;
+
+    * else, `abs(value_type(static_cast<const this_type&>(E)))`,
+        if that expression is valid,
+	      with overload resolution performed in a context
+	      that includes the declaration
+        `template<class T> T abs(T) = delete;`.
+	      If the function selected by overload resolution
+	      does not return the absolute value of its input,
+	      the program is ill-formed, no diagnostic required.
+
+<!-- TODO (mfh 2022/07/06) this lookup language will go into front matter. -->
+
+*[Note:*
+This function exists because of `vector_norm2` and `vector_abs_sum`.
+
+The unsigned integer special case avoids an ambiguous lookup.
+The other case invokes `abs` via unqualified lookup.
+--*end note]*
+
+```c++
+constexpr friend auto real(const derived_type& x);
+```
+
+The expression `real(E)` for subexpression `E` whose type is `derived_type`
+is expression-equivalent to:
+
+    * `value_type(static_cast<const this_type&>(E))`,
+        if `value_type` is an arithmetic type;
+
+    * else, `real(value_type(static_cast<const this_type&>(E)))`,
+	      if that expression is valid,
+	      with overload resolution performed in a context
+	      that includes the declaration
+        `template<class T> T real(T) = delete;`;
+	      if the function selected by overload resolution
+	      does not return the absolute value of its input,
+	      the program is ill-formed, no diagnostic required;
+
+    * else, `value_type(static_cast<const this_type&>(E))`.
+
+*[Note:*
+This function exists because of `vector_abs_sum`.
+
+The arithmetic type special case exists because
+`std::real` returns a different type than its input
+for some arithmetic types.
+All arithmetic types represent a noncomplex number.
+Otherwise, if `real` can be found via unqualified lookup, it is used.
+If not, then `value_type` is assumed to represent a noncomplex number,
+for which the number's real part is the same as the number.
+--*end note]*
+
+```c++
+constexpr friend auto imag(const derived_type& x);
+```
+
+The expression `imag(E)` for subexpression `E` whose type is `derived_type`
+is expression-equivalent to:
+
+    * `value_type{}`,
+        if `value_type` is an arithmetic type;
+
+    * else, `imag(value_type(static_cast<const this_type&>(E)))`,
+	      if that expression is valid,
+	      with overload resolution performed in a context
+	      that includes the declaration
+        `template<class T> T imag(T) = delete;`;
+	      if the function selected by overload resolution
+	      does not return the absolute value of its input,
+	      the program is ill-formed, no diagnostic required;
+
+    * else, `value_type{}`.
+
+*[Note:*
+This function exists because of `vector_abs_sum`.
+
+The arithmetic type special case exists because
+`std::imag` returns a different type than its input
+for some arithmetic types.
+All arithmetic types represent a noncomplex number.
+Otherwise, if `imag` can be found via unqualified lookup, it is used.
+If not, then `value_type` is assumed to represent a noncomplex number,
+for which the number's imaginary part is zero
+(which is constructed by value-initializing `value_type`).
+--*end note]*
+
+```c++
+constexpr friend auto conj(const derived_type& x);
+```
+
+* *Effects:* Equivalent to `return `_`conj-if-needed`_`(x);`.
+
+### Exposition-only class template `scaled_scalar`
+
+The exposition-only class template `scaled_scalar` represents a
+read-only value, which is the product of a fixed value (the "scaling
+factor") and the value of a reference to an element of a
+`mdspan`.  *[Note:* The value is read only to avoid confusion
+with the definition of "assigning to a scaled scalar."  --*end note]*
+`scaled_scalar` is part of the implementation of `accessor_scaled`
+**[linalg.scaled.accessor_scaled]**.
+
+```c++
+template<class ScalingFactor, class ReferenceValue>
+concept <it>scalable</it> = // exposition only
+requires {
+  { declval<ScalingFactor>() * declval<ReferenceValue>() };
+};
+
+template<class ScalingFactor, class Reference, class ReferenceValue>
+class scaled_scalar : // exposition only
+  public proxy_reference<Reference, ReferenceValue,
+    scaled_scalar<ScalingFactor, Reference, ReferenceValue>>
+{
+private:
+  ScalingFactor scaling_factor_;
+
+  using my_type = scaled_scalar<ScalingFactor, Reference, ReferenceValue>; // exposition only
+  using base_type = proxy_reference<Reference, ReferenceValue, my_type>; // exposition only
+public:
+  explicit scaled_scalar(const ScalingFactor& scaling_factor, const Reference& reference);
+
+  using value_type = decltype(scaling_factor_ * ReferenceValue(declval<Reference>()));
+  value_type to_value(Reference reference) const;
+};
+```
+
+*[Note:*
+
+The point of the `ReferenceValue` template parameter
+is so that the input of `to_value` can be cast to a value immediately,
+before any transformations are applied.
+This ensures the original order of operations,
+as if computing nonlazily.
+It also makes fewer requirements of the reference type.
+
+--*end note]*
+
+*Mandates:*
+
+    * _`scalable`_`<ScalingFactor, ReferenceValue>`, and
+
+    * `value_type` is a complete object type that is neither an abstract class type nor an array type.
+
+`ScalingFactor` models `semiregular`.
+
+`Reference` models `copy_constructible`.
+
+```c++
+explicit scaled_scalar(const ScalingFactor& scaling_factor, const Reference& reference);
+```
+
+*Effects:*
+
+    * Direct non-list-initializes `static_cast<base_type&>(*this)` with `reference`, and
+
+    * direct non-list-initializes `scaling_factor_` with `scaling_factor`.
+
+```c++
+value_type to_value(Reference reference) const;
+```
+
+*Effects:* Equivalent to `return scaling_factor_ * ReferenceValue(reference);`.
+
+The class template `accessor_scaled` is an `mdspan` accessor
+policy whose reference type represents the product of a scaling factor
+and its nested `mdspan` accessor's reference.
+
+### Class template `accessor_scaled` [linalg.scaled.accessor_scaled]
+
+The class template `accessor_scaled` is an `mdspan` accessor
+policy whose reference type represents the product of a fixed value
+(the "scaling factor") and its nested `mdspan` accessor's
+reference.  It is part of the implementation of `scaled`
+**[linalg.scaled.scaled]**.
+
+```c++
+template<class ScalingFactor,
+         class Accessor>
+class accessor_scaled {
+public:
+  using reference = scaled_scalar<ScalingFactor,
+    typename Accessor::reference,
+    typename Accessor::element_type>;
+  using element_type = add_const_t<typename reference::value_type>;
+  using data_handle_type = Accessor::data_handle_type;
+  using offset_policy = accessor_scaled<ScalingFactor, Accessor::offset_policy>;
+
+  constexpr accessor_scaled(const ScalingFactor& s, const Accessor& a);
+
+  constexpr reference access(data_handle_type p, size_t i) const noexcept;
+
+  constexpr offset_policy::data_handle_type offset(data_handle_type p, size_t i) const noexcept;
+
+  constexpr ScalingFactor scaling_factor() const;
+
+  constexpr Accessor nested_accessor() const;
+
+private:
+  ScalingFactor scaling_factor_; // exposition only
+  Accessor accessor_; // exposition only
+};
+```
+
+*Mandates:*: `is_copy_constructible_v<typename Accessor::reference>` is `true`.
+
+`ScalingFactor` models `semiregular`.
+
+`Accessor` meets the accessor policy requirements **[mdspan.accessor.reqmts]**.
+
+```c++
+constexpr accessor_scaled(const ScalingFactor& s, const Accessor& a);
+```
+
+*Effects:*
+
+    * Direct non-list-initializes `scaling_factor_` with `s`, and
+
+    * direct non-list-initializes `accessor_` with `a`.
+
+```c++
+constexpr reference access(data_handle_type p, size_t i) const noexcept;
+```
+
+*Effects:* Equivalent to `return reference(scaling_factor_, accessor_.access(p, i));`.
+
+```c++
+constexpr offset_policy::data_handle_type
+offset(data_handle_type p, size_t i) const noexcept;
+```
+
+*Effects:* Equivalent to `return accessor_.offset(p, i);`.
+
+```c++
+constexpr ScalingFactor scaling_factor() const;
+```
+
+*Effects:* Equivalent to `return scaling_factor_;`.
+
+```c++
+constexpr Accessor nested_accessor() const;
+```
+
+*Effects:* Equivalent to `return accessor_;`.
+
+### `scaled` [linalg.scaled.scaled]
+
+The `scaled` function takes a scaling factor `alpha` and an `mdspan`
+`x`, and returns a new read-only `mdspan` with the same domain
+as `x`, that represents the elementwise product of `alpha` with each
+element of `x`.
+
+*[Note:*
+Terms in this product will not be reordered.
+--*end note]*
+
+```c++
+template<class ScalingFactor,
+         class ElementType,
+         class Extents,
+         class Layout,
+         class Accessor>
+constexpr auto scaled(
+  ScalingFactor scaling_factor,
+  const mdspan<ElementType, Extents, Layout, Accessor>& x);
+```
+*Effects:* Equivalent to
+    `return mdspan{x.data(), x.mapping(), accessor_scaled{alpha, x.accessor()}};`.
+
+*[Note:*
+The elements of the returned `mdspan` are read only.
+
+Nested `scaled` expressions remain nested.
+An expression such as `scaled(alpha, scaled(beta, x))`
+would not be transformed into `scaled(alpha * beta, x)`.
+This is because such transformations would change at least
+the order of operations, and possibly also the result type.
+For example, if `x` is a rank-1 `mdspan` whose `value_type` is `double`,
+and if `sizeof(int)` is 4 and `double` is IEEE 754 binary64,
+then `scaled(1 << 20, scaled(1 << 20, x))` does not overflow `int`,
+but `scaled((1 << 20) * (1 << 20), x)` would overflow `int`.
+--*end note]*
+
+[*Example:*
+```c++
+void test_scaled(mdspan<double, extents<int, 10>> x)
+{
+  auto x_scaled = scaled(5.0, x);
+  for(int i = 0; i < x.extent(0); ++i) {
+    assert(x_scaled[i] == 5.0 * x[i]);
+  }
+}
+```
+--*end example*]
+
+## Conjugated in-place transformation [linalg.conj]
+
+The `conjugated` function takes an `mdspan` `x`, and returns
+a new read-only `mdspan` `y` with the same domain as `x`, whose
+elements are the complex conjugates of the corresponding elements of
+`x`.
+
+*[Note:*
+
+An implementation could dispatch to a function in the BLAS library, by
+noticing that the `Accessor` type of an `mdspan` input has type
+`accessor_conjugate`, and that its nested `Accessor` type is
+compatible with the BLAS library.  If so, it could set the
+corresponding `TRANS*` BLAS function argument accordingly and call the
+BLAS function.
+
+--*end note]*
+
+### Exposition-only class template `conjugated_scalar`
+
+The exposition-only class template `conjugated_scalar` represents a
+read-only value, which is the complex conjugate of the value of a
+reference to an element of an `mdspan`.  *[Note:* The value is
+read only to avoid confusion with the definition of "assigning to the
+conjugate of a scalar."  --*end note]* `conjugated_scalar` is part of
+the implementation of `accessor_conjugate`
+**[linalg.conj.accessor_conjugate]**.
+
+```c++
+template<class ReferenceValue>
+concept <it>conjugatable</it> = // exposition only
+requires {
+  { <it>conj-if-needed</it>(declval<ReferenceValue>()) } -> same_as<ReferenceValue>;
+};
+
+template<class Reference, class ReferenceValue>
+class conjugated_scalar : // exposition only
+  public proxy_reference<Reference, ReferenceValue, conjugated_scalar<Reference, ReferenceValue>>
+{
+private:
+  using my_type = conjugated_scalar<Reference, ReferenceValue>; // exposition only
+  using base_type = proxy_reference<Reference, ReferenceValue, my_type>; // exposition only
+
+public:
+  constexpr explicit conjugated_scalar(Reference reference);
+
+  using value_type = /* see below */;
+  constexpr static auto to_value(Reference reference);
+};
+```
+
+*Mandates:* _`conjugatable`_`<ReferenceValue>`.
+
+`Reference` models `copy_constructible`.
+
+```c++
+using value_type = /* see below */;
+```
+
+`value_type` names the type `decltype(`_`conj-if-needed`_`(ReferenceValue(declval<Reference>())))`.
+
+```c++
+constexpr explicit conjugated_scalar(Reference reference);
+```
+
+* *Effects:* Initializes `base_type` with `reference`.
+
+```c++
+constexpr static auto to_value(Reference value_type);
+```
+
+* *Preconditions:* This function may be invoked arbitrarily many times.
+
+* *Effects:* Equivalent to `return `_`conj-if-needed`_`(ReferenceValue(reference));`.
+
+### Class template `accessor_conjugate` [linalg.conj.accessor_conjugate]
+
+The class template `accessor_conjugate` is an `mdspan` accessor
+policy whose reference type represents the complex conjugate of its
+nested `mdspan` accessor's reference.
+It is part of the implementation of `conjugated`
+**[linalg.conj.conjugated]**.
+
+```c++
+template<class Accessor>
+class accessor_conjugate {
+private:
+  Accessor acc_; // exposition only
+
+public:
+  using reference     = /* see below */;
+  using element_type  = /* see below */;
+  using data_handle_type = typename Accessor::data_handle_type;
+  using offset_policy = /* see below */;
+
+  constexpr accessor_conjugate(Accessor a);
+
+  constexpr reference access(data_handle_type p, size_t i) const
+    noexcept(noexcept(reference(acc_.access(p, i))));
+
+  constexpr typename offset_policy::data_handle_type
+    offset(data_handle_type p, size_t i) const
+      noexcept(noexcept(acc_.offset(p, i)));
+
+  constexpr Accessor nested_accessor() const;
+};
+```
+
+`Accessor` meets the `mdspan` accessor policy requirements **[mdspan.accessor.reqmts]**.
+
+```c++
+using reference = /* see below */;
+```
+
+This names
+
+* `typename Accessor::reference`,
+    if `remove_cv_t<typename Accessor::element_type>` is an arithmetic type;
+
+* otherwise, `conjugated_scalar<typename Accessor::reference, remove_cv_t<typename Accessor::element_type>>`.
+
+```c++
+using element_type = /* see below */
+```
+
+Let the exposition-only type `pre-const-element-type` name
+
+* `typename Accessor::element_type`,
+    if `remove_cv<typename Accessor::element_type>` is an arithmetic type;
+
+* otherwise, `reference::value_type`.
+
+Then, `element_type` names `add_const_t<`_`pre-const-element-type`_`>`.
+
+*[Note:* `accessor_conjugate` provides read-only access. --*end note]*
+
+```c++
+using offset_policy = /* see below */;
+```
+
+This names
+
+* `typename Accessor::offset_policy`,
+    if `remove_cv_t<typename Accessor::element_type>` is an arithmetic type;
+
+* otherwise, `accessor_conjugate<typename Accessor::offset_policy>`.
+
+```c++
+constexpr accessor_conjugate(Accessor a);
+```
+
+* *Effects:* Direct non-list-initializes `acc_` with `a`.
+
+```c++
+constexpr reference access(data_handle_type p, size_t i) const
+  noexcept(noexcept(reference(acc_.access(p, i))));
+```
+
+* *Effects:* Equivalent to `return reference(acc_.access(p, i));`.
+
+```c++
+constexpr typename offset_policy::data_handle_type
+  offset(data_handle_type p, size_t i) const
+    noexcept(noexcept(acc_.offset(p, i)));
+```
+
+* *Effects:* Equivalent to `return acc_.offset(p, i);`.
+
+```c++
+constexpr Accessor nested_accessor() const;
+```
+
+* *Effects:* Equivalent to `return acc_;`.
+
+### `conjugated` [linalg.conj.conjugated]
+
+```c++
+template<class ElementType,
+         class Extents,
+         class Layout,
+         class Accessor>
+constexpr auto conjugated(
+  mdspan<ElementType, Extents, Layout, Accessor> a);
+```
+
+Let `R` name the type
+`mdspan<ReturnElementType, Extents, Layout, ReturnAccessor>`,
+where
+
+* `ReturnElementType` is
+
+    * if `Accessor` is `accessor_conjugate<NestedAccessor>`
+        for some `NestedAccessor`, then
+        `typename NestedAccessor::element_type` *[Note:*
+        conjugation is self-annihilating --*end note]*;
+
+    * else if `remove_cv_t<ElementType>` is an arithmetic type,
+        then `ElementType`;
+
+    * else `accessor_conjugate<Accessor>::element_type`;
+
+* and `ReturnAccessor` is:
+
+    * if `Accessor` is `accessor_conjugate<NestedAccessor>`
+        for some `NestedAccessor`, then `NestedAccessor` *[Note:*
+        conjugation is self-annihilating --*end note]*;
+
+    * else if `remove_cv_t<ElementType>` is an arithmetic type,
+        then `Accessor` *[Note:* this reduces nesting
+        in cases where conjugation is known to be the identity
+        --*end note]*;
+
+    * else `accessor_conjugate<Accessor>`.
+
+*Effects:*
+
+    * If `Accessor` is `accessor_conjugate<NestedAccessor>`,
+        then equivalent to
+        `return R(a.data(), a.mapping(), a.nested_accessor());`;
+
+    * else if `remove_cv_t<ElementType>` is an arithmetic type,
+        then equivalent to
+        `return R(a.data(), a.mapping(), a.accessor());`;
+
+    * else, equivalent to
+        `return R(a.data(), a.mapping(), ReturnAccessor(a.accessor()));`;
+
+*[Note:*
+The elements of the returned `mdspan` are read only.
+--*end note]*;
+
+[*Example:*
+```c++
+void test_conjugated_complex(
+  mdspan<complex<double>, extents<int, 10>> a)
+{
+  auto a_conj = conjugated(a);
+  for(int i = 0; i < a.extent(0); ++i) {
+    assert(a_conj[i] == conj(a[i]);
+  }
+  auto a_conj_conj = conjugated(a_conj);
+  for(int i = 0; i < a.extent(0); ++i) {
+    assert(a_conj_conj[i] == a[i]);
+  }
+}
+
+void test_conjugated_real(
+  mdspan<double, extents<int, 10>> a)
+{
+  auto a_conj = conjugated(a);
+  for(int i = 0; i < a.extent(0); ++i) {
+    assert(a_conj[i] == a[i]);
+  }
+  auto a_conj_conj = conjugated(a_conj);
+  for(int i = 0; i < a.extent(0); ++i) {
+    assert(a_conj_conj[i] == a[i]);
+  }
+}
+```
+--*end example*]
+
+## Transpose in-place transformation [linalg.transp]
+
+`layout_transpose` is an `mdspan` layout mapping policy that
+swaps the rightmost two indices, extents, and strides (if applicable)
+of any unique `mdspan` layout mapping policy.
+
+The `transposed` function takes an `mdspan`
+representing a matrix, and returns a new read-only `mdspan`
+representing the transpose of the input matrix.
+
+### `layout_transpose` [linalg.transp.layout_transpose]
+
+`layout_transpose` is an `mdspan` layout mapping policy that
+swaps the rightmost two indices, extents, and strides (if applicable)
+of any unique `mdspan` layout mapping policy.
+
+```c++
+template<class InputExtents>
+using transpose_extents_t = /* see below */; // exposition only
+```
+
+For `InputExtents` a specialization of `extents`,
+`transpose_extents_t<InputExtents>` names the `extents` type
+`OutputExtents` such that
+
+* `InputExtents::static_extent(InputExtents::rank()-1)` equals
+    `OutputExtents::static_extent(OutputExtents::rank()-2)`,
+
+* `InputExtents::static_extent(InputExtents::rank()-2)` equals
+    `OutputExtents::static_extent(OutputExtents::rank()-1)`, and
+
+* `InputExtents::static_extent(r)` equals
+    `OutputExtents::static_extent(r)` for 0 ≤ `r` <
+    `InputExtents::rank()-2`.
+
+* *Preconditions:* `InputExtents` is a specialization of `extents`.
+
+* *Constraints:* `InputExtents::rank()` equals 2.
+
+```c++
+template<class InputExtents>
+constexpr transpose_extents_t<InputExtents>
+transpose_extents(const InputExtents& in); // exposition only
+```
+
+* *Constraints:* `InputExtents::rank()` equals 2.
+
+* *Returns:* An `extents` object `out` such that
+
+    * `out.extent(in.rank()-1)` equals `in.extent(in.rank()-2)`,
+
+    * `out.extent(in.rank()-2)` equals `in.extent(in.rank()-1)`, and
+
+    * `out.extent(r)` equals `in.extent(r)` for 0 ≤ `r` < `in.rank()-2`.
+
+```c++
+template<class Layout>
+class layout_transpose {
+public:
+  template<class Extents>
+  struct mapping {
+  private:
+    using nested_mapping_type =
+      typename Layout::template mapping<
+        transpose_extents_t<Extents>>; // exposition only
+    nested_mapping_type nested_mapping_; // exposition only
+
+  public:
+    using extents_type = Extents;
+    using size_type = typename extents_type::size_type;
+    using layout_type = layout_transpose;
+
+    constexpr explicit mapping(const nested_mapping_type& map);
+
+    constexpr extents_type extents() const
+      noexcept(noexcept(nested_mapping_.extents()));
+
+    constexpr size_type required_span_size() const
+      noexcept(noexcept(nested_mapping_.required_span_size()));
+
+    template<class... Indices>
+      constexpr size_type operator()(Indices... indices) const
+        noexcept(noexcept(nested_mapping_(indices...)));
+
+    constexpr nested_mapping_type nested_mapping() const;
+
+    static constexpr bool is_always_unique();
+    static constexpr bool is_always_contiguous();
+    static constexpr bool is_always_strided();
+
+    constexpr bool is_unique() const
+      noexcept(noexcept(nested_mapping_.is_unique()));
+    constexpr bool is_contiguous() const
+      noexcept(noexcept(nested_mapping_.is_contiguous()));
+    constexpr bool is_strided() const
+      noexcept(noexcept(nested_mapping_.is_strided()));
+
+    constexpr size_type stride(size_t r) const
+      noexcept(noexcept(nested_mapping_.stride(r)));
+
+    template<class OtherExtents>
+      friend constexpr bool
+        operator==(const mapping&, const mapping<OtherExtents>&) noexcept;
+  };
+};
+```
+
+* *Preconditions:* `Layout` shall meet the `mdspan` layout mapping policy requirements.
+
+* *Constraints:* `Extents::rank()` equals 2.
+
+```c++
+constexpr explicit mapping(const nested_mapping_type& map);
+```
+
+* *Effects:* Initializes `nested_mapping_` with `map`.
+
+```c++
+constexpr extents_type extents() const
+  noexcept(noexcept(nested_mapping_.extents()));
+```
+
+* *Effects:* Equivalent to
+    `return transpose_extents(nested_mapping_.extents());`.
+
+```c++
+constexpr size_type required_span_size() const
+  noexcept(noexcept(nested_mapping_.required_span_size()));
+```
+
+* *Effects:* Equivalent to `return nested_mapping_.required_span_size();`.
+
+```c++
+template<class... Indices>
+  constexpr size_type operator()(Indices... indices) const
+    noexcept(noexcept(nested_mapping_(indices...)));
+```
+
+* *Effects:* Equivalent to `return nested_mapping_(last_two_indices_reversed);`,
+    where `last_two_indices_reversed` is the result of
+    reversing the last two elements of `indices`.
+
+```c++
+constexpr nested_mapping_type nested_mapping() const;
+```
+
+* *Effects:* Equivalent to `return nested_mapping_;`.
+
+```c++
+static constexpr bool is_always_unique();
+```
+
+* *Effects:* Equivalent to
+    `return nested_mapping_type::is_always_unique();`.
+
+```c++
+static constexpr bool is_always_contiguous();
+```
+
+* *Effects:* Equivalent to
+    `return nested_mapping_type::is_always_contiguous();`.
+
+```c++
+static constexpr bool is_always_strided();
+```
+
+* *Effects:* Equivalent to
+    `return nested_mapping_type::is_always_strided();`.
+
+```c++
+constexpr bool is_unique() const
+  noexcept(noexcept(nested_mapping_.is_unique()));
+```
+
+* *Effects:* Equivalent to `return nested_mapping_.is_unique();`.
+
+```c++
+constexpr bool is_contiguous() const
+  noexcept(noexcept(nested_mapping_.is_contiguous()));
+```
+
+* *Effects:* Equivalent to `return nested_mapping_.is_contiguous();`.
+
+```c++
+constexpr bool is_strided() const
+  noexcept(noexcept(nested_mapping_.is_strided()));
+```
+
+* *Effects:* Equivalent to `return nested_mapping_.is_strided();`.
+
+```c++
+constexpr size_type stride(size_t r) const
+  noexcept(noexcept(nested_mapping_.stride(r)));
+```
+
+* *Constraints:* `is_always_strided()` is `true`.
+
+* *Effects:* Equivalent to `return nested_mapping_.stride(s);`, where
+
+    * `s` is `rank()` - 2 if `r` equals `rank()` - 1,
+
+    * `s` is `rank()` - 1 if `r` equals `rank()` - 2, and
+
+    * `s` is `r` for 0 ≤ `r` < `in.rank()-2`.
+
+```c++
+template<class OtherExtents>
+  friend constexpr bool
+    operator==(const mapping&, const mapping<OtherExtents>&) noexcept;
+```
+
+* *Constraints:*
+
+    * `nested_mapping_type` and `decltype(m.nested_mapping_)` are equality comparable, and
+
+    * `OtherExtents::rank()` equals `rank()`.
+
+* *Effects:* Equivalent to `nested_mapping_ == m.nested_mapping_;`.
+
+### `transposed` [linalg.transp.transposed]
+
+The `transposed` function takes a rank-2 `mdspan`
+representing a matrix, and returns a new read-only `mdspan`
+representing the transpose of the input matrix.  The input matrix's
+data are not modified, and the returned `mdspan` accesses the
+input matrix's data in place.
+
+```c++
+template<class ElementType,
+         class Extents,
+         class Layout,
+         class Accessor>
+constexpr auto transposed(
+  mdspan<ElementType, Extents, Layout, Accessor> a);
+```
+
+Let `ReturnExtents` name the type `transpose_extents_t<Extents>`.
+Let `R` name the type
+`mdspan<ReturnElementType, ReturnExtents, ReturnLayout, ReturnAccessor>`,
+where
+
+* `ReturnElementType` is:
+
+    * if `Accessor` is `default_accessor<ElementType>`,
+        then `add_const_t<ElementType>`;
+
+    * else, `ElementType`; *[Note:* For general accessors,
+        the `const ElementType` version of the accessor may not exist;
+        Even if it does, `transposed` has no way to deduce it generically.
+        --*end note]*
+
+* `ReturnLayout` is:
+
+    * if `Layout` is `layout_left`, then `layout_right`;
+
+    * else if `Layout` is `layout_right`, then `layout_left`;
+
+    * else if `Layout` is `layout_stride`, then `layout_stride`;
+
+    * else if `Layout` is `layout_left_padded<padding_stride>` for some `padding_stride`,
+      then `layout_right_padded<padding_stride>`;
+
+    * else if `Layout` is `layout_right_padded<padding_stride>` for some `padding_stride`,
+      then `layout_left_padded<padding_stride>`;
+
+    * else if `Layout` is `layout_blas_packed<Triangle, StorageOrder>`
+        for some `Triangle` and `StorageOrder`,
+        then `layout_blas_packed<OppositeTriangle, OppositeStorageOrder>`,
+        where
+
+        * `OppositeTriangle` names the type
+            `conditional_t<is_same_v<Triangle, upper_triangle_t>,
+            lower_triangle_t, upper_triangle_t>`, and
+
+        * `OppositeStorageOrder` names the type
+            `conditional_t<is_same_v<StorageOrder, column_major_t>,
+            row_major_t, column_major_t>`;
+
+    * else if `Layout` is `layout_transpose<NestedLayout>`
+        for some `NestedLayout`, then `NestedLayout` *[Note:*
+        this optimizes applying `transposed` twice
+        to an `mdspan` with a custom layout,
+        as long as there are no intervening layout changes --*end note]*;
+
+    * else, `layout_transpose<Layout>`;
+
+* and, `ReturnAccessor` is:
+
+    * if `Accessor` is `default_accessor<ElementType>`,
+        then `default_accessor<add_const_t<ElementType>>`;
+
+    * else, `Accessor`.
+
+* *Effects:*
+
+    * If `Layout` is `layout_left`, `layout_right`, or
+        `layout_blas_packed<Triangle, StorageOrder>`
+        for some `Triangle` and `StorageOrder`,
+        then equivalent to
+```c++
+return R(a.data(),
+  ReturnMapping(transpose_extents(a.mapping().extents())),
+  a.accessor());
+```
+
+    * else, if `Layout` is `layout_left_padded<padding_stride>`
+        for some `padding_stride`, then equivalent to
+```c++
+return R(a.data(),
+  ReturnMapping(
+    transpose_extents(a.mapping().extents()),
+    a.mapping().stride(1)),
+  a.accessor());
+```
+
+    * else, if `Layout` is `layout_right_padded<padding_stride>`
+        for some `padding_stride`, then equivalent to
+```c++
+return R(a.data(),
+  ReturnMapping(
+    transpose_extents(a.mapping().extents()),
+    a.mapping().stride(0)),
+  a.accessor());
+```
+
+    * else, if `Layout` is `layout_stride`, then equivalent to
+        *[Note:* reverse the strides as well as the extents --*end note]*
+```c++
+return R(a.data(),
+  ReturnMapping(
+    transpose_extents(a.mapping().extents()),
+    array<decltype(), a.mapping().rank()>{
+      a.mapping().stride(1),
+      a.mapping().stride(0)}),
+    a.accessor());
+```
+
+    * else, if `Layout` is `layout_transpose<NestedLayout>`
+        for some `NestedLayout`, then equivalent to
+        *[Note:* getting the nested mapping untransposes the extents --*end note]*
+```c++        
+return R(a.data(), a.mapping().nested_mapping(), a.accessor());
+```
+
+    * else, equivalent to
+        `return R(a.data(), ReturnMapping(a.mapping()), a.accessor());`,
+        where `ReturnMapping` names the type
+        `typename layout_transpose<Layout>::template mapping<ReturnExtents>`.
+
+* *Remarks:* The elements of the returned `mdspan` are read only.
+
+[*Example:*
+```c++
+void test_transposed(mdspan<double, extents<size_t, 3, 4>> a)
+{
+  const auto num_rows = a.extent(0);
+  const auto num_cols = a.extent(1);
+
+  auto a_t = transposed(a);
+  assert(num_rows == a_t.extent(1));
+  assert(num_cols == a_t.extent(0));
+  assert(a.stride(0) == a_t.stride(1));
+  assert(a.stride(1) == a_t.stride(0));
+
+  for(size_t row = 0; row < num_rows; ++row) {
+    for(size_t col = 0; col < num_rows; ++col) {
+      assert(a[row, col] == a_t[col, row]);
+    }
+  }
+
+  auto a_t_t = transposed(a_t);
+  assert(num_rows == a_t_t.extent(0));
+  assert(num_cols == a_t_t.extent(1));
+  assert(a.stride(0) == a_t_t.stride(0));
+  assert(a.stride(1) == a_t_t.stride(1));
+
+  for(size_t row = 0; row < num_rows; ++row) {
+    for(size_t col = 0; col < num_rows; ++col) {
+      assert(a[row, col] == a_t_t[row, col]);
+    }
+  }
+}
+```
+--*end example*]
+
+## Conjugate transpose transform [linalg.conj_transp]
+
+The `conjugate_transposed` function returns a conjugate transpose
+view of an object.  This combines the effects of `transposed` and
+`conjugated`.
+
+```c++
+template<class ElementType,
+         class Extents,
+         class Layout,
+         class Accessor>
+constexpr auto conjugate_transposed(
+  mdspan<ElementType, Extents, Layout, Accessor> a);
+```
+
+* *Effects:* Equivalent to `return conjugated(transposed(a));`.
+
+[*Example:*
+```c++
+void test_conjugate_transposed(
+  mdspan<complex<double>, extents<size_t, 3, 4>> a)
+{
+  const auto num_rows = a.extent(0);
+  const auto num_cols = a.extent(1);
+
+  auto a_ct = conjugate_transposed(a);
+  assert(num_rows == a_ct.extent(1));
+  assert(num_cols == a_ct.extent(0));
+  assert(a.stride(0) == a_ct.stride(1));
+  assert(a.stride(1) == a_ct.stride(0));
+
+  for(size_t row = 0; row < num_rows; ++row) {
+    for(size_t col = 0; col < num_rows; ++col) {
+      assert(a[row, col] == conj(a_ct[col, row]));
+    }
+  }
+
+  auto a_ct_ct = conjugate_transposed(a_ct);
+  assert(num_rows == a_ct_ct.extent(0));
+  assert(num_cols == a_ct_ct.extent(1));
+  assert(a.stride(0) == a_ct_ct.stride(0));
+  assert(a.stride(1) == a_ct_ct.stride(1));
+
+  for(size_t row = 0; row < num_rows; ++row) {
+    for(size_t col = 0; col < num_rows; ++col) {
+      assert(a[row, col] == a_ct_ct[row, col]);
+      assert(conj(a_ct[col, row]) == a_ct_ct[row, col]);
+    }
+  }
+}
+```
+--*end example*]
+
+## Algorithms [linalg.algs]
+
+### Requirements based on template parameter name [linalg.algs.reqs]
+
+Throughout this Clause, where the template parameters are not
+constrained, the names of template parameters are used to express type
+requirements.  In the requirements below, we use `*` in a typename to
+denote a "wildcard," that matches zero characters, `_1`, `_2`, `_3`,
+or other things as appropriate.
+
+* Algorithms that have a template parameter named `ExecutionPolicy`
+    are parallel algorithms **[algorithms.parallel.defns]**.
+
+* `Real` is any type such that `complex<Real>` is specified.
+    *[Note:* See **[complex.numbers.general]**. --*end note]*
+
+* `in_vector*_t` is a rank-1 `mdspan` with a
+    potentially `const` element type and a unique layout.
+    If the algorithm accesses the object, it will do so in read-only fashion.
+
+* `inout_vector*_t` is a rank-1 `mdspan`
+    with a non-`const` element type,
+    and whose layout is always unique
+    (`layout_type::is_always_unique()` equals `true`).
+
+* `out_vector*_t` is a rank-1 `mdspan`
+    with a non-`const` element type,
+    and whose layout is always unique
+    (`layout_type::is_always_unique()` equals `true`).
+    If the algorithm accesses the object, it will do so in write-only fashion.
+
+* `in_matrix*_t` is a rank-2 `mdspan` with a
+    `const` element type.
+    If the algorithm accesses the object, it will do so in read-only fashion.
+
+* `inout_matrix*_t` is a rank-2 `mdspan`
+    with a non-`const` element type.
+
+* `out_matrix*_t` is a rank-2 `mdspan` with
+    a non-`const` element type.
+    If the algorithm accesses the object, it will do so in write-only fashion.
+
+* `in_object*_t` is a rank-1 or rank-2
+    `mdspan` with a potentially `const` element type,
+    and whose layout is always unique
+    (`layout_type::is_always_unique()` equals `true`).
+    If the algorithm accesses the object,
+    it will do so in read-only fashion.
+
+* `inout_object*_t` is a rank-1 or rank-2
+    `mdspan` with a non-`const` element type,
+    and whose layout is always unique
+    (`layout_type::is_always_unique()` equals `true`).
+
+* `out_object*_t` is a rank-1 or rank-2
+    `mdspan` with a non-`const` element type,
+    and whose layout is always unique
+    (`layout_type::is_always_unique()` equals `true`).
+
+* `Triangle` is either `upper_triangle_t` or `lower_triangle_t`.
+
+* `DiagonalStorage` is either `implicit_unit_diagonal_t` or `explicit_diagonal_t`.
+
+* `in_*_t` template parameters may deduce a `const` lvalue reference
+    or a (non-`const`) rvalue reference to an `mdspan`.
+
+* `inout_*_t` and `out_*_t` template parameters may deduce
+    a `const` lvalue reference to an `mdspan`, or
+    a (non-`const`) rvalue reference to an `mdspan`.
+
+* `BinaryDivideOp` template parameters
+    are a binary function object (**[function.objects]**).
+
+### BLAS 1 functions [linalg.algs.blas1]
+
+*[Note:*
+
+The BLAS developed in three "levels": 1, 2, and 3.  BLAS 1 includes
+vector-vector operations, BLAS 2 matrix-vector operations, and BLAS 3
+matrix-matrix operations.  The level coincides with the number of
+nested loops in a naïve sequential implementation of the operation.
+Increasing level also comes with increasing potential for data reuse.
+The BLAS traditionally lists computing a Givens rotation among the
+BLAS 1 operations, even though it only operates on scalars.
+
+--*end note]*
+
+*Complexity:*
+All algorithms in this Clause with `mdspan` parameters
+perform a count of `mdspan` array accesses and arithmetic operations
+that is linear in the maximum product of extents of any `mdspan` parameter.
+
+#### Givens rotations [linalg.algs.blas1.givens]
+
+##### Compute Givens rotation [linalg.algs.blas1.givens.lartg]
+
+```c++
+template<class Real>
+void givens_rotation_setup(const Real a,
+                           const Real b,
+                           Real& c,
+                           Real& s,
+                           Real& r);
+
+template<class Real>
+void givens_rotation_setup(const complex<Real>& a,
+                           const complex<Real>& b,
+                           Real& c,
+                           complex<Real>& s,
+                           complex<Real>& r);
+```
+
+This function computes the plane (Givens) rotation represented by the
+two values `c` and `s` such that the 2x2 system of equations
+*[Note:* use of monospaced text in this equation does not indicate C++ code --*end note]*
+
+```
+[c        s]   [a]   [r]
+[          ] * [ ] = [ ]
+[-conj(s) c]   [b]   [0]
+```
+
+holds, where `c` is always a real scalar, and `c*c + abs(s)*abs(s)` equals one.
+That is, `c` and `s` represent a 2 x 2 matrix, that when multiplied by the
+right by the input vector whose components are `a` and `b`, produces a
+result vector whose first component `r` is the Euclidean norm of the
+input vector, and whose second component as zero.
+
+*[Note:*
+This function corresponds to the LAPACK function `xLARTG`.
+The BLAS variant `xROTG` takes four arguments -- `a`, `b`, `c`, and
+`s`-- and overwrites the input `a` with `r`.  We have chosen
+`xLARTG`'s interface because it separates input and output, and to
+encourage following `xLARTG`'s more careful implementation.
+--*end note]*
+
+*[Note:*
+`givens_rotation_setup` has an overload for complex numbers,
+because the output argument `c` (cosine) is a signed magnitude.
+--*end note]*
+
+* *Effects:* Assigns to `c` and `s` the plane (Givens) rotation
+    corresponding to the input `a` and `b`.  Assigns to `r` the
+    Euclidean norm of the two-component vector formed by `a` and `b`.
+
+* *Throws:* Nothing.
+
+##### Apply a computed Givens rotation to vectors [linalg.algs.blas1.givens.rot]
+
+```c++
+template<class inout_vector_1_t,
+         class inout_vector_2_t,
+         class Real>
+void givens_rotation_apply(
+  inout_vector_1_t x,
+  inout_vector_2_t y,
+  const Real c,
+  const Real s);
+
+template<class ExecutionPolicy,
+         class inout_vector_1_t,
+         class inout_vector_2_t,
+         class Real>
+void givens_rotation_apply(
+  ExecutionPolicy&& exec,
+  inout_vector_1_t x,
+  inout_vector_2_t y,
+  const Real c,
+  const Real s);
+
+template<class inout_vector_1_t,
+         class inout_vector_2_t,
+         class Real>
+void givens_rotation_apply(
+  inout_vector_1_t x,
+  inout_vector_2_t y,
+  const Real c,
+  const complex<Real> s);
+
+template<class ExecutionPolicy,
+         class inout_vector_1_t,
+         class inout_vector_2_t,
+         class Real>
+void givens_rotation_apply(
+  ExecutionPolicy&& exec,
+  inout_vector_1_t x,
+  inout_vector_2_t y,
+  const Real c,
+  const complex<Real> s);
+```
+
+*[Note:*
+These functions correspond to the BLAS function `xROT`.  `c` and `s`
+form a plane (Givens) rotation.  Users normally would compute `c` and
+`s` using `givens_rotation_setup`, but they are not required to do
+this.
+--*end note]*
+
+For `i` in the domains of both `x` and `y`,
+the mathematical expressions for the algorithm are
+`x[i] = c*x[i] + s*y[i]` and
+`y[i] = c*y[i] - `_`conj-if-needed`_`(s)*x[i]`.
+
+* *Preconditions:* `x.extent(0)` equals `y.extent(0)`.
+
+* *Mandates:* If neither `x.static_extent(0)` nor `y.static_extent(0)`
+    equals `dynamic_extent`, then `x.static_extent(0)` equals
+    `y.static_extent(0)`.
+
+* *Effects:* Applies the plane (Givens) rotation specified by `c` and
+    `s` to the input vectors `x` and `y`,
+    as if the rotation were a 2 x 2 matrix and
+    the input vectors were successive rows of a matrix with two rows.
+
+#### Swap matrix or vector elements [linalg.algs.blas1.swap]
+
+```c++
+template<class inout_object_1_t,
+         class inout_object_2_t>
+void swap_elements(inout_object_1_t x,
+                   inout_object_2_t y);
+
+template<class ExecutionPolicy,
+         class inout_object_1_t,
+         class inout_object_2_t>
+void swap_elements(ExecutionPolicy&& exec,
+                   inout_object_1_t x,
+                   inout_object_2_t y);
+```
+
+*[Note:* These functions correspond to the BLAS function `xSWAP`.
+--*end note]*
+
+* *Preconditions:* For all `r` in 0, 1, ..., `x.rank()` - 1,
+    `x.extent(r)` equals `y.extent(r)`.
+
+* *Constraints:*
+
+    * `x.rank()` equals `y.rank()`.
+
+    * `x.rank()` is no more than 2.
+
+    * For `i...` in the domain of `x` and `y`,
+        the expression `x[i...] = y[i...]` is well formed.
+
+* *Mandates:* For all `r` in 0, 1, ..., `x.rank()` - 1,
+    if neither `x.static_extent(r)` nor `y.static_extent(r)`
+    equals `dynamic_extent`,
+    then `x.static_extent(r)` equals `y.static_extent(r)`.
+
+* *Effects:* Swap all corresponding elements of the objects
+    `x` and `y`.
+
+#### Multiply the elements of an object in place by a scalar [linalg.algs.blas1.scal]
+
+```c++
+template<class Scalar,
+         class inout_object_t>
+void scale(const Scalar alpha,
+           inout_object_t obj);
+
+template<class ExecutionPolicy,
+         class Scalar,
+         class inout_object_t>
+void scale(ExecutionPolicy&& exec,
+           const Scalar alpha,
+           inout_object_t obj);
+```
+
+*[Note:* These functions correspond to the BLAS function `xSCAL`.
+--*end note]*
+
+For `i...` in the domain of `obj`,
+the mathematical expression for the algorithm is `obj[i...] = alpha * obj[i...]`.
+
+* *Constraints:* `obj.rank()` is less than or equal to 2.
+
+* *Effects*: Replace each element of `obj` in place
+    by the product of `alpha` and that element.
+
+#### Copy elements of one matrix or vector into another [linalg.algs.blas1.copy]
+
+```c++
+template<class in_object_t,
+         class out_object_t>
+void copy(in_object_t x,
+          out_object_t y);
+
+template<class ExecutionPolicy,
+         class in_object_t,
+         class out_object_t>
+void copy(ExecutionPolicy&& exec,
+          in_object_t x,
+          out_object_t y);
+```
+
+*[Note:* These functions correspond to the BLAS function `xCOPY`.
+--*end note]*
+
+* *Preconditions:* For all `r` in 0, 1, ..., `x.rank()` - 1,
+    `x.extent(r)` equals `y.extent(r)`.
+
+* *Constraints:*
+
+    * `x.rank()` equals `y.rank()`.
+
+    * For all `i...` in the domain of `x` and `y`,
+        the expression `y[i...] = x[i...]` is well formed.
+
+* *Mandates:* For all `r` in 0, 1, ..., `x.rank()` - 1, if neither
+    `x.static_extent(r)` nor `y.static_extent(r)` equals
+    `dynamic_extent`, then `x.static_extent(r)` equals
+    `y.static_extent(r)`.
+
+* *Effects:* Overwrite each element of `y` with the corresponding
+    element of `x`.
+
+#### Add vectors or matrices elementwise [linalg.algs.blas1.add]
+
+```c++
+template<class in_object_1_t,
+         class in_object_2_t,
+         class out_object_t>
+void add(in_object_1_t x,
+         in_object_2_t y,
+         out_object_t z);
+
+template<class ExecutionPolicy,
+         class in_object_1_t,
+         class in_object_2_t,
+         class out_object_t>
+void add(ExecutionPolicy&& exec,
+         in_object_1_t x,
+         in_object_2_t y,
+         out_object_t z);
+```
+
+*[Note:* These functions correspond to the BLAS function `xAXPY`.
+--*end note]*
+
+For `i...` in the domains of `x`, `y`, and `z`,
+the mathematical expression for the algorithm is `z[i...] = x[i...] + y[i...]`.
+
+* *Preconditions:* For all `r` in 0, 1, ..., `x.rank()` - 1,
+
+    * `x.extent(r)` equals `z.extent(r)`.
+
+    * `y.extent(r)` equals `z.extent(r)`.
+
+* *Constraints:* `x.rank()`, `y.rank()`, and `z.rank()` are all equal.
+
+* *Mandates:* For all `r` in 0, 1, ..., `x.rank()` - 1,
+
+    * if neither `x.static_extent(r)` nor `z.static_extent(r)` equals
+        `dynamic_extent`, then `x.static_extent(r)` equals
+        `z.static_extent(r)`; and
+
+    * if neither `y.static_extent(r)` nor `z.static_extent(r)` equals
+        `dynamic_extent`, then `y.static_extent(r)` equals
+        `z.static_extent(r)`.
+
+    * if neither `x.static_extent(r)` nor `y.static_extent(r)` equals
+        `dynamic_extent`, then `x.static_extent(r)` equals
+        `y.static_extent(r)`;
+
+* *Effects*: Compute the elementwise sum z = x + y.
+
+#### Dot product of two vectors [linalg.algs.blas1.dot]
+
+##### Nonconjugated dot product of two vectors [linalg.algs.blas1.dot.dotu]
+
+*[Note:* The functions in this section correspond to the BLAS
+functions `xDOT` (for real element types) and `xDOTU` (for complex
+element types).  --*end note]*
+
+Nonconjugated dot product with specified result type
+
+```c++
+template<class in_vector_1_t,
+         class in_vector_2_t,
+         class T>
+T dot(in_vector_1_t v1,
+      in_vector_2_t v2,
+      T init);
+template<class ExecutionPolicy,
+         class in_vector_1_t,
+         class in_vector_2_t,
+         class T>
+T dot(ExecutionPolicy&& exec,
+      in_vector_1_t v1,
+      in_vector_2_t v2,
+      T init);
+```
+
+For `N` equal to `v1.extent(0)`,
+the mathematical expression for the algorithm is
+`init = init` plus the sum of `v1[i] * v2[i]`
+for all `i` in the domain of `v1`.
+
+* *Preconditions:* `v1.extent(0)` equals `v2.extent(0)`.
+
+* *Mandates:* If neither `v1.static_extent(0)` nor
+    `v2.static_extent(0)` equals `dynamic_extent`, then
+    `v1.static_extent(0)` equals `v2.static_extent(0)`.
+
+* *Effects:* Let `N` be `v1.extent(0)`.
+    If `N` is zero, returns `init`, else returns
+    *GENERALIZED_SUM*(`plus<>()`, `init`, `v1[0]*v2[0]`, ..., `v1[N-1]*v2[N-1]`).
+
+* *Remarks:* If `in_vector_t::element_type` and `T` are both
+    floating-point types or complex versions thereof, and if `T` has
+    higher precision than `in_vector_type::element_type`, then
+    intermediate terms in the sum use `T`'s precision or greater.
+
+*[Note:* Like `reduce`, `dot` applies binary `operator+` in an
+unspecified order.  This may yield a nondeterministic result for
+non-associative or non-commutative `operator+` such as floating-point
+addition.  However, implementations may perform extra work to make the
+result deterministic.  They may do so for all `dot` overloads, or just
+for specific `ExecutionPolicy` types. --*end note]*
+
+*[Note:* Users can get `xDOTC` behavior by giving the first argument
+as the result of `conjugated`.  Alternately, they can use the shortcut `dotc`
+below. --*end note]*
+
+Nonconjugated dot product with default result type
+
+```c++
+template<class in_vector_1_t,
+         class in_vector_2_t>
+auto dot(in_vector_1_t v1,
+         in_vector_2_t v2) -> /* see-below */;
+template<class ExecutionPolicy,
+         class in_vector_1_t,
+         class in_vector_2_t>
+auto dot(ExecutionPolicy&& exec,
+         in_vector_1_t v1,
+         in_vector_2_t v2) -> /* see-below */;
+```
+
+* *Effects:* Let `T` be `decltype(v1[0]*v2[0])`.  Then, the
+    two-parameter overload is equivalent to `dot(v1, v2, T{});`, and the
+    three-parameter overload is equivalent to `dot(exec, v1, v2, T{});`.
+
+##### Conjugated dot product of two vectors [linalg.algs.blas1.dot.dotc]
+
+*[Note:*
+
+The functions in this section correspond to the BLAS functions `xDOT`
+(for real element types) and `xDOTC` (for complex element types).
+
+`dotc` exists to give users reasonable default inner product behavior
+for both real and complex element types.
+
+--*end note]*
+
+Conjugated dot product with specified result type
+
+```c++
+template<class in_vector_1_t,
+         class in_vector_2_t,
+         class T>
+T dotc(in_vector_1_t v1,
+       in_vector_2_t v2,
+       T init);
+template<class ExecutionPolicy,
+         class in_vector_1_t,
+         class in_vector_2_t,
+         class T>
+T dotc(ExecutionPolicy&& exec,
+       in_vector_1_t v1,
+       in_vector_2_t v2,
+       T init);
+```
+
+* *Effects:* The three-argument overload is equivalent to
+    `dot(conjugated(v1), v2, init);`.
+    The four-argument overload is equivalent to
+    `dot(exec, conjugated(v1), v2, init);`.
+
+Conjugated dot product with default result type
+
+```c++
+template<class in_vector_1_t,
+         class in_vector_2_t>
+auto dotc(in_vector_1_t v1,
+          in_vector_2_t v2) -> /* see-below */;
+template<class ExecutionPolicy,
+         class in_vector_1_t,
+         class in_vector_2_t>
+auto dotc(ExecutionPolicy&& exec,
+          in_vector_1_t v1,
+          in_vector_2_t v2) -> /* see-below */;
+```
+
+* *Effects:* Let `T` be `decltype(`_`conj-if-needed`_`(v1[0]) * v2[0])`.
+    Then, the two-parameter overload is
+    equivalent to `dotc(v1, v2, T{});`, and the three-parameter overload
+    is equivalent to `dotc(exec, v1, v2, T{});`.
+
+#### Scaled sum of squares of a vector's elements [linalg.algs.blas1.ssq]
+
+```c++
+template<class T>
+struct sum_of_squares_result {
+  T scaling_factor;
+  T scaled_sum_of_squares;
+};
+template<class in_vector_t,
+         class T>
+sum_of_squares_result<T> vector_sum_of_squares(
+  in_vector_t v,
+  sum_of_squares_result<T> init);
+template<class ExecutionPolicy,
+         class in_vector_t,
+         class T>
+sum_of_squares_result<T> vector_sum_of_squares(
+  ExecutionPolicy&& exec,
+  in_vector_t v,
+  sum_of_squares_result<T> init);
+```
+
+*[Note:* These functions correspond to the LAPACK function `xLASSQ`.
+--*end note]*
+
+* *Preconditions:*
+
+    * `T` shall be *Cpp17MoveConstructible* and *Cpp17LessThanComparable*, and
+
+    * `abs(x[0])` shall be convertible to `T`.
+
+* *Constraints:* For all `i` in the domain of `v`,
+    and for `f` and `ssq` of type `T`,
+    the expression `ssq = ssq + (abs(x[i]) / f)*(abs(x[i]) / f)` is well formed.
+
+* *Effects:* Returns two values:
+
+    * `scaling_factor`: the maximum of `init.scaling_factor`
+        and `abs(x[i])` for all `i` in the domain of `v`; and
+
+    * `scaled_sum_of_squares`: a value such that
+        `scaling_factor * scaling_factor * scaled_sum_of_squares`
+        equals the sum of squares of `abs(x[i])` plus
+        `init.scaling_factor * init.scaling_factor * init.scaled_sum_of_squares`.
+
+* *Remarks:* If `in_vector_t::element_type` is either a floating-point type
+    or `complex<R>` for some floating-point type `R`,
+    and if `T` is a floating-point type, then
+
+    * if `T` has higher precision than `in_vector_type::element_type`, then
+        intermediate terms in the sum use `T`'s precision or greater; and
+    * any guarantees regarding overflow and underflow of `vector_sum_of_squares`
+        are implementation-defined.
+
+#### Euclidean norm of a vector [linalg.algs.blas1.nrm2]
+
+##### Euclidean norm with specified result type
+
+```c++
+template<class in_vector_t,
+         class T>
+T vector_norm2(in_vector_t v,
+               T init);
+template<class ExecutionPolicy,
+         class in_vector_t,
+         class T>
+T vector_norm2(ExecutionPolicy&& exec,
+               in_vector_t v,
+               T init);
+```
+
+*[Note:* These functions correspond to the BLAS function `xNRM2`.
+--*end note]*
+
+For `N` equal to `v.extent(0)`,
+the mathematical expression for the algorithm is
+`sqrt(init + s)`,
+where `s` is the sum of `abs(v[i]) * abs(v[i])`
+for all `i` in the domain of `v`.
+*[Note:*
+This does not imply a recommended implementation for floating-point types.
+See *Remarks* below.
+--*end note]*
+
+* *Preconditions:* `init + abs(declval<in_vector_t::value_type>())*abs(declval<in_vector_t::value_type>())`
+    shall be convertible to `T`.
+
+* *Effects:* Returns the square root of the sum of squares
+    of `init` and the absolute values of the elements of `A`.
+    *[Note:*
+    For `init` equal to zero, this is the Euclidean norm
+    (also called 2-norm) of the vector `v`.
+
+    This description does not imply a recommended implementation
+    for floating-point types.
+    See *Remarks* below.
+    --*end note]*
+
+* *Remarks:* If `in_vector_t::element_type` is a floating-point type
+    or a complex version thereof, and if `T` is a floating-point type, then
+
+    * if `T` has higher precision than `in_vector_type::element_type`, then
+        intermediate terms in the sum use `T`'s precision or greater; and
+
+    * any guarantees regarding overflow and underflow of `vector_norm2`
+        are implementation-defined.
+
+*[Note:*
+The `abs` function is invoked via unqualified lookup.
+
+A suggested implementation of this function for floating-point types `T`
+would use the `scaled_sum_of_squares` result
+from `vector_sum_of_squares(x, {.scaling_factor=1.0, .scaled_sum_of_squares=init})`.
+--*end note]*
+
+##### Euclidean norm with default result type
+
+```c++
+template<class in_vector_t>
+auto vector_norm2(in_vector_t v) -> /* see-below */;
+template<class ExecutionPolicy,
+         class in_vector_t>
+auto vector_norm2(ExecutionPolicy&& exec,
+                  in_vector_t v) -> /* see-below */;
+```
+
+* *Effects:* Let `T` be `decltype(abs(v[0]) * abs(v[0]))`.
+    Then, the one-parameter overload is equivalent to
+    `vector_norm2(v, T{});`,
+    and the two-parameter overload is equivalent to
+    `vector_norm2(exec, v, T{});`.
+
+#### Sum of absolute values of vector elements [linalg.algs.blas1.asum]
+
+##### Sum of absolute values with specified result type
+
+```c++
+template<class in_vector_t,
+         class T>
+T vector_abs_sum(in_vector_t v,
+                 T init);
+template<class ExecutionPolicy,
+         class in_vector_t,
+         class T>
+T vector_abs_sum(ExecutionPolicy&& exec,
+                 in_vector_t v,
+                 T init);
+```
+
+*[Note:* This function corresponds to the BLAS functions `SASUM`,
+`DASUM`, `CSASUM`, and `DZASUM`.  The different behavior for complex
+element types is based on the observation that this lower-cost
+approximation of the one-norm serves just as well as the actual
+one-norm for many linear algebra algorithms in practice. --*end note]*
+
+For `N` equal to `v.extent(0)`,
+the mathematical expression for the algorithm is
+`init` plus the sum of `abs(v[i])`
+for all `i` in the domain of `v`.
+
+* *Preconditions:* For `i` in the domain of `v`,
+    `init + abs(v[i])` shall be convertible to `T`.
+
+* *Effects:* Let `N` be `v.extent(0)`:
+
+    * If `N` is zero, returns `init`;
+
+    * else, if `in_vector_t::element_type` is `complex<R>` for some `R`,
+        then returns *GENERALIZED_SUM*(`plus<>()`, `init`,
+        `abs(real(v[0])) + abs(imag(v[0]))`, ...,
+        `abs(real(v[N-1])) + abs(imag(v[N-1]))`).
+
+    * else, returns *GENERALIZED_SUM*(`plus<>()`, `init`,
+        `abs(v[0])`, ..., `abs(v[N-1])`).
+
+* *Remarks:* If `in_vector_t::element_type` is a floating-point type
+    or a complex version thereof, if `T` is a floating-point type,
+    and if `T` has higher precision than `in_vector_type::element_type`,
+    then intermediate terms in the sum use `T`'s precision or greater.
+
+*[Note:*
+The `abs`, `real`, and `imag` functions are invoked via unqualified lookup.
+--*end note]*
+
+##### Sum of absolute values with default result type
+
+```c++
+template<class in_vector_t>
+auto vector_abs_sum(in_vector_t v) -> /* see-below */;
+template<class ExecutionPolicy,
+         class in_vector_t>
+auto vector_abs_sum(ExecutionPolicy&& exec,
+                    in_vector_t v) -> /* see-below */;
+```
+
+* *Effects:* Let `T` be `decltype(abs(v[0]))`.  Then, the
+    one-parameter overload is equivalent to `vector_abs_sum(v, T{});`,
+    and the two-parameter overload is equivalent to
+    `vector_abs_sum(exec, v, T{});`.
+
+#### Index of maximum absolute value of vector elements [linalg.algs.blas1.iamax]
+
+```c++
+template<class in_vector_t>
+typename in_vector_t::size_type idx_abs_max(in_vector_t v);
+
+template<class ExecutionPolicy,
+         class in_vector_t>
+typename in_vector_t::size_type	idx_abs_max(
+  ExecutionPolicy&& exec,
+  in_vector_t v);
+```
+
+*[Note:* These functions correspond to the BLAS function `IxAMAX`.
+--*end note]*
+
+* *Preconditions:* For `i` in the domain of `v`,
+    let `abs_value_type` be `decltype(v[i])`;
+    then, `abs_value_type` shall be *Cpp17LessThanComparable*.
+
+* *Effects:* Returns the index (in the domain of `v`) of
+    the first element of `v` having largest absolute value.  If `v` has
+    zero elements, then returns
+    `numeric_limits<typename in_vector_t::size_type>::max()`.
+
+*[Note:*
+The `abs` function is invoked via unqualified lookup.
+--*end note]*
+
+#### Frobenius norm of a matrix [linalg.algs.blas1.matfrobnorm]
+
+##### Frobenius norm with specified result type
+
+```c++
+template<class in_matrix_t,
+         class T>
+T matrix_frob_norm(
+  in_matrix_t A,
+  T init);
+template<class ExecutionPolicy,
+         class in_matrix_t,
+         class T>
+T matrix_frob_norm(
+  ExecutionPolicy&& exec,
+  in_matrix_t A,
+  T init);
+```
+
+* *Preconditions:* `init + abs(declval<in_matrix_t::value_type>())*abs(declval<in_matrix_t::value_type>())`
+    shall be convertible to `T`.
+
+* *Effects:* Returns the square root of the sum of squares
+    of `init` and the absolute values of the elements of `A`.
+    *[Note:*
+    For `init` equal to zero, this is the Frobenius norm of the matrix `A`.
+
+    This description does not imply a recommended implementation
+    for floating-point types.
+    See *Remarks* below.
+    --*end note]*
+
+* *Remarks:* If `in_matrix_t::element_type` is a floating-point type
+    or `complex<R>` for some floating-point type `R`,
+    and if `T` is a floating-point type, then
+
+    * if `T` has higher precision than `in_matrix_type::element_type`, then
+        intermediate terms in the sum use `T`'s precision or greater; and
+
+    * any guarantees regarding overflow and underflow of `matrix_frob_norm`
+        are implementation-defined.
+
+*[Note:*
+The `abs` function is invoked via unqualified lookup.
+--*end note]*
+
+##### Frobenius norm with default result type
+
+```c++
+template<class in_matrix_t>
+auto matrix_frob_norm(
+  in_matrix_t A) -> /* see-below */;
+template<class ExecutionPolicy,
+         class in_matrix_t>
+auto matrix_frob_norm(
+  ExecutionPolicy&& exec,
+  in_matrix_t A) -> /* see-below */;
+```
+
+* *Effects:* Let `T` be `abs(declval<in_matrix_t::value_type>())*abs(declval<in_matrix_t::value_type>())`.
+    Then, the one-parameter overload is equivalent to
+    `matrix_frob_norm(A, T{});`,
+    and the two-parameter overload is equivalent to
+    `matrix_frob_norm(exec, A, T{});`.
+
+#### One norm of a matrix [linalg.algs.blas1.matonenorm]
+
+##### One norm with specified result type
+
+```c++
+template<class in_matrix_t,
+         class T>
+T matrix_one_norm(
+  in_matrix_t A,
+  T init);
+template<class ExecutionPolicy,
+         class in_matrix_t,
+         class T>
+T matrix_one_norm(
+  ExecutionPolicy&& exec,
+  in_matrix_t A,
+  T init);
+```
+
+* *Preconditions:* `abs(A[0,0])` shall be convertible to `T`.
+
+* *Effects:*
+
+    * If `A.extent(1)` is zero, returns `init`;
+
+    * else, returns the sum of `init` and the one norm of the matrix `A`.
+        The one norm of the matrix `A` is the maximum over all columns of `A`,
+        of the sum of the absolute values of the elements of the column.
+
+* *Remarks:* If `in_matrix_t::element_type` is a floating-point type
+    or `complex<R>` for some floating-point type `R`,
+    if `T` is a floating-point type,
+    and if `T` has higher precision than `in_matrix_type::element_type`,
+    then intermediate terms in each sum use `T`'s precision or greater.
+
+##### One norm with default result type
+
+```c++
+template<class in_matrix_t>
+auto matrix_one_norm(
+  in_matrix_t A) -> /* see-below */;
+template<class ExecutionPolicy,
+         class in_matrix_t>
+auto matrix_one_norm(
+  ExecutionPolicy&& exec,
+  in_matrix_t A) -> /* see-below */;
+```
+
+* *Effects:* Let `T` be `decltype(abs(A[0,0])`.
+    Then, the one-parameter overload is equivalent to
+    `matrix_one_norm(A, T{});`,
+    and the two-parameter overload is equivalent to
+    `matrix_one_norm(exec, A, T{});`.
+
+*[Note:*
+The `abs` function is invoked via unqualified lookup.
+--*end note]*
+
+#### Infinity norm of a matrix [linalg.algs.blas1.matinfnorm]
+
+##### Infinity norm with specified result type
+
+```c++
+template<class in_matrix_t,
+         class T>
+T matrix_inf_norm(
+  in_matrix_t A,
+  T init);
+template<class ExecutionPolicy,
+         class in_matrix_t,
+         class T>
+T matrix_inf_norm(
+  ExecutionPolicy&& exec,
+  in_matrix_t A,
+  T init);
+```
+
+* *Preconditions:* `abs(A[0,0])` shall be convertible to `T`.
+
+* *Effects:*
+
+    * If `A.extent(0)` is zero, returns `init`;
+
+    * else, returns the sum of `init` and the infinity norm of the matrix `A`.
+        The infinity norm of the matrix `A` is the maximum over all rows of `A`,
+        of the sum of the absolute values of the elements of the row.
+
+* *Remarks:* If `in_matrix_t::element_type` is a floating-point type
+    or `complex<R>` for some floating-point type `R`,
+    if `T` is a floating-point type,
+    and if `T` has higher precision than `in_matrix_type::element_type`,
+    then intermediate terms in each sum use `T`'s precision or greater.
+
+*[Note:*
+The `abs` function is invoked via unqualified lookup.
+--*end note]*
+
+##### Infinity norm with default result type
+
+```c++
+template<class in_matrix_t>
+auto matrix_inf_norm(
+  in_matrix_t A) -> /* see-below */;
+template<class ExecutionPolicy,
+         class in_matrix_t>
+auto matrix_inf_norm(
+  ExecutionPolicy&& exec,
+  in_matrix_t A) -> /* see-below */;
+```
+
+* *Effects:* Let `T` be `decltype(abs(A[0,0])`.
+    Then, the one-parameter overload is equivalent to
+    `matrix_inf_norm(A, T{});`,
+    and the two-parameter overload is equivalent to
+    `matrix_inf_norm(exec, A, T{});`.
+
+### BLAS 2 functions [linalg.algs.blas2]
+
+#### General matrix-vector product [linalg.algs.blas2.gemv]
+
+*[Note:* These functions correspond to the BLAS function
+`xGEMV`. --*end note]*
+
+The following requirements apply to all functions in this section.
+
+* *Preconditions:*
+
+    * `A.extent(1)` equals `x.extent(0)`,
+
+    * `A.extent(0)` equals `y.extent(0)`, and
+
+    * `y.extent(0)` equals `z.extent(0)` (if applicable).
+
+* *Constraints:* For all functions in this section:
+
+    * `in_matrix_t` has unique layout; and
+
+    * `A.rank()` equals 2, `x.rank()` equals 1, `y.rank()` equals 1, and
+        `z.rank()` equals 1 (if applicable).
+
+* *Mandates:*
+
+    * If neither `A.static_extent(1)` nor `x.static_extent(0)` equals
+        `dynamic_extent`, then `A.static_extent(1)` equals
+        `x.static_extent(0)`.
+
+    * If neither `A.static_extent(0)` nor `y.static_extent(0)` equals
+        `dynamic_extent`, then `A.static_extent(0)` equals
+        `y.static_extent(0)`.
+
+    * If neither `y.static_extent(0)` nor `z.static_extent(0)` equals
+        `dynamic_extent`, then `y.static_extent(0)` equals
+        `z.static_extent(0)` (if applicable).
+
+* *Complexity:* All algorithms in this Clause with `mdspan` parameters
+    perform a count of `mdspan` array accesses and arithmetic operations
+    that is linear in `x.extent(0)` times `A.extent(1)`.
+
+##### Overwriting matrix-vector product
+
+```c++
+template<class in_vector_t,
+         class in_matrix_t,
+         class out_vector_t>
+void matrix_vector_product(in_matrix_t A,
+                           in_vector_t x,
+                           out_vector_t y);
+
+template<class ExecutionPolicy,
+         class in_vector_t,
+         class in_matrix_t,
+         class out_vector_t>
+void matrix_vector_product(ExecutionPolicy&& exec,
+                           in_matrix_t A,
+                           in_vector_t x,
+                           out_vector_t y);
+```
+
+For `i` in the domain of `y` and `N` equal to `A.extent(1)`,
+the mathematical expression for the algorithm is
+`y[i] =` the sum of `A[i,j] * x[j]`
+for all `j` such that `i,j` is in the domain of `A`.
+
+* *Effects:* Assigns to the elements of `y` the product of the matrix
+    `A` with the vector `x`.
+
+[*Example:*
+```c++
+constexpr size_t num_rows = 5;
+constexpr size_t num_cols = 6;
+
+// y = 3.0 * A * x
+void scaled_matvec_1(
+  mdspan<double, extents<size_t, num_rows, num_cols>> A,
+  mdspan<double, extents<size_t, num_cols>> x,
+  mdspan<double, extents<size_t, num_rows>> y)
+{
+  matrix_vector_product(scaled(3.0, A), x, y);
+}
+
+// y = 3.0 * A * x + 2.0 * y
+void scaled_matvec_2(
+  mdspan<double, extents<size_t, num_rows, num_cols>> A,
+  mdspan<double, extents<size_t, num_cols>> x,
+  mdspan<double, extents<size_t, num_rows>> y)
+{
+  matrix_vector_product(scaled(3.0, A), x,
+                        scaled(2.0, y), y);
+}
+
+// z = 7.0 times the transpose of A, times y
+void scaled_matvec_2(mdspan<double, extents<size_t, num_rows, num_cols>> A,
+  mdspan<double, extents<size_t, num_rows>> y,
+  mdspan<double, extents<size_t, num_cols>> z)
+{
+  matrix_vector_product(scaled(7.0, transposed(A)), y, z);
+}
+```
+--*end example*]
+
+##### Updating matrix-vector product
+
+```c++
+template<class in_vector_1_t,
+         class in_matrix_t,
+         class in_vector_2_t,
+         class out_vector_t>
+void matrix_vector_product(in_matrix_t A,
+                           in_vector_1_t x,
+                           in_vector_2_t y,
+                           out_vector_t z);
+
+template<class ExecutionPolicy,
+         class in_vector_1_t,
+         class in_matrix_t,
+         class in_vector_2_t,
+         class out_vector_t>
+void matrix_vector_product(ExecutionPolicy&& exec,
+                           in_matrix_t A,
+                           in_vector_1_t x,
+                           in_vector_2_t y,
+                           out_vector_t z);
+```
+
+For `i` in the domain of `z` and `N` equal to `A.extent(1)`,
+the mathematical expression for the algorithm is
+`z[i] = y[i] + A[i,j] * x[j]`
+for all `j` such that `i,j` is in the domain of `A`.
+
+* *Effects:* Assigns to the elements of `z` the elementwise sum of
+    `y`, and the product of the matrix `A` with the vector `x`.
+
+#### Symmetric matrix-vector product [linalg.algs.blas2.symv]
+
+*[Note:* These functions correspond to the BLAS functions `xSYMV` and
+`xSPMV`. --*end note]*
+
+The following requirements apply to all functions in this section.
+
+* *Preconditions:*
+
+    * `A.extent(0)` equals `A.extent(1)`,
+
+    * `A.extent(1)` equals `x.extent(0)`,
+
+    * `A.extent(0)` equals `y.extent(0)`, and
+
+    * `y.extent(0)` equals `z.extent(0)` (if applicable).
+
+* *Constraints:*
+
+    * `in_matrix_t` either has unique layout, or `layout_blas_packed` layout.
+
+    * If `in_matrix_t` has `layout_blas_packed` layout, then the
+        layout's `Triangle` template argument has the same type as
+        the function's `Triangle` template argument.
+
+    * `A.rank()` equals 2, `x.rank()` equals 1, `y.rank()` equals 1, and
+        `z.rank()` equals 1 (if applicable).
+
+* *Mandates:*
+
+    * If neither `A.static_extent(0)` nor `A.static_extent(1)` equals
+        `dynamic_extent`, then `A.static_extent(0)` equals
+        `A.static_extent(1)`.
+
+    * If neither `A.static_extent(1)` nor `x.static_extent(0)` equals
+        `dynamic_extent`, then `A.static_extent(1)` equals
+        `x.static_extent(0)`.
+
+    * If neither `A.static_extent(0)` nor `y.static_extent(0)` equals
+        `dynamic_extent`, then `A.static_extent(0)` equals
+        `y.static_extent(0)`.
+
+    * If neither `y.static_extent(0)` nor `z.static_extent(0)` equals
+        `dynamic_extent`, then `y.static_extent(0)` equals
+        `z.static_extent(0)` (if applicable).
+
+* *Complexity:* All algorithms in this Clause with `mdspan` parameters
+    perform a count of `mdspan` array accesses and arithmetic operations
+    that is linear in `x.extent(0)` times `A.extent(1)`.
+
+* *Remarks:* The functions will only access the triangle of `A` specified by
+    the `Triangle` argument `t`, and will interpret the value `A[i,j]`
+    as equal to `A[j,i]` for indices `i,j`
+    in the domain of `A` but outside the triangle specified by `t`.
+
+##### Overwriting symmetric matrix-vector product
+
+```c++
+template<class in_matrix_t,
+         class Triangle,
+         class in_vector_t,
+         class out_vector_t>
+void symmetric_matrix_vector_product(in_matrix_t A,
+                                     Triangle t,
+                                     in_vector_t x,
+                                     out_vector_t y);
+
+template<class ExecutionPolicy,
+         class in_matrix_t,
+         class Triangle,
+         class in_vector_t,
+         class out_vector_t>
+void symmetric_matrix_vector_product(ExecutionPolicy&& exec,
+                                     in_matrix_t A,
+                                     Triangle t,
+                                     in_vector_t x,
+                                     out_vector_t y);
+```
+
+For `i` in the domain of `y`,
+the mathematical expression for the algorithm is
+`y[i] =` the sum of `A[i,j] * x[j]`
+for all `j` in the triangle of `A` specified by `t`,
+plus the sum of `A[j,i] * x[j]`
+for all `j` not equal to `i` such that `j,i` is in the domain of A
+but not in the triangle of `A` specified by `t`.
+
+* *Effects:* Assigns to the elements of `y` the product of the matrix
+    `A` with the vector `x`.
+
+##### Updating symmetric matrix-vector product
+
+```c++
+template<class in_matrix_t,
+         class Triangle,
+         class in_vector_1_t,
+         class in_vector_2_t,
+         class out_vector_t>
+void symmetric_matrix_vector_product(
+  in_matrix_t A,
+  Triangle t,
+  in_vector_1_t x,
+  in_vector_2_t y,
+  out_vector_t z);
+
+template<class ExecutionPolicy,
+         class in_matrix_t,
+         class Triangle,
+         class in_vector_1_t,
+         class in_vector_2_t,
+         class out_vector_t>
+void symmetric_matrix_vector_product(
+  ExecutionPolicy&& exec,
+  in_matrix_t A,
+  Triangle t,
+  in_vector_1_t x,
+  in_vector_2_t y,
+  out_vector_t z);
+```
+
+For `i` in the domain of `y`,
+the mathematical expression for the algorithm is
+`z[i] = y[i]` plus the sum of `A[i,j] * x[j]`
+for all `j` in the triangle of `A` specified by `t`,
+plus the sum of `A[j,i] * x[j]`
+for all `j` not equal to `i` such that `j,i` is in the domain of A
+but not in the triangle of `A` specified by `t`.
+
+* *Effects:* Assigns to the elements of `z` the elementwise sum of
+    `y`, with the product of the matrix `A` with the vector `x`.
+
+#### Hermitian matrix-vector product [linalg.algs.blas2.hemv]
+
+*[Note:* These functions correspond to the BLAS functions `xHEMV` and
+`xHPMV`. --*end note]*
+
+The following requirements apply to all functions in this section.
+
+* *Preconditions:*
+
+    * `A.extent(0)` equals `A.extent(1)`,
+
+    * `A.extent(1)` equals `x.extent(0)`,
+
+    * `A.extent(0)` equals `y.extent(0)`, and
+
+    * `y.extent(0)` equals `z.extent(0)` (if applicable).
+
+* *Constraints:*
+
+    * `in_matrix_t` either has unique layout, or `layout_blas_packed` layout.
+
+    * If `in_matrix_t` has `layout_blas_packed` layout, then the
+        layout's `Triangle` template argument has the same type as
+        the function's `Triangle` template argument.
+
+    * `A.rank()` equals 2, `x.rank()` equals 1, `y.rank()` equals 1, and
+        `z.rank()` equals 1.
+
+* *Mandates:*
+
+    * If neither `A.static_extent(0)` nor `A.static_extent(1)` equals
+        `dynamic_extent`, then `A.static_extent(0)` equals
+        `A.static_extent(1)`.
+
+    * If neither `A.static_extent(1)` nor `x.static_extent(0)` equals
+        `dynamic_extent`, then `A.static_extent(1)` equals
+        `x.static_extent(0)`.
+
+    * If neither `A.static_extent(0)` nor `y.static_extent(0)` equals
+        `dynamic_extent`, then `A.static_extent(0)` equals
+        `y.static_extent(0)`.
+
+    * If neither `y.static_extent(0)` nor `z.static_extent(0)` equals
+        `dynamic_extent`, then `y.static_extent(0)` equals
+        `z.static_extent(0)` (if applicable).
+
+* *Complexity:* All algorithms in this Clause with `mdspan` parameters
+    perform a count of `mdspan` array accesses and arithmetic operations
+    that is linear in `x.extent(0)` times `A.extent(1)`.
+
+* *Remarks:* The functions will only access the triangle of `A` specified by
+    the `Triangle` argument `t`, and will interpret the value `A[i,j]`
+    as equal to _`conj-if-needed`_`A[j,i]` for indices `i,j`
+    in the domain of `A` but outside the triangle specified by `t`.
+
+##### Overwriting Hermitian matrix-vector product
+
+```c++
+template<class in_matrix_t,
+         class Triangle,
+         class in_vector_t,
+         class out_vector_t>
+void hermitian_matrix_vector_product(in_matrix_t A,
+                                     Triangle t,
+                                     in_vector_t x,
+                                     out_vector_t y);
+
+template<class ExecutionPolicy,
+         class in_matrix_t,
+         class Triangle,
+         class in_vector_t,
+         class out_vector_t>
+void hermitian_matrix_vector_product(ExecutionPolicy&& exec,
+                                     in_matrix_t A,
+                                     Triangle t,
+                                     in_vector_t x,
+                                     out_vector_t y);
+```
+
+For `i` in the domain of `y`,
+the mathematical expression for the algorithm is
+`y[i] =` the sum of `A[i,j] * x[j]`
+for all `j` in the triangle of `A` specified by `t`,
+plus the sum of _`conj-if-needed`_`(A[j,i]) * x[j]`
+for all `j` not equal to `i` such that `j,i` is in the domain of A
+but not in the triangle of `A` specified by `t`.
+
+* *Effects:* Assigns to the elements of `y` the product of the matrix
+    `A` with the vector `x`.
+
+##### Updating Hermitian matrix-vector product
+
+```c++
+template<class in_matrix_t,
+         class Triangle,
+         class in_vector_1_t,
+         class in_vector_2_t,
+         class out_vector_t>
+void hermitian_matrix_vector_product(in_matrix_t A,
+                                     Triangle t,
+                                     in_vector_1_t x,
+                                     in_vector_2_t y,
+                                     out_vector_t z);
+
+template<class ExecutionPolicy,
+         class in_matrix_t,
+         class Triangle,
+         class in_vector_1_t,
+         class in_vector_2_t,
+         class out_vector_t>
+void hermitian_matrix_vector_product(ExecutionPolicy&& exec,
+                                     in_matrix_t A,
+                                     Triangle t,
+                                     in_vector_1_t x,
+                                     in_vector_2_t y,
+                                     out_vector_t z);
+```
+
+For `i` in the domain of `y`,
+the mathematical expression for the algorithm is
+`z[i] = y[i]` plus the sum of `A[i,j] * x[j]`
+for all `j` in the triangle of `A` specified by `t`,
+plus the sum of _`conj-if-needed`_`(A[j,i]) * x[j]`
+for all `j` not equal to `i` such that `j,i` is in the domain of A
+but not in the triangle of `A` specified by `t`.
+
+* *Effects:* Assigns to the elements of `z` the elementwise sum of
+    `y`, and the product of the matrix `A` with the vector `x`.
+
+#### Triangular matrix-vector product [linalg.algs.blas2.trmv]
+
+*[Note:* These functions correspond to the BLAS functions `xTRMV` and
+`xTPMV`. --*end note]*
+
+The following requirements apply to all functions in this section.
+
+* *Preconditions:*
+
+    * `A.extent(0)` equals `A.extent(1)`,
+
+    * `A.extent(0)` equals `y.extent(0)`,
+
+    * `A.extent(1)` equals `x.extent(0)` (if applicable), and
+
+    * `y.extent(0)` equals `z.extent(0)` (if applicable).
+
+* *Constraints:*
+
+    * `in_matrix_t` either has unique layout, or `layout_blas_packed` layout;
+
+    * if `in_matrix_t` has `layout_blas_packed` layout, then the
+        layout's `Triangle` template argument has the same type as
+        the function's `Triangle` template argument;
+
+    * `A.rank()` equals 2;
+
+    * `y.rank()` equals 1;
+
+    * `x.rank()` equals 1 (if applicable); and
+
+    * `z.rank()` equals 1 (if applicable).
+
+* *Mandates:*
+
+    * if neither `A.static_extent(0)` nor `A.static_extent(1)` equals
+        `dynamic_extent`, then `A.static_extent(0)` equals
+        `A.static_extent(1)`;
+
+    * if neither `A.static_extent(0)` nor `y.static_extent(0)` equals
+        `dynamic_extent`, then `A.static_extent(0)` equals
+        `y.static_extent(0)`;
+
+    * if neither `A.static_extent(1)` nor `x.static_extent(0)` equals
+        `dynamic_extent`, then `A.static_extent(1)` equals
+        `x.static_extent(0)` (if applicable); and
+
+    * if neither `y.static_extent(0)` nor `z.static_extent(0)` equals
+        `dynamic_extent`, then `y.static_extent(0)` equals
+        `z.static_extent(0)` (if applicable).
+
+* *Complexity:* All algorithms in this Clause with `mdspan` parameters
+    perform a count of `mdspan` array accesses and arithmetic operations
+    that is linear in `x.extent(0)` times `A.extent(1)`.
+
+* *Remarks:*
+
+    * The functions will only access the triangle of `A` specified by
+        the `Triangle` argument `t`.
+
+    * If the `DiagonalStorage` template argument has type
+        `implicit_unit_diagonal_t`,
+        then the functions will not access the diagonal of `A`,
+        and will interpret `A` as if each of its diagonal elements
+        behaves as a two-sided multiplicative identity.
+
+##### Overwriting triangular matrix-vector product [linalg.algs.blas2.trmv.ov]
+
+```c++
+template<class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_vector_t,
+         class out_vector_t>
+void triangular_matrix_vector_product(
+  in_matrix_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_vector_t x,
+  out_vector_t y);
+template<class ExecutionPolicy,
+         class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_vector_t,
+         class out_vector_t>
+void triangular_matrix_vector_product(
+  ExecutionPolicy&& exec,
+  in_matrix_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_vector_t x,
+  out_vector_t y);
+```
+
+For `i` in the domain of `y`,
+the mathematical expression for the algorithm is
+`y[i] =` the sum of `A[i,j] * x[j]`
+for all `j` in the subset of the domain of `A` specified by `t` and `d`.
+
+* *Effects:* Assigns to the elements of `y` the product of the matrix
+    `A` with the vector `x`.
+
+##### In-place triangular matrix-vector product [linalg.algs.blas2.trmv.in-place]
+
+```c++
+template<class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class inout_vector_t>
+void triangular_matrix_vector_product(
+  in_matrix_t A,
+  Triangle t,
+  DiagonalStorage d,
+  inout_vector_t y);
+template<class ExecutionPolicy,
+         class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class inout_vector_t>
+void triangular_matrix_vector_product(
+  ExecutionPolicy&& exec,
+  in_matrix_t A,
+  Triangle t,
+  DiagonalStorage d,
+  inout_vector_t y);
+```
+
+*[Note:*
+
+Performing this operation in place hinders parallelization.
+However, other `ExecutionPolicy`-specific optimizations,
+such as vectorization, are still possible.
+This is why the `ExecutionPolicy` overload exists.
+
+--*end note]*
+
+For `i` in the domain of `y`,
+the mathematical expression for the algorithm is
+`y[i] =` the sum of `A[i,j] * y[j]`
+for all `j` in the subset of the domain of `A` specified by `t` and `d`.
+
+* *Preconditions:* `A.extent(1)` equals `y.extent(0)`.
+
+* *Mandates:* If neither `A.static_extent(1)` nor `y.static_extent(0)`
+    equals `dynamic_extent`, then `A.static_extent(1)` equals
+    `y.static_extent(0)`.
+
+* *Effects:* Overwrites `y` (on output) with the product of the matrix
+    `A` with the vector `y` (on input).
+
+##### Updating triangular matrix-vector product [linalg.algs.blas2.trmv.up]
+
+```c++
+template<class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_vector_1_t,
+         class in_vector_2_t,
+         class out_vector_t>
+void triangular_matrix_vector_product(in_matrix_t A,
+                                      Triangle t,
+                                      DiagonalStorage d,
+                                      in_vector_1_t x,
+                                      in_vector_2_t y,
+                                      out_vector_t z);
+
+template<class ExecutionPolicy,
+         class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_vector_1_t,
+         class in_vector_2_t,
+         class out_vector_t>
+void triangular_matrix_vector_product(ExecutionPolicy&& exec,
+                                      in_matrix_t A,
+                                      Triangle t,
+                                      DiagonalStorage d,
+                                      in_vector_1_t x,
+                                      in_vector_2_t y,
+                                      out_vector_t z);
+```
+
+For `i` in the domain of `y`,
+the mathematical expression for the algorithm is
+`z[i] = y[i]` plus the sum of `A[i,j] * x[j]`
+for all `j` in the subset of the domain of `A` specified by `t` and `d`.
+
+* *Effects:* Assigns to the elements of `z` the elementwise sum of
+    `y`, with the product of the matrix `A` with the vector `x`.
+
+#### Solve a triangular linear system [linalg.algs.blas2.trsv]
+
+*[Note:* These functions correspond to the BLAS functions `xTRSV` and
+`xTPSV`. --*end note]*
+
+The following requirements apply to all functions in this section.
+
+* *Preconditions:*
+
+    * `A.extent(0)` equals `A.extent(1)`, and
+
+    * `A.extent(1)` equals `b.extent(0)`.
+
+* *Constraints:*
+
+    * `A.rank()` equals 2;
+
+    * `b.rank()` equals 1;
+
+    * `in_matrix_t` either has unique layout, or `layout_blas_packed` layout; and
+
+    * if `in_matrix_t` has `layout_blas_packed` layout, then the
+        layout's `Triangle` template argument has the same type as
+        the function's `Triangle` template argument.
+
+* *Mandates:*
+
+    * if neither `A.static_extent(0)` nor `A.static_extent(1)` equals
+        `dynamic_extent`, then `A.static_extent(0)` equals
+        `A.static_extent(1)`; and
+
+    * if neither `A.static_extent(1)` nor `b.static_extent(0)` equals
+        `dynamic_extent`, then `A.static_extent(1)` equals
+        `b.static_extent(0)`.
+
+* *Complexity:* All algorithms in this Clause with `mdspan` parameters
+    perform a count of `mdspan` array accesses and arithmetic operations
+    that is linear in `x.extent(0)` times `A.extent(1)`.
+
+* *Remarks:*
+
+    * The functions will only access the triangle of `A` specified by
+        the `Triangle` argument `t`.
+
+    * If the `DiagonalStorage` template argument has type
+        `implicit_unit_diagonal_t`,
+        then the functions will not access the diagonal of `A`,
+        and will interpret `A` as if each of its diagonal elements
+        behaves as a two-sided multiplicative identity.
+
+##### Not-in-place triangular solve [linalg.algs.blas2.trsv.not-in-place]
+
+```c++
+template<class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_vector_t,
+         class out_vector_t,
+         class BinaryDivideOp>
+void triangular_matrix_vector_solve(
+  in_matrix_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_vector_t b,
+  out_vector_t x,
+  BinaryDivideOp divide);
+template<class ExecutionPolicy,
+         class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_vector_t,
+         class out_vector_t,
+         class BinaryDivideOp>
+void triangular_matrix_vector_solve(
+  ExecutionPolicy&& exec,
+  in_matrix_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_vector_t b,
+  out_vector_t x,
+  BinaryDivideOp divide);
+
+template<class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_vector_t,
+         class out_vector_t>
+void triangular_matrix_vector_solve(
+  in_matrix_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_vector_t b,
+  out_vector_t x);
+template<class ExecutionPolicy,
+         class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_vector_t,
+         class out_vector_t>
+void triangular_matrix_vector_solve(
+  ExecutionPolicy&& exec,
+  in_matrix_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_vector_t b,
+  out_vector_t x);
+```
+
+If `DiagonalStorage` is `explicit_diagonal_t`,
+then for `i` in the domain of `x`,
+the mathematical expression for the algorithm is
+
+* `x[i] = divide(b[i] - s, A[i,i])`
+    for overloads with a `divide` parameter, and
+
+* `x[i] = (b[i] - s) / A[i,i]` for all other overloads,
+
+where `s` is the sum of `A[i,j] * x[j]`
+for all `j` not equal to `i`
+in the subset of the domain of `A` specified by `t` and `d`.
+
+If `DiagonalStorage` is `implicit_unit_diagonal_t`,
+then for `i` in the domain of `x`,
+the mathematical expression for the algorithm is
+`x[i] = b[i] - s`,
+where `s` is the sum of `A[i,j] * x[j]`
+for all `j` not equal to `i`
+in the subset of the domain of `A` specified by `t` and `d`.
+
+* *Preconditions:* `A.extent(0)` equals `x.extent(0)`.
+
+* *Constraints:* `x.rank()` equals 1 and `b.rank()` equals 1.
+
+* *Mandates:* If neither `A.static_extent(0)` nor `x.static_extent(0)` equals
+    `dynamic_extent`, then `A.static_extent(0)` equals `x.static_extent(0)`.
+
+* *Effects:* Assigns to the elements of `x` the result of solving the
+    triangular linear system Ax=b.
+
+##### In-place triangular solve [linalg.algs.blas2.trsv.in-place]
+
+```c++
+template<class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class inout_vector_t,
+         class BinaryDivideOp>
+void triangular_matrix_vector_solve(
+  in_matrix_t A,
+  Triangle t,
+  DiagonalStorage d,
+  inout_vector_t b,
+  BinaryDivideOp divide);
+template<class ExecutionPolicy,
+         class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class inout_vector_t,
+         class BinaryDivideOp>
+void triangular_matrix_vector_solve(
+  ExecutionPolicy&& exec,
+  in_matrix_t A,
+  Triangle t,
+  DiagonalStorage d,
+  inout_vector_t b,
+  BinaryDivideOp divide);
+
+template<class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class inout_vector_t>
+void triangular_matrix_vector_solve(
+  in_matrix_t A,
+  Triangle t,
+  DiagonalStorage d,
+  inout_vector_t b);
+template<class ExecutionPolicy,
+         class in_matrix_t,
+         class Triangle,
+         class DiagonalStorage,
+         class inout_vector_t>
+void triangular_matrix_vector_solve(
+  ExecutionPolicy&& exec,
+  in_matrix_t A,
+  Triangle t,
+  DiagonalStorage d,
+  inout_vector_t b);
+```
+
+*[Note:*
+
+Performing triangular solve in place hinders parallelization.
+However, other `ExecutionPolicy`-specific optimizations,
+such as vectorization, are still possible.
+This is why the `ExecutionPolicy` overload exists.
+
+--*end note]*
+
+If `DiagonalStorage` is `explicit_diagonal_t`,
+then for `i` in the domain of `x`,
+the mathematical expression for the algorithm is
+
+* `b[i] = divide(b[i] - s, A[i,i])`
+    for overloads with a `divide` parameter, and
+
+* `b[i] = (b[i] - s) / A[i,i]` for all other overloads,
+
+where `s` is the sum of `A[i,j] * b[j]`
+for all `j` not equal to `i`
+in the subset of the domain of `A` specified by `t` and `d`.
+
+If `DiagonalStorage` is `implicit_unit_diagonal_t`,
+then for `i` in the domain of `x`,
+the mathematical expression for the algorithm is
+`b[i] = b[i] - s`,
+where `s` is the sum of `A[i,j] * b[j]`
+for all `j` not equal to `i`
+in the subset of the domain of `A` specified by `t` and `d`.
+
+* *Preconditions:* `A.extent(0)` equals `b.extent(0)`.
+
+* *Mandates:* If neither `A.static_extent(0)` nor `b.static_extent(0)`
+    equals `dynamic_extent`,
+    then `A.static_extent(0)` equals `b.static_extent(0)`.
+
+* *Effects:* Overwrites `b` with the result of solving the triangular
+    linear system Ax=b for x.
+
+#### Rank-1 (outer product) update of a matrix [linalg.algs.blas2.rank1]
+
+##### Nonsymmetric nonconjugated rank-1 update [linalg.algs.blas2.rank1.geru]
+
+```c++
+template<class in_vector_1_t,
+         class in_vector_2_t,
+         class inout_matrix_t>
+void matrix_rank_1_update(
+  in_vector_1_t x,
+  in_vector_2_t y,
+  inout_matrix_t A);
+
+template<class ExecutionPolicy,
+         class in_vector_1_t,
+         class in_vector_2_t,
+         class inout_matrix_t>
+void matrix_rank_1_update(
+  ExecutionPolicy&& exec,
+  in_vector_1_t x,
+  in_vector_2_t y,
+  inout_matrix_t A);
+```
+
+*[Note:* This function corresponds to the BLAS functions `xGER` (for
+real element types) and `xGERU` (for complex element types). --*end
+note]*
+
+For `i,j` in the domain of `A`,
+the mathematical expression for the algorithm is
+`A[i,j] += x[i] * y[j]`.
+
+* *Preconditions:*
+
+    * `A.extent(0)` equals `x.extent(0)`, and
+
+    * `A.extent(1)` equals `y.extent(0)`.
+
+* *Constraints:* `A.rank()` equals 2, `x.rank()` equals 1,
+    and `y.rank()` equals 1.
+
+* *Mandates:*
+
+    * If neither `A.static_extent(0)` nor `x.static_extent(0)` equals
+        `dynamic_extent`, then `A.static_extent(0)` equals
+        `x.static_extent(0)`.
+
+    * If neither `A.static_extent(1)` nor `y.static_extent(0)` equals
+        `dynamic_extent`, then `A.static_extent(1)` equals
+        `y.static_extent(0)`.
+
+* *Effects:* Assigns to `A` on output the sum of `A` on input, and the
+    outer product of `x` and `y`.
+
+* *Complexity:* The count of `mdspan` array accesses and arithmetic operations
+    is linear in `x.extent(0)` times `y.extent(0)`.
+
+*[Note:* Users can get `xGERC` behavior by giving the second argument
+as the result of `conjugated`.  Alternately, they can use the shortcut
+`matrix_rank_1_update_c` below. --*end note]*
+
+##### Nonsymmetric conjugated rank-1 update [linalg.algs.blas2.rank1.gerc]
+
+```c++
+template<class in_vector_1_t,
+         class in_vector_2_t,
+         class inout_matrix_t>
+void matrix_rank_1_update_c(
+  in_vector_1_t x,
+  in_vector_2_t y,
+  inout_matrix_t A);
+
+template<class ExecutionPolicy,
+         class in_vector_1_t,
+         class in_vector_2_t,
+         class inout_matrix_t>
+void matrix_rank_1_update_c(
+  ExecutionPolicy&& exec,
+  in_vector_1_t x,
+  in_vector_2_t y,
+  inout_matrix_t A);
+```
+
+*[Note:* This function corresponds to the BLAS functions `xGER` (for
+real element types) and `xGERC` (for complex element types). --*end
+note]*
+
+* *Effects:* Equivalent to `matrix_rank_1_update(x, conjugated(y), A);`.
+
+##### Rank-1 update of a Symmetric matrix [linalg.algs.blas2.rank1.syr]
+
+```c++
+template<class in_vector_t,
+         class inout_matrix_t,
+         class Triangle>
+void symmetric_matrix_rank_1_update(
+  in_vector_t x,
+  inout_matrix_t A,
+  Triangle t);
+template<class ExecutionPolicy,
+         class in_vector_t,
+         class inout_matrix_t,
+         class Triangle>
+void symmetric_matrix_rank_1_update(
+  ExecutionPolicy&& exec,
+  in_vector_t x,
+  inout_matrix_t A,
+  Triangle t);
+template<class T,
+         class in_vector_t,
+         class inout_matrix_t,
+         class Triangle>
+void symmetric_matrix_rank_1_update(
+  T alpha,
+  in_vector_t x,
+  inout_matrix_t A,
+  Triangle t);
+template<class ExecutionPolicy,
+         class T,
+         class in_vector_t,
+         class inout_matrix_t,
+         class Triangle>
+void symmetric_matrix_rank_1_update(
+  ExecutionPolicy&& exec,
+  T alpha,
+  in_vector_t x,
+  inout_matrix_t A,
+  Triangle t);
+```
+
+*[Note:*
+
+These functions correspond to the BLAS functions `xSYR` and `xSPR`.
+
+They have overloads taking a scaling factor `alpha`, because it would be
+impossible to express updates like C = C - x x^T otherwise.
+
+ --*end note]*
+
+For `i,j` in the domain of `A`
+and in the triangle of `A` specified by `t`,
+the mathematical expression for the algorithm is
+`A[i,j] += x[i] * x[j]` for overloads without an `alpha` parameter, and
+`A[i,j] += alpha * x[i] * x[j]` for overloads with an `alpha` parameter.
+
+* *Preconditions:*
+
+    * `A.extent(0)` equals `A.extent(1)`, and
+
+    * `A.extent(0)` equals `x.extent(0)`.
+
+* *Constraints:*
+
+    * `A.rank()` equals 2 and `x.rank()` equals 1.
+
+    * `A` either has unique layout, or `layout_blas_packed` layout.
+
+    * if `A` has `layout_blas_packed` layout, then the layout's
+        `Triangle` template argument has the same type as the function's
+        `Triangle` template argument.
+
+* *Mandates:*
+
+    * If neither `A.static_extent(0)` nor `A.static_extent(1)` equals
+        `dynamic_extent`, then `A.static_extent(0)` equals
+        `A.static_extent(1)`.
+
+    * If neither `A.static_extent(0)` nor `x.static_extent(0)` equals
+        `dynamic_extent`, then `A.static_extent(0)` equals
+        `x.static_extent(0)`.
+
+* *Effects:*
+
+    * Overloads without an `alpha` parameter assign to `A` on output,
+        the elementwise sum of `A` on input,
+        with (the outer product of `x` and `x`).
+
+    * Overloads with an `alpha` parameter assign to `A` on output,
+        the elementwise sum of `A` on input,
+        with the product of alpha and (the outer product of `x` and `x`).
+
+* *Complexity:* The count of `mdspan` array accesses and arithmetic operations
+    is linear in `x.extent(0)` times `x.extent(0)`.
+
+* *Remarks:* The functions will only access the triangle of `A`
+    specified by the `Triangle` argument `t`,
+    and will interpret the value `A[i,j]` as equal to `A[j,i]`
+    for indices `i,j` in the domain `A` but outside that triangle.
+
+##### Rank-1 update of a Hermitian matrix [linalg.algs.blas2.rank1.her]
+
+```c++
+template<class in_vector_t,
+         class inout_matrix_t,
+         class Triangle>
+void hermitian_matrix_rank_1_update(
+  in_vector_t x,
+  inout_matrix_t A,
+  Triangle t);
+template<class ExecutionPolicy,
+         class in_vector_t,
+         class inout_matrix_t,
+         class Triangle>
+void hermitian_matrix_rank_1_update(
+  ExecutionPolicy&& exec,
+  in_vector_t x,
+  inout_matrix_t A,
+  Triangle t);
+template<class T,
+         class in_vector_t,
+         class inout_matrix_t,
+         class Triangle>
+void hermitian_matrix_rank_1_update(
+  T alpha,
+  in_vector_t x,
+  inout_matrix_t A,
+  Triangle t);
+template<class ExecutionPolicy,
+         class T,
+         class in_vector_t,
+         class inout_matrix_t,
+         class Triangle>
+void hermitian_matrix_rank_1_update(
+  ExecutionPolicy&& exec,
+  T alpha,
+  in_vector_t x,
+  inout_matrix_t A,
+  Triangle t);
+```
+
+*[Note:*
+
+These functions correspond to the BLAS functions `xHER` and `xHPR`.
+
+They have overloads taking a scaling factor `alpha`, because it would be
+impossible to express the update A = A - x x^H otherwise.
+
+--*end note]*
+
+For `i,j` in the domain of `A`
+and in the triangle of `A` specified by `t`,
+the mathematical expression for the algorithm is
+`A[i,j] += x[i] * `_`conj-if-needed`_`(x[j])` for overloads without an `alpha` parameter, and
+`A[i,j] += alpha * x[i] * `_`conj-if-needed`_`(x[j])` for overloads with an `alpha` parameter.
+
+* *Preconditions:*
+
+    * `A.extent(0)` equals `A.extent(1)`; and
+
+    * `A.extent(0)` equals `x.extent(0)`.
+
+* *Constraints:*
+
+    * `A.rank()` equals 2 and `x.rank()` equals 1.
+
+    * `A` either has unique layout, or `layout_blas_packed` layout.
+
+    * If `A` has `layout_blas_packed` layout, then the layout's
+        `Triangle` template argument has the same type as the function's
+        `Triangle` template argument.
+
+* *Mandates:*
+
+    * If neither `A.static_extent(0)` nor `A.static_extent(1)` equals
+        `dynamic_extent`, then `A.static_extent(0)` equals
+        `A.static_extent(1)`.
+
+    * If neither `A.static_extent(0)` nor `x.static_extent(0)` equals
+        `dynamic_extent`, then `A.static_extent(0)` equals
+        `x.static_extent(0)`.
+
+* *Effects:*
+
+    * Overloads without `alpha` assign to `A` on output, the elementwise
+        sum of `A` on input, with (the outer product of `x` and the
+        conjugate of `x`).
+
+    * Overloads with `alpha` assign to `A` on output, the elementwise
+        sum of `A` on input, with alpha times (the outer product of `x`
+        and the conjugate of `x`).
+
+* *Complexity:* The count of `mdspan` array accesses and arithmetic operations
+    is linear in `x.extent(0)` times `x.extent(0)`.
+
+* *Remarks:*
+
+    * The functions will only access the triangle of `A` specified by
+        the `Triangle` argument `t`.
+
+    * For indices `i,j` in the domain of `A`
+        but outside the triangle specified by `t`,
+        the functions will interpret the value `A[i,j]`
+        as equal to _`conj-if-needed`_`A[j,i]`.
+
+#### Rank-2 update of a symmetric matrix [linalg.algs.blas2.rank2.syr2]
+
+```c++
+template<class in_vector_1_t,
+         class in_vector_2_t,
+         class inout_matrix_t,
+         class Triangle>
+void symmetric_matrix_rank_2_update(
+  in_vector_1_t x,
+  in_vector_2_t y,
+  inout_matrix_t A,
+  Triangle t);
+
+template<class ExecutionPolicy,
+         class in_vector_1_t,
+         class in_vector_2_t,
+         class inout_matrix_t,
+         class Triangle>
+void symmetric_matrix_rank_2_update(
+  ExecutionPolicy&& exec,
+  in_vector_1_t x,
+  in_vector_2_t y,
+  inout_matrix_t A,
+  Triangle t);
+```
+
+*[Note:* These functions correspond to the BLAS functions `xSYR2` and
+`xSPR2`. --*end note]*
+
+For `i,j` in the domain of `A`
+and in the triangle of `A` specified by `t`,
+the mathematical expression for the algorithm is
+`A[i,j] += x[i] * y[j] + y[i] * x[j]`.
+
+* *Preconditions:*
+
+    * `A.extent(0)` equals `A.extent(1)`,
+
+    * `A.extent(0)` equals `x.extent(0)`, and
+
+    * `A.extent(0)` equals `y.extent(0)`.
+
+* *Constraints:*
+
+    * `A.rank()` equals 2, `x.rank()` equals 1, and `y.rank()` equals 1.
+
+    * `A` either has unique layout, or `layout_blas_packed` layout.
+
+    * If `A` has `layout_blas_packed` layout, then the layout's
+        `Triangle` template argument has the same type as the function's
+        `Triangle` template argument.
+
+* *Mandates:*
+
+    * If neither `A.static_extent(0)` nor `A.static_extent(1)` equals
+        `dynamic_extent`, then `A.static_extent(0)` equals
+        `A.static_extent(1)`.
+
+    * If neither `A.static_extent(0)` nor `x.static_extent(0)` equals
+        `dynamic_extent`, then `A.static_extent(0)` equals
+        `x.static_extent(0)`.
+
+    * If neither `A.static_extent(0)` nor `y.static_extent(0)` equals
+        `dynamic_extent`, then `A.static_extent(0)` equals
+        `y.static_extent(0)`.
+
+* *Effects:* Assigns to `A` on output the sum of `A` on input, the
+    outer product of `x` and `y`, and the outer product of `y` and `x`.
+
+* *Complexity:* The count of `mdspan` array accesses and arithmetic operations
+    is linear in `x.extent(0)` times `y.extent(0)`.
+
+* *Remarks:* The functions will only access the triangle of `A`
+    specified by the `Triangle` argument `t`,
+    and will interpret the value `A[i,j]` as equal to `A[j,i]`
+    for indices `i,j` in the domain `A` but outside that triangle.
+
+#### Rank-2 update of a Hermitian matrix [linalg.algs.blas2.rank2.her2]
+
+```c++
+template<class in_vector_1_t,
+         class in_vector_2_t,
+         class inout_matrix_t,
+         class Triangle>
+void hermitian_matrix_rank_2_update(
+  in_vector_1_t x,
+  in_vector_2_t y,
+  inout_matrix_t A,
+  Triangle t);
+
+template<class ExecutionPolicy,
+         class in_vector_1_t,
+         class in_vector_2_t,
+         class inout_matrix_t,
+         class Triangle>
+void hermitian_matrix_rank_2_update(
+  ExecutionPolicy&& exec,
+  in_vector_1_t x,
+  in_vector_2_t y,
+  inout_matrix_t A,
+  Triangle t);
+```
+
+*[Note:* These functions correspond to the BLAS functions `xHER2` and
+`xHPR2`. --*end note]*
+
+For `i,j` in the domain of `A`
+and in the triangle of `A` specified by `t`,
+the mathematical expression for the algorithm is
+`A[i,j] += x[i] * `_`conj-if-needed`_`(y[j]) + y[i] * `_`conj-if-needed`_`(x[j])`.
+
+* *Preconditions:*
+
+    * `A.extent(0)` equals `A.extent(1)`,
+
+    * `A.extent(0)` equals `x.extent(0)`, and
+
+    * `A.extent(0)` equals `y.extent(0)`.
+
+* *Constraints:*
+
+    * `A.rank()` equals 2, `x.rank()` equals 1, and `y.rank()` equals 1.
+
+    * `A` either has unique layout, or `layout_blas_packed` layout.
+
+    * If `A` has `layout_blas_packed` layout, then the layout's
+        `Triangle` template argument has the same type as the function's
+        `Triangle` template argument.
+
+* *Mandates:*
+
+    * If neither `A.static_extent(0)` nor `A.static_extent(1)` equals
+        `dynamic_extent`, then `A.static_extent(0)` equals
+        `A.static_extent(1)`.
+
+    * If neither `A.static_extent(0)` nor `x.static_extent(0)` equals
+        `dynamic_extent`, then `A.static_extent(0)` equals
+        `x.static_extent(0)`.
+
+    * If neither `A.static_extent(0)` nor `y.static_extent(0)` equals
+        `dynamic_extent`, then `A.static_extent(0)` equals
+        `y.static_extent(0)`.
+
+* *Effects:* Assigns to `A` on output the sum of `A` on input,
+    the outer product of `x` and the conjugate of `y`,
+    and the outer product of `y` and the conjugate of `x`.
+
+* *Complexity:* The count of `mdspan` array accesses and arithmetic operations
+    is linear in `x.extent(0)` times `y.extent(0)`.
+
+* *Remarks:* The functions will only access the triangle of `A` specified by
+    the `Triangle` argument `t`, and will interpret the value `A[i,j]`
+    as equal to _`conj-if-needed`_`A[j,i]` for indices `i,j`
+    in the domain of `A` but outside the triangle specified by `t`.
+
+### BLAS 3 functions [linalg.algs.blas3]
+
+#### General matrix-matrix product [linalg.algs.blas3.gemm]
+
+*[Note:* These functions correspond to the BLAS function `xGEMM`.
+--*end note]*
+
+The following requirements apply to all functions in this section.
+
+* *Preconditions:*
+
+    * `C.extent(0)` equals `E.extent(0)` (if applicable),
+
+    * `C.extent(1)` equals `E.extent(1)` (if applicable),
+
+    * `A.extent(1)` equals `B.extent(0)`,
+
+    * `A.extent(0)` equals `C.extent(0)`, and
+
+    * `B.extent(1)` equals `C.extent(1)`.
+
+* *Constraints:*
+
+    * `in_matrix_1_t`, `in_matrix_2_t`, `in_matrix_3_t` (if applicable),
+        and `out_matrix_t` have unique layout.
+
+    * `A.rank()` equals 2, `B.rank()` equals 2, `C.rank()` equals 2, and
+        `E.rank()` (if applicable) equals 2.
+
+* *Mandates:*
+
+    * For all `r` in 0, 1, ..., `C.rank()` - 1, if neither
+        `C.static_extent(r)` nor `E.static_extent(r)` equals
+        `dynamic_extent`, then `C.static_extent(r)` equals
+        `E.static_extent(r)` (if applicable).
+
+    * If neither `A.static_extent(1)` nor `B.static_extent(0)` equals
+        `dynamic_extent`, then `A.static_extent(1)` equals
+        `B.static_extent(0)`.
+
+    * If neither `A.static_extent(0)` nor `C.static_extent(0)` equals
+        `dynamic_extent`, then `A.static_extent(0)` equals
+        `C.static_extent(0)`.
+
+    * If neither `B.static_extent(1)` nor `C.static_extent(1)` equals
+        `dynamic_extent`, then `B.static_extent(1)` equals
+        `C.static_extent(1)`.
+
+* *Complexity:* For all algorithms in this Clause,
+    the count of `mdspan` array accesses and arithmetic operations
+    is linear in `A.extent(0)` times `B.extent(1)` times `A.extent(1)`.
+
+##### Overwriting general matrix-matrix product
+
+```c++
+template<class in_matrix_1_t,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void matrix_product(in_matrix_1_t A,
+                    in_matrix_2_t B,
+                    out_matrix_t C);
+
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void matrix_product(ExecutionPolicy&& exec,
+                    in_matrix_1_t A,
+                    in_matrix_2_t B,
+                    out_matrix_t C);
+```
+
+For `i,j` in the domain of `C`,
+the mathematical expression for the algorithm is
+`C[i,j] =` the sum of `A[i,k] * B[k,j]`
+for all `k` such that `i,k` is in the domain of `A`.
+
+* *Effects:* Assigns to the elements of the matrix `C` the product of
+    the matrices `A` and `B`.
+
+##### Updating general matrix-matrix product
+
+```c++
+template<class in_matrix_1_t,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void matrix_product(in_matrix_1_t A,
+                    in_matrix_2_t B,
+                    in_matrix_3_t E,
+                    out_matrix_t C);
+
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void matrix_product(ExecutionPolicy&& exec,
+                    in_matrix_1_t A,
+                    in_matrix_2_t B,
+                    in_matrix_3_t E,
+                    out_matrix_t C);
+```
+
+For `i,j` in the domain of `C`,
+the mathematical expression for the algorithm is
+`C[i,j] = E[i,j]` plus the sum of `A[i,k] * B[k,j]`
+for all `k` such that `i,k` is in the domain of `A`.
+
+* *Effects:* Assigns to the elements of the matrix `C` on output, the
+    elementwise sum of `E` and the product of the matrices `A` and `B`.
+
+* *Remarks:* `C` and `E` may refer to the same matrix.
+    If so, then they must have the same layout.
+
+#### Symmetric matrix-matrix product [linalg.algs.blas3.symm]
+
+*[Note:*
+
+These functions correspond to the BLAS function `xSYMM`.
+
+Unlike the symmetric rank-1 or rank-k update functions, these functions assume
+that the input matrix `A` -- not the output matrix -- is symmetric.
+
+--*end note]*
+
+The following requirements apply to all functions in this section.
+
+* *Preconditions:*
+
+    * `A.extent(0)` equals `A.extent(1)`,
+
+    * `C.extent(0)` equals `E.extent(0)` (if applicable), and
+
+    * `C.extent(1)` equals `E.extent(1)` (if applicable).
+
+* *Constraints:*
+
+    * `in_matrix_1_t` either has unique layout,
+        or `layout_blas_packed` layout.
+
+    * `in_matrix_2_t`, `in_matrix_3_t` (if applicable),
+        and `out_matrix_t` have unique layout.
+
+    * If `in_matrix_1_t` has `layout_blas_packed` layout, then the
+        layout's `Triangle` template argument has the same type as
+        the function's `Triangle` template argument.
+
+    * `A.rank()` equals 2, `B.rank()` equals 2, `C.rank()` equals 2, and
+        `E.rank()` (if applicable) equals 2.
+
+* *Mandates:*
+
+    * If neither `A.static_extent(0)` nor `A.static_extent(1)` equals
+        `dynamic_extent`, then `A.static_extent(0)` equals
+        `A.static_extent(1)`.
+
+    * For all `r` in 0, 1, ..., `C.rank()` - 1, if neither
+        `C.static_extent(r)` nor `E.static_extent(r)` equals
+        `dynamic_extent`, then `C.static_extent(r)` equals
+        `E.static_extent(r)` (if applicable).
+
+* *Remarks:*
+
+    * *Remarks:* The functions will only access the triangle of `A`
+        specified by the `Triangle` argument `t`,
+        and will interpret the value `A[i,j]` as equal to `A[j,i]`
+        for indices `i,j` in the domain `A` but outside that triangle.
+
+    * *Remarks:* `C` and `E` (if applicable) may refer to the same
+        matrix.  If so, then they must have the same layout.
+
+The following requirements apply to all overloads of
+`symmetric_matrix_left_product`.
+
+* *Preconditions:*
+
+    * `A.extent(1)` equals `B.extent(0)`,
+
+    * `A.extent(0)` equals `C.extent(0)`, and
+
+    * `B.extent(1)` equals `C.extent(1)`.
+
+* *Mandates:*
+
+    * if neither `A.static_extent(1)` nor `B.static_extent(0)` equals
+        `dynamic_extent`, then `A.static_extent(1)` equals
+        `B.static_extent(0)`;
+
+    * if neither `A.static_extent(0)` nor `C.static_extent(0)` equals
+        `dynamic_extent`, then `A.static_extent(0)` equals
+        `C.static_extent(0)`; and
+
+    * if neither `B.static_extent(1)` nor `C.static_extent(1)` equals
+        `dynamic_extent`, then `B.static_extent(1)` equals
+        `C.static_extent(1)`.
+
+* *Complexity:* The count of `mdspan` array accesses and arithmetic operations
+    is linear in `A.extent(0)` times `B.extent(1)` times `A.extent(1)`.
+
+The following requirements apply to all overloads of
+`symmetric_matrix_right_product`.
+
+* *Preconditions:*
+
+    * `B.extent(1)` equals `A.extent(0)`,
+
+    * `B.extent(0)` equals `C.extent(0)`, and
+
+    * `A.extent(1)` equals `C.extent(1)`.
+
+* *Mandates:*
+
+    * if neither `B.static_extent(1)` nor `A.static_extent(0)` equals
+        `dynamic_extent`, then `B.static_extent(1)` equals
+        `A.static_extent(0)`;
+
+    * if neither `B.static_extent(0)` nor `C.static_extent(0)` equals
+        `dynamic_extent`, then `B.static_extent(0)` equals
+        `C.static_extent(0)`; and
+
+    * if neither `A.static_extent(1)` nor `C.static_extent(1)` equals
+        `dynamic_extent`, then `A.static_extent(1)` equals
+        `C.static_extent(1)`.
+
+* *Complexity:* The count of `mdspan` array accesses and arithmetic operations
+    is linear in `B.extent(0)` times `A.extent(1)` times `B.extent(1)`.
+
+##### Overwriting symmetric matrix-matrix left product [linalg.algs.blas3.symm.ov.left]
+
+```c++
+template<class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void symmetric_matrix_left_product(
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  out_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void symmetric_matrix_left_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  out_matrix_t C);
+```
+
+For `i,j` in the domain of `C`,
+the mathematical expression for the algorithm is
+`C[i,j] = A[i,i] * B[i,j]` plus the sum of `A[i,k1] * B[k1,j]`
+for all `k1` not equal to `i`
+such that `i,k1` is in the domain of `A`
+and in the triangle of `A` specified by `t`,
+plus the sum of `A[k2,i] * B[k2,j]`
+for all `k2` not equal to `i`
+such that `k2,i` is in the domain of `A`
+and in the triangle of `A` specified by `t`.
+
+* *Effects:* Assigns to the elements of the matrix `C`
+    the product of the matrices `A` and `B`.
+
+##### Overwriting symmetric matrix-matrix right product [linalg.algs.blas3.symm.ov.right]
+
+```c++
+template<class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void symmetric_matrix_right_product(
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  out_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void symmetric_matrix_right_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  out_matrix_t C);
+```
+
+For `i,j` in the domain of `C`,
+the mathematical expression for the algorithm is
+`C[i,j] = B[i,j] * A[i,i]`
+plus the sum of `B[i,k1] * A[k1,j]`
+for all `k1` not equal to `j`
+such that `k1,j` is in the domain of `A`
+and in the triangle of `A` specified by `t`,
+plus the sum of `B[i,k2] * A[j,k2]`
+for all `k2` not equal to `j`
+such that `k2,j` is in the domain of `A`
+and in the triangle of `A` specified by `t`.
+
+* *Effects:* Assigns to the elements of the matrix `C`
+    the product of the matrices `B` and `A`.
+
+##### Updating symmetric matrix-matrix left product [linalg.algs.blas3.symm.up.left]
+
+```c++
+template<class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void symmetric_matrix_left_product(
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void symmetric_matrix_left_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+```
+
+For `i,j` in the domain of `C`,
+the mathematical expression for the algorithm is
+`C[i,j] = E[i,j] + A[i,i] * B[i,j]` plus the sum of `A[i,k1] * B[k1,j]`
+for all `k1` not equal to `i`
+such that `i,k1` is in the domain of `A`
+and in the triangle of `A` specified by `t`,
+plus the sum of `A[k2,i] * B[k2,j]`
+for all `k2` not equal to `i`
+such that `k2,i` is in the domain of `A`
+and in the triangle of `A` specified by `t`.
+
+* *Effects:* assigns to the elements of the matrix `C` on output,
+    the elementwise sum of `E` and the product of the matrices `A` and `B`.
+
+##### Updating symmetric matrix-matrix right product [linalg.algs.blas3.symm.up.right]
+
+```c++
+template<class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void symmetric_matrix_right_product(
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void symmetric_matrix_right_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+```
+
+For `i,j` in the domain of `C`,
+the mathematical expression for the algorithm is
+`C[i,j] = E[i,j] + B[i,j] * A[i,i]`
+plus the sum of `B[i,k1] * A[k1,j]`
+for all `k1` not equal to `j`
+such that `k1,j` is in the domain of `A`
+and in the triangle of `A` specified by `t`,
+plus the sum of `B[i,k2] * A[j,k2]`
+for all `k2` not equal to `j`
+such that `k2,j` is in the domain of `A`
+and in the triangle of `A` specified by `t`.
+
+* *Effects:* assigns to the elements of the matrix `C` on output, the
+    elementwise sum of `E` and the product of the matrices `B` and `A`.
+
+#### Hermitian matrix-matrix product [linalg.algs.blas3.hemm]
+
+*[Note:*
+
+These functions correspond to the BLAS function `xHEMM`.
+
+Unlike the Hermitian rank-1 or rank-k update functions, these functions assume
+that the input matrix -- not the output matrix -- is Hermitian.
+
+--*end note]*
+
+The following requirements apply to all functions in this section.
+
+* *Preconditions:*
+
+    * `A.extent(0)` equals `A.extent(1)`,
+
+    * `C.extent(0)` equals `E.extent(0)` (if applicable), and
+
+    * `C.extent(1)` equals `E.extent(1)` (if applicable).
+
+* *Constraints:*
+
+    * `in_matrix_1_t` either has unique layout,
+        or `layout_blas_packed` layout.
+
+    * `in_matrix_2_t`, `in_matrix_3_t` (if applicable), and
+        `out_matrix_t` have unique layout.
+
+    * If `in_matrix_1_t` has `layout_blas_packed` layout, then the
+        layout's `Triangle` template argument has the same type as
+        the function's `Triangle` template argument.
+
+    * `A.rank()` equals 2, `B.rank()` equals 2, `C.rank()` equals 2, and
+        `E.rank()` (if applicable) equals 2.
+
+* *Mandates:*
+
+    * If neither `A.static_extent(0)` nor `A.static_extent(1)` equals
+        `dynamic_extent`, then `A.static_extent(0)` equals
+        `A.static_extent(1)`.
+
+    * For all `r` in 0, 1, ..., `C.rank()` - 1, if neither
+        `C.static_extent(r)` nor `E.static_extent(r)` equals
+        `dynamic_extent`, then `C.static_extent(r)` equals
+        `E.static_extent(r)` (if applicable).
+
+* *Remarks:*
+
+    * The functions will only access the triangle of `A` specified by
+        the `Triangle` argument `t`, and will interpret the value `A[i,j]`
+        as equal to _`conj-if-needed`_`A[j,i]` for indices `i,j`
+        in the domain of `A` but outside the triangle specified by `t`.
+
+    * `C` and `E` (if applicable) may refer to the same matrix.
+        If so, then they must have the same layout.
+
+The following requirements apply to all overloads of
+`hermitian_matrix_left_product`.
+
+* *Preconditions:*
+
+    * `A.extent(1)` equals `B.extent(0)`,
+
+    * `A.extent(0)` equals `C.extent(0)`, and
+
+    * `B.extent(1)` equals `C.extent(1)`.
+
+* *Mandates:*
+
+    * If neither `A.static_extent(1)` nor `B.static_extent(0)` equals
+        `dynamic_extent`, then `A.static_extent(1)` equals
+        `B.static_extent(0)`;
+
+    * if neither `A.static_extent(0)` nor `C.static_extent(0)` equals
+        `dynamic_extent`, then `A.static_extent(0)` equals
+        `C.static_extent(0)`; and
+
+    * if neither `B.static_extent(1)` nor `C.static_extent(1)` equals
+        `dynamic_extent`, then `B.static_extent(1)` equals
+        `C.static_extent(1)`.
+
+* *Complexity:* The count of `mdspan` array accesses and arithmetic operations
+    is linear in `A.extent(0)` times `B.extent(1)` times `A.extent(1)`.
+
+The following requirements apply to all overloads of
+`hermitian_matrix_right_product`.
+
+* *Preconditions:*
+
+    * `B.extent(1)` equals `A.extent(0)`,
+
+    * `B.extent(0)` equals `C.extent(0)`, and
+
+    * `A.extent(1)` equals `C.extent(1)`.
+
+* *Mandates:*
+
+    * If neither `B.static_extent(1)` nor `A.static_extent(0)` equals
+        `dynamic_extent`, then `B.static_extent(1)` equals
+        `A.static_extent(0)`;
+
+    * if neither `B.static_extent(0)` nor `C.static_extent(0)` equals
+        `dynamic_extent`, then `B.static_extent(0)` equals
+        `C.static_extent(0)`; and
+
+    * if neither `A.static_extent(1)` nor `C.static_extent(1)` equals
+        `dynamic_extent`, then `A.static_extent(1)` equals
+        `C.static_extent(1)`.
+
+* *Complexity:* The count of `mdspan` array accesses and arithmetic operations
+    is linear in `B.extent(0)` times `A.extent(1)` times `B.extent(1)`.
+
+##### Overwriting Hermitian matrix-matrix left product [linalg.algs.blas3.hemm.ov.left]
+
+```c++
+template<class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void hermitian_matrix_left_product(
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  out_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void hermitian_matrix_left_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  out_matrix_t C);
+```
+
+For `i,j` in the domain of `C`,
+the mathematical expression for the algorithm is
+`C[i,j] = A[i,i] * B[i,j]`
+plus the sum of `A[i,k1] * B[k1,j]`
+for all `k1` not equal to `i`
+such that `i,k1` is in the domain of `A`
+and in the triangle of `A` specified by `t`,
+plus the sum of _`conj-if-needed`_`(A[k2,i]) * B[k2,j]`
+for all `k2` not equal to `i`
+such that `k2,i` is in the domain of `A`
+and in the triangle of `A` specified by `t`.
+
+* *Effects:* Assigns to the elements of the matrix `C` the product of
+    the matrices `A` and `B`.
+
+##### Overwriting Hermitian matrix-matrix right product [linalg.algs.blas3.hemm.ov.right]
+
+```c++
+template<class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void hermitian_matrix_right_product(
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  out_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void hermitian_matrix_right_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  out_matrix_t C);
+```
+
+For `i,j` in the domain of `C`,
+the mathematical expression for the algorithm is
+`C[i,j] = B[i,j] * A[i,i]`
+plus the sum of `B[i,k1] * A[k1,j]`
+for all `k1` not equal to `j`
+such that `k1,j` is in the domain of `A`
+and in the triangle of `A` specified by `t`,
+plus the sum of `B[i,k2] * `_`conj-if-needed`_`(A[j,k2])`
+for all `k2` not equal to `j`
+such that `k2,j` is in the domain of `A`
+and in the triangle of `A` specified by `t`.
+
+* *Effects:* Assigns to the elements of the matrix `C` the product of
+    the matrices `B` and `A`.
+
+##### Updating Hermitian matrix-matrix left product [linalg.algs.blas3.hemm.up.left]
+
+```c++
+template<class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void hermitian_matrix_left_product(
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void hermitian_matrix_left_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+```
+
+For `i,j` in the domain of `C`,
+the mathematical expression for the algorithm is
+`C[i,j] = E[i,j] + A[i,i] * B[i,j]`
+plus the sum of `A[i,k1] * B[k1,j]`
+for all `k1` not equal to `i`
+such that `i,k1` is in the domain of `A`
+and in the triangle of `A` specified by `t`,
+plus the sum of _`conj-if-needed`_`(A[k2,i]) * B[k2,j]`
+for all `k2` not equal to `i`
+such that `k2,i` is in the domain of `A`
+and in the triangle of `A` specified by `t`.
+
+* *Effects:* Assigns to the elements of the matrix `C` on output,
+    the elementwise sum of `E` and the product of the matrices `A` and `B`.
+
+##### Updating Hermitian matrix-matrix right product [linalg.algs.blas3.hemm.up.right]
+
+```c++
+template<class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void hermitian_matrix_right_product(
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void hermitian_matrix_right_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+```
+
+For `i,j` in the domain of `C`,
+the mathematical expression for the algorithm is
+`C[i,j] = E[i,j] + B[i,j] * A[i,i]`
+plus the sum of `B[i,k1] * A[k1,j]`
+for all `k1` not equal to `j`
+such that `k1,j` is in the domain of `A`
+and in the triangle of `A` specified by `t`,
+plus the sum of `B[i,k2] * `_`conj-if-needed`_`(A[j,k2])`
+for all `k2` not equal to `j`
+such that `k2,j` is in the domain of `A`
+and in the triangle of `A` specified by `t`.
+
+* *Effects:* Assigns to the elements of the matrix `C` on output, the
+    elementwise sum of `E` and the product of the matrices `B` and `A`.
+
+#### Triangular matrix-matrix product [linalg.algs.blas3.trmm]
+
+*[Note:* These functions correspond to the BLAS function `xTRMM`.
+--*end note]*
+
+The following requirements apply to all functions in this section.
+
+* *Preconditions:*
+
+    * `A.extent(0)` equals `A.extent(1)`,
+
+    * `C.extent(0)` equals `E.extent(0)` (if applicable), and
+
+    * `C.extent(1)` equals `E.extent(1)` (if applicable).
+
+* *Constraints:*
+
+    * `in_matrix_1_t` either has unique layout,
+        or `layout_blas_packed` layout.
+
+    * `in_matrix_2_t`, `in_matrix_3_t` (if applicable), `out_matrix_t`,
+        and `inout_matrix_t` (if applicable) have unique layout.
+
+    * If `in_matrix_1_t` has `layout_blas_packed` layout, then the
+        layout's `Triangle` template argument has the same type as
+        the function's `Triangle` template argument.
+
+    * `A.rank()` equals 2, `B.rank()` equals 2, `C.rank()` equals 2, and
+        `E.rank()` (if applicable) equals 2.
+
+* *Mandates:*
+
+    * If neither `A.static_extent(0)` nor `A.static_extent(1)` equals
+        `dynamic_extent`, then `A.static_extent(0)` equals
+        `A.static_extent(1)`.
+
+    * For all `r` in 0, 1, ..., `C.rank()` - 1, if neither
+        `C.static_extent(r)` nor `E.static_extent(r)` equals
+        `dynamic_extent`, then `C.static_extent(r)` equals
+        `E.static_extent(r)` (if applicable).
+
+* *Remarks:*
+
+    * The functions will only access the triangle of `A` specified by
+        the `Triangle` argument `t`.
+
+    * If the `DiagonalStorage` template argument has type
+        `implicit_unit_diagonal_t`,
+        then the functions will not access the diagonal of `A`,
+        and will interpret `A` as if each of its diagonal elements
+        behaves as a two-sided multiplicative identity.
+
+    * `C` and `E` (if applicable) may refer to the same matrix.
+        If so, then they must have the same layout.
+
+The following requirements apply to all overloads of
+`triangular_matrix_left_product`.
+
+* *Preconditions:*
+
+    * `A.extent(1)` equals `B.extent(0)` (if applicable),
+
+    * `A.extent(0)` equals `C.extent(0)`, and
+
+    * `B.extent(1)` equals `C.extent(1)` (if applicable).
+
+* *Mandates:*
+
+    * if neither `A.static_extent(1)` nor `B.static_extent(0)` equals
+        `dynamic_extent`, then `A.static_extent(1)` equals
+        `B.static_extent(0)` (if applicable);
+
+    * if neither `A.static_extent(0)` nor `C.static_extent(0)` equals
+        `dynamic_extent`, then `A.static_extent(0)` equals
+        `C.static_extent(0)`; and
+
+    * if neither `B.static_extent(1)` nor `C.static_extent(1)` equals
+        `dynamic_extent`, then `B.static_extent(1)` equals
+        `C.static_extent(1)` (if applicable).
+
+* *Complexity:* The count of `mdspan` array accesses and arithmetic operations
+    is linear in `A.extent(0)` times `B.extent(1)` times `A.extent(1)`.
+
+The following requirements apply to all overloads of
+`triangular_matrix_right_product`.
+
+* *Preconditions:*
+
+    * `B.extent(1)` equals `A.extent(0)` (if applicable),
+
+    * `B.extent(0)` equals `C.extent(0)` (if applicable), and
+
+    * `A.extent(1)` equals `C.extent(1)`.
+
+* *Mandates:*
+
+    * if neither `B.static_extent(1)` nor `A.static_extent(0)` equals
+        `dynamic_extent`, then `B.static_extent(1)` equals
+        `A.static_extent(0)` (if applicable);
+
+    * if neither `B.static_extent(0)` nor `C.static_extent(0)` equals
+        `dynamic_extent`, then `B.static_extent(0)` equals
+        `C.static_extent(0)` (if applicable); and
+
+    * if neither `A.static_extent(1)` nor `C.static_extent(1)` equals
+        `dynamic_extent`, then `A.static_extent(1)` equals
+        `C.static_extent(1)`.
+
+* *Complexity:* The count of `mdspan` array accesses and arithmetic operations
+    is linear in `B.extent(0)` times `A.extent(1)` times `B.extent(1)`.
+
+##### Overwriting triangular matrix-matrix left product [linalg.algs.blas3.trmm.ov.left]
+
+Not-in-place overwriting triangular matrix-matrix left product
+
+```c++
+template<class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void triangular_matrix_left_product(
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_matrix_2_t B,
+  out_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void triangular_matrix_left_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_matrix_2_t B,
+  out_matrix_t C);
+```
+
+For `i,j` in the domain of `C`,
+the mathematical expression for the algorithm is
+`C[i,j] = ` the sum of `A[i,k] * B[k,j]`
+for all `k` such that `i,k` is in the domain of `A`
+and in the triangle of `A` specified by `t` and `d`.
+
+* *Effects:* Assigns to the elements of the matrix `C`
+    the product of the matrices `A` and `B`.
+
+In-place overwriting triangular matrix-matrix left product
+
+```c++
+template<class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class inout_matrix_t>
+void triangular_matrix_left_product(
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  inout_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class inout_matrix_t>
+void triangular_matrix_left_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  inout_matrix_t C);
+```
+
+For `i,j` in the domain of `C`,
+the mathematical expression for the algorithm is
+`C[i,j] = ` the sum of `A[i,k] * C[k,j]`
+for all `k` such that `i,k` is in the domain of `A`
+and in the triangle of `A` specified by `t` and `d`.
+
+* *Preconditions:* `A.extent(1)` equals `C.extent(0)`.
+
+* *Mandates:* If neither `A.static_extent(1)` nor `C.static_extent(0)`
+    equals `dynamic_extent`,
+    then `A.static_extent(1)` equals `C.static_extent(0)`.
+
+* *Effects:* Overwrites `C` on output with the product of the matrices
+    `A` and `C` (on input).
+
+##### Overwriting triangular matrix-matrix right product [linalg.algs.blas3.trmm.ov.right]
+
+Not-in-place overwriting triangular matrix-matrix right product
+```c++
+template<class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void triangular_matrix_right_product(
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_matrix_2_t B,
+  out_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void triangular_matrix_right_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_matrix_2_t B,
+  out_matrix_t C);
+```
+
+For `i,j` in the domain of `C`,
+the mathematical expression for the algorithm is
+`C[i,j] = ` the sum of `B[i,k] * A[k,j]`
+for all `k` such that `k,j` is in the domain of `A`
+and in the triangle of `A` specified by `t` and `d`.
+
+* *Effects:* Assigns to the elements of the matrix `C`
+    the product of the matrices `B` and `A`.
+
+In-place overwriting triangular matrix-matrix right product
+```c++
+template<class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class inout_matrix_t>
+void triangular_matrix_right_product(
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  inout_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class inout_matrix_t>
+void triangular_matrix_right_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  inout_matrix_t C);
+```
+
+For `i,j` in the domain of `C`,
+the mathematical expression for the algorithm is
+`C[i,j] = ` the sum of `C[i,k] * A[k,j]`
+for all `k` such that `k,j` is in the domain of `A`
+and in the triangle of `A` specified by `t` and `d`.
+
+* *Preconditions:* `C.extent(1)` equals `A.extent(0)`.
+
+* *Mandates:* If neither `C.static_extent(1)` nor `A.static_extent(0)`
+    equals `dynamic_extent`, then `C.static_extent(1)` equals
+    `A.static_extent(0)`.
+
+* *Effects:* Overwrites `C` on output
+    with the product of the matrices `C` (on input) and `A`.
+
+##### Updating triangular matrix-matrix left product [linalg.algs.blas3.trmm.up.left]
+
+```c++
+template<class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void triangular_matrix_left_product(
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void triangular_matrix_left_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+```
+
+For `i,j` in the domain of `C`,
+the mathematical expression for the algorithm is
+`C[i,j] = E[i,j]` plus the sum of `A[i,k] * B[k,j]`
+for all `k` such that `i,k` is in the domain of `A`
+and in the triangle of `A` specified by `t` and `d`.
+
+* *Effects:* Assigns to the elements of the matrix `C` on output,
+    the elementwise sum of `E` and the product of the matrices `A` and `B`.
+
+##### Updating triangular matrix-matrix right product [linalg.algs.blas3.trmm.up.right]
+
+```c++
+template<class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void triangular_matrix_right_product(
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class in_matrix_3_t,
+         class out_matrix_t>
+void triangular_matrix_right_product(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_matrix_2_t B,
+  in_matrix_3_t E,
+  out_matrix_t C);
+```
+
+For `i,j` in the domain of `C`,
+the mathematical expression for the algorithm is
+`C[i,j] = E[i,j]` plus the sum of `B[i,k] * A[k,j]`
+for all `k` such that `k,j` is in the domain of `A`
+and in the triangle of `A` specified by `t` and `d`.
+
+* *Effects:* Assigns to the elements of the matrix `C` on output,
+    the elementwise sum of `E` and the product of the matrices `B` and `A`.
+
+#### Rank-k update of a symmetric or Hermitian matrix [linalg.alg.blas3.rank-k]
+
+*[Note:* Users can achieve the effect of the `TRANS` argument of these
+BLAS functions, by applying `transposed` or `conjugate_transposed`
+to the input matrix. --*end note]*
+
+* *Complexity:* For all algorithms in this Clause,
+    the count of `mdspan` array accesses and arithmetic operations
+    is linear in `A.extent(0)` times `A.extent(1)` times `A.extent(0)`.
+
+##### Rank-k symmetric matrix update [linalg.alg.blas3.rank-k.syrk]
+
+```c++
+template<class T,
+         class in_matrix_1_t,
+         class inout_matrix_t,
+         class Triangle>
+void symmetric_matrix_rank_k_update(
+  T alpha,
+  in_matrix_1_t A,
+  inout_matrix_t C,
+  Triangle t);
+template<class ExecutionPolicy,
+         class T,
+         class in_matrix_1_t,
+         class inout_matrix_t,
+         class Triangle>
+void symmetric_matrix_rank_k_update(
+  ExecutionPolicy&& exec,
+  T alpha,
+  in_matrix_1_t A,
+  inout_matrix_t C,
+  Triangle t);
+```
+
+*[Note:*
+
+These functions correspond to the BLAS function `xSYRK`.
+
+They take a scaling factor `alpha`, because it would be
+impossible to express the update C = C - A A^T otherwise.
+The scaling factor parameter is required
+in order to avoid ambiguity with `ExecutionPolicy`.
+
+--*end note]*
+
+For `i,j` in the domain of `C`
+and in the triangle of `C` specified by `t`,
+the mathematical expression for the algorithm is
+`C[i,j] = C[i,j]` plus the sum of `alpha * A[i,k] * A[j,k]`
+for all `k` such that `i,k` is in the domain of `A`.
+
+* *Preconditions:*
+
+    * `A.extent(0)` equals `C.extent(0)`, and
+
+    * `C.extent(0)` equals `C.extent(1)`.
+
+* *Constraints:*
+
+    * `A.rank()` equals 2 and `C.rank()` equals 2.
+
+    * `C` either has unique layout, or `layout_blas_packed` layout.
+
+    * If `C` has `layout_blas_packed` layout, then the layout's
+        `Triangle` template argument has the same type as the function's
+        `Triangle` template argument.
+
+* *Mandates:*
+
+    * If neither `A.static_extent(0)` nor `C.static_extent(0)` equals
+        `dynamic_extent`, then `A.static_extent(0)` equals
+        `C.static_extent(0)`.
+
+    * If neither `C.static_extent(0)` nor `C.static_extent(1)` equals
+        `dynamic_extent`, then `C.static_extent(0)` equals
+        `C.static_extent(1)`.
+
+* *Effects:*
+
+    * Assigns to `C` on output, the elementwise sum of `C` on input
+        with `alpha` times (the matrix product of `A`
+        and the nonconjugated transpose of `A`).
+
+* *Remarks:* The functions will only access the triangle of `C` specified by
+    the `Triangle` argument `t`, and will interpret the value `C[i,j]`
+    as equal to `C[j,i]` for indices `i,j`
+    in the domain of `C` but outside the triangle specified by `t`.
+
+##### Rank-k Hermitian matrix update [linalg.alg.blas3.rank-k.herk]
+
+```c++
+template<class T,
+         class in_matrix_1_t,
+         class inout_matrix_t,
+         class Triangle>
+void hermitian_matrix_rank_k_update(
+  T alpha,
+  in_matrix_1_t A,
+  inout_matrix_t C,
+  Triangle t);
+template<class ExecutionPolicy,
+         class T,
+         class in_matrix_1_t,
+         class inout_matrix_t,
+         class Triangle>
+void hermitian_matrix_rank_k_update(
+  ExecutionPolicy&& exec,
+  T alpha,
+  in_matrix_1_t A,
+  inout_matrix_t C,
+  Triangle t);
+```
+
+*[Note:*
+
+These functions correspond to the BLAS function `xHERK`.
+
+They take a scaling factor `alpha`, because it would be
+impossible to express the updates C = C - A A^T or C = C - A A^H
+otherwise.
+The scaling factor parameter is required
+in order to avoid ambiguity with `ExecutionPolicy`.
+
+--*end note]*
+
+For `i,j` in the domain of `C`
+and in the triangle of `C` specified by `t`,
+the mathematical expression for the algorithm is
+`C[i,j] = C[i,j]` plus the sum of `alpha * A[i,k] * `_`conj-if-needed`_`(A[j,k])`
+for all `k` such that `i,k` is in the domain of `A`.
+
+* *Preconditions:*
+
+    * `A.extent(0)` equals `C.extent(0)`, and
+
+    * `C.extent(0)` equals `C.extent(1)`.
+
+* *Constraints:*
+
+    * `A.rank()` equals 2 and `C.rank()` equals 2.
+
+    * `C` either has unique layout, or `layout_blas_packed` layout.
+
+    * If `C` has `layout_blas_packed` layout, then the layout's
+        `Triangle` template argument has the same type as the function's
+        `Triangle` template argument.
+
+* *Mandates:*
+
+    * If neither `A.static_extent(0)` nor `C.static_extent(0)` equals
+        `dynamic_extent`, then `A.static_extent(0)` equals
+        `C.static_extent(0)`.
+
+    * If neither `C.static_extent(0)` nor `C.static_extent(1)` equals
+        `dynamic_extent`, then `C.static_extent(0)` equals
+        `C.static_extent(1)`.
+
+* *Effects:*
+
+    * Assigns to `C` on output, the elementwise
+        sum of `C` on input with alpha times (the matrix product of `A`
+        and the conjugated transpose of `A`).
+
+* *Remarks:* The functions will only access the triangle of `C` specified by
+    the `Triangle` argument `t`, and will interpret the value `C[i,j]`
+    as equal to `C[j,i]` for indices `i,j`
+    in the domain of `C` but outside the triangle specified by `t`.
+
+#### Rank-2k update of a symmetric or Hermitian matrix [linalg.alg.blas3.rank2k]
+
+*[Note:* Users can achieve the effect of the `TRANS` argument of these
+BLAS functions, by applying `transposed` or `conjugate_transposed`
+to the input matrices. --*end note]*
+
+* *Complexity:* The count of `mdspan` array accesses and arithmetic operations
+    is linear in `A.extent(0)` times `A.extent(1)` times `B.extent(1)`.
+
+##### Rank-2k symmetric matrix update [linalg.alg.blas3.rank2k.syr2k]
+
+```c++
+template<class in_matrix_1_t,
+         class in_matrix_2_t,
+         class inout_matrix_t,
+         class Triangle>
+void symmetric_matrix_rank_2k_update(
+  in_matrix_1_t A,
+  in_matrix_2_t B,
+  inout_matrix_t C,
+  Triangle t);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class in_matrix_2_t,
+         class inout_matrix_t,
+         class Triangle>
+void symmetric_matrix_rank_2k_update(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  in_matrix_2_t B,
+  inout_matrix_t C,
+  Triangle t);
+```
+
+*[Note:* These functions correspond to the BLAS function `xSYR2K`.
+The BLAS "quick reference" has a typo; the "ALPHA" argument of
+`CSYR2K` and `ZSYR2K` should not be conjugated.  --*end note]*
+
+For `i,j` in the domain of `C`
+and in the triangle of `C` specified by `t`,
+the mathematical expression for the algorithm is
+`C[i,j] = C[i,j]` plus the sum of `A[i,k1] * B[j,k1]`
+for all `k1` such that `i,k1` is in the domain of `A`,
+plus the sum of `B[i,k2] * A[j,k2]`
+for all `k2` such that `i,k2` is in the domain of `B`.
+
+* *Preconditions:*
+
+    * `A.extent(0)` equals `B.extent(0)`,
+
+    * `A.extent(1)` equals `B.extent(1)`, and
+
+    * `A.extent(0)` equals `C.extent(0)`.
+
+* *Constraints:*
+
+    * `A.rank()` equals 2, `B.rank()` equals 2, and `C.rank()` equals 2.
+
+    * `C` either has unique layout, or `layout_blas_packed` layout.
+
+    * If `C` has `layout_blas_packed` layout, then the layout's
+        `Triangle` template argument has the same type as the function's
+        `Triangle` template argument.
+
+* *Mandates:*
+
+    * If neither `A.static_extent(0)` nor `B.static_extent(0)` equals
+        `dynamic_extent`, then `A.static_extent(0)` equals
+        `B.static_extent(0)`.
+
+    * If neither `A.static_extent(1)` nor `B.static_extent(1)` equals
+        `dynamic_extent`, then `A.static_extent(1)` equals
+        `B.static_extent(1)`.
+
+    * If neither `A.static_extent(0)` nor `C.static_extent(0)` equals
+        `dynamic_extent`, then `A.static_extent(0)` equals
+        `C.static_extent(0)`.
+
+* *Effects:* Assigns to `C` on output, the elementwise sum of `C` on
+    input with (the matrix product of `A` and the nonconjugated
+    transpose of `B`) and (the matrix product of `B` and the
+    nonconjugated transpose of `A`.)
+
+* *Remarks:* The functions will only access the triangle of `C` specified by
+    the `Triangle` argument `t`, and will interpret the value `C[i,j]`
+    as equal to `C[j,i]` for indices `i,j`
+    in the domain of `C` but outside the triangle specified by `t`.
+
+##### Rank-2k Hermitian matrix update [linalg.alg.blas3.rank2k.her2k]
+
+```c++
+template<class in_matrix_1_t,
+         class in_matrix_2_t,
+         class inout_matrix_t,
+         class Triangle>
+void hermitian_matrix_rank_2k_update(
+  in_matrix_1_t A,
+  in_matrix_2_t B,
+  inout_matrix_t C,
+  Triangle t);
+
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class in_matrix_2_t,
+         class inout_matrix_t,
+         class Triangle>
+void hermitian_matrix_rank_2k_update(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  in_matrix_2_t B,
+  inout_matrix_t C,
+  Triangle t);
+```
+
+*[Note:* These functions correspond to the BLAS function `xHER2K`.
+--*end note]*
+
+For `i,j` in the domain of `C`
+and in the triangle of `C` specified by `t`,
+the mathematical expression for the algorithm is
+`C[i,j] = C[i,j]` plus the sum of `A[i,k1] * `_`conj-if-needed`_`(B[j,k1])`
+for all `k1` such that `i,k1` is in the domain of `A`,
+plus the sum of `B[i,k2] * `_`conj-if-needed`_`(A[j,k2])`
+for all `k2` such that `i,k2` is in the domain of `B`.
+
+* *Preconditions:*
+
+    * `A.extent(0)` equals `B.extent(0)`,
+
+    * `A.extent(1)` equals `B.extent(1)`, and
+
+    * `A.extent(0)` equals `C.extent(0)`.
+
+* *Constraints:*
+
+    * `A.rank()` equals 2, `B.rank()` equals 2, and `C.rank()` equals 2.
+
+    * `C` either has unique layout, or `layout_blas_packed` layout.
+
+    * If `C` has `layout_blas_packed` layout, then the layout's
+        `Triangle` template argument has the same type as the function's
+        `Triangle` template argument.
+
+* *Mandates:*
+
+    * If neither `A.static_extent(0)` nor `B.static_extent(0)` equals
+        `dynamic_extent`, then `A.static_extent(0)` equals
+        `B.static_extent(0)`.
+
+    * If neither `A.static_extent(1)` nor `B.static_extent(1)` equals
+        `dynamic_extent`, then `A.static_extent(1)` equals
+        `B.static_extent(1)`.
+
+    * If neither `A.static_extent(0)` nor `C.static_extent(0)` equals
+        `dynamic_extent`, then `A.static_extent(0)` equals
+        `C.static_extent(0)`.
+
+* *Effects:* Assigns to `C` on output,
+    the elementwise sum of `C` on input with
+    (the matrix product of `A` and the conjugate transpose of `B`) and
+    (the matrix product of `B` and the conjugate transpose of `A`.)
+
+* *Remarks:* The functions will only access the triangle of `C` specified by
+    the `Triangle` argument `t`, and will interpret the value `C[i,j]`
+    as equal to _`conj-if-needed`_`C[j,i]` for indices `i,j`
+    in the domain of `C` but outside the triangle specified by `t`.
+
+#### Solve multiple triangular linear systems [linalg.alg.blas3.trsm]
+
+*[Note:* These functions correspond to the BLAS function `xTRSM`.  The
+Reference BLAS does not have a `xTPSM` function. --*end note]*
+
+The following requirements apply to all functions in this section.
+
+* *Preconditions:*
+
+    * For all `r` in 0, 1, ..., `B.rank()` - 1,
+        `X.extent(r)` equals `B.extent(r)` (if applicable); and
+
+    * `A.extent(0)` equals `A.extent(1)`.
+
+* *Constraints:*
+
+    * `A.rank()` equals 2 and `B.rank()` equals 2;
+
+    * `X.rank()` equals 2 (if applicable);
+
+    * `in_matrix_1_t` either has unique layout, or `layout_blas_packed` layout;
+
+    * `in_matrix_2_t` has unique layout (if applicable);
+
+    * `out_matrix_t` has unique layout;
+
+    * `inout_matrix_t` has unique layout (if applicable);
+
+    * if `r,j` is in the domain of `X` and `B`, then the expression
+        `X[r,j] = B[r,j]` is well formed (if applicable); and
+
+    * if `DiagonalStorage` is `explicit_diagonal_t`,
+        and `i,j` is in the domain of `X`,
+        then the expression `X[i,j] /= A[i,i]` is well formed (if applicable).
+
+* *Mandates:*
+
+    * For all `r` in 0, 1, ..., `X.rank()` - 1, if neither
+        `X.static_extent(r)` nor `B.static_extent(r)` equals
+        `dynamic_extent`, then `X.static_extent(r)` equals
+        `B.static_extent(r)` (if applicable).
+
+    * If neither `A.static_extent(0)` nor `A.static_extent(1)` equals
+        `dynamic_extent`, then `A.static_extent(0)` equals
+        `A.static_extent(1)`.
+
+* *Remarks:*
+
+    * The functions will only access the triangle of `A` specified by
+        the `Triangle` argument `t`.
+
+    * If the `DiagonalStorage` template argument has type
+        `implicit_unit_diagonal_t`,
+        then the functions will not access the diagonal of `A`,
+        and will interpret `A` as if each of its diagonal elements
+        behaves as a two-sided multiplicative identity.
+
+##### Solve multiple triangular linear systems with triangular matrix on the left [linalg.alg.blas3.trsm.left]
+
+* *Complexity:* The count of `mdspan` array accesses and arithmetic operations
+    is linear in `A.extent(0)` times `A.extent(1)` times `X.extent(1)`.
+
+Not-in-place left solve of multiple triangular systems
+
+```c++
+template<class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class out_matrix_t,
+         class BinaryDivideOp>
+void triangular_matrix_matrix_left_solve(
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_matrix_2_t B,
+  out_matrix_t X,
+  BinaryDivideOp divide);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class out_matrix_t,
+         class BinaryDivideOp>
+void triangular_matrix_matrix_left_solve(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_matrix_2_t B,
+  out_matrix_t X,
+  BinaryDivideOp divide);
+
+template<class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void triangular_matrix_matrix_left_solve(
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_matrix_2_t B,
+  out_matrix_t X);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void triangular_matrix_matrix_left_solve(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_matrix_2_t B,
+  out_matrix_t X);
+```
+
+If `DiagonalStorage` is `explicit_diagonal_t`,
+then for `i,j` in the domain of `X`,
+the mathematical expression for the algorithm is
+
+* `X[i,j] = divide(B[i,j] - s, A[i,i])`
+    for overloads with a `divide` parameter, and
+
+* `X[i,j] = (B[i,j] - s) / A[i,i]` for all other overloads,
+
+where `s` is the sum of `A[i,k] * X[k,j]`
+for all `k` not equal to `i`
+in the subset of the domain of `A` specified by `t`.
+
+*[Note:*
+Since the triangular matrix is on the left,
+the desired `divide` implementation
+in the case of noncommutative multiplication
+would be mathematically equivalent to
+the product of (the inverse of the second argument)
+and the first argument, in that order.
+--*end note]*
+
+If `DiagonalStorage` is `implicit_unit_diagonal_t`,
+then for `i,j` in the domain of `X`,
+the mathematical expression for the algorithm is
+`X[i,j] = B[i,j] - s`,
+where `s` is the sum of `A[i,k] * X[k,j]`
+for all `k` not equal to `i`
+in the subset of the domain of `A` specified by `t`.
+
+* *Preconditions:* `A.extent(1)` equals `B.extent(0)`.
+
+* *Mandates:* If neither `A.static_extent(1)` nor `B.static_extent(0)`
+    equals `dynamic_extent`, then
+    `A.static_extent(1)` equals `B.static_extent(0)`.
+
+* *Effects:* Assigns to the elements of `X`
+    the result of solving the triangular linear system(s) AX=B for X.
+
+In-place left solve of multiple triangular systems
+
+```c++
+template<class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class inout_matrix_t,
+         class BinaryDivideOp>
+void triangular_matrix_matrix_left_solve(
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  inout_matrix_t B,
+  BinaryDivideOp divide);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class inout_matrix_t,
+         class BinaryDivideOp>
+void triangular_matrix_matrix_left_solve(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  inout_matrix_t B,
+  BinaryDivideOp divide);
+
+template<class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class inout_matrix_t>
+void triangular_matrix_matrix_left_solve(
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  inout_matrix_t B);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class inout_matrix_t>
+void triangular_matrix_matrix_left_solve(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  inout_matrix_t B);
+```
+
+*[Note:*
+
+This algorithm makes it possible to compute factorizations like
+Cholesky and LU in place.
+
+Performing triangular solve in place hinders parallelization.
+However, other `ExecutionPolicy`-specific optimizations,
+such as vectorization, are still possible.
+This is why the `ExecutionPolicy` overload exists.
+
+--*end note]*
+
+If `DiagonalStorage` is `explicit_diagonal_t`,
+then for `i,j` in the domain of `B`,
+the mathematical expression for the algorithm is
+
+* `B[i,j] = divide(B[i,j] - s, A[i,i])`
+    for overloads with a `divide` parameter, and
+
+* `B[i,j] = (B[i,j] - s) / A[i,i]` for all other overloads,
+
+where `s` is the sum of `A[i,k] * B[k,j]`
+for all `k` not equal to `i`
+in the subset of the domain of `A` specified by `t`.
+
+*[Note:*
+Since the triangular matrix is on the left,
+the desired `divide` implementation
+in the case of noncommutative multiplication
+would be mathematically equivalent to
+the product of (the inverse of the second argument)
+and the first argument, in that order.
+--*end note]*
+
+If `DiagonalStorage` is `implicit_unit_diagonal_t`,
+then for `i,j` in the domain of `B`,
+the mathematical expression for the algorithm is
+`B[i,j] = B[i,j] - s`,
+where `s` is the sum of `A[i,k] * B[k,j]`
+for all `k` not equal to `i`
+in the subset of the domain of `A` specified by `t`.
+
+* *Preconditions:* `A.extent(1)` equals `B.extent(0)`.
+
+* *Mandates:* If neither `A.static_extent(1)` nor `B.static_extent(0)`
+    equals `dynamic_extent`, then
+    `A.static_extent(1)` equals `B.static_extent(0)`.
+
+* *Effects:* Overwrites `B` with the result of solving the triangular
+     linear system(s) AX=B for X.
+
+##### Solve multiple triangular linear systems with triangular matrix on the right [linalg.alg.blas3.trsm.right]
+
+* *Complexity:* The count of `mdspan` array accesses and arithmetic operations
+    is linear in `B.extent(0)` times `B.extent(1)` times `A.extent(1)`.
+
+Not-in-place right solve of multiple triangular systems
+
+```c++
+template<class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class out_matrix_t,
+         class BinaryDivideOp>
+void triangular_matrix_matrix_right_solve(
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_matrix_2_t B,
+  out_matrix_t X,
+  BinaryDivideOp divide);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class out_matrix_t,
+         class BinaryDivideOp>
+void triangular_matrix_matrix_right_solve(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_matrix_2_t B,
+  out_matrix_t X,
+  BinaryDivideOp divide);
+
+template<class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void triangular_matrix_matrix_right_solve(
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_matrix_2_t B,
+  out_matrix_t X);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class in_matrix_2_t,
+         class out_matrix_t>
+void triangular_matrix_matrix_right_solve(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  in_matrix_2_t B,
+  out_matrix_t X);
+```
+
+If `DiagonalStorage` is `explicit_diagonal_t`,
+then for `i,j` in the domain of `X`,
+the mathematical expression for the algorithm is
+
+* `X[i,j] = divide(B[i,j] - s, A[j,j])`
+    for overloads with a `divide` parameter, and
+
+* `X[i,j] = (B[i,j] - s) / A[j,j]` for all other overloads,
+
+where `s` is the sum of `X[i,k] * A[k,j]`
+for all `k` not equal to `j`
+in the subset of the domain of `A` specified by `t`.
+
+*[Note:*
+Since the triangular matrix is on the right,
+the desired `divide` implementation
+in the case of noncommutative multiplication
+would be mathematically equivalent to
+the product of the first argument, and
+(the inverse of the second argument),
+in that order.
+--*end note]*
+
+If `DiagonalStorage` is `implicit_unit_diagonal_t`,
+then for `i,j` in the domain of `X`,
+the mathematical expression for the algorithm is
+`X[i,j] = B[i,j] - s`,
+where `s` is the sum of `X[i,k] * A[k,j]`
+for all `k` not equal to `j`
+in the subset of the domain of `A` specified by `t`.
+
+*[Note:*
+
+One can derive these mathematical expressions
+from the mathematical expressions of the
+`triangular_matrix_matrix_left_solve()` algorithm,
+by swapping the order of indices of each matrix access
+(representing the transpose), swapping `i` and `j`,
+and swapping the order of product terms in the sum `s`.
+This is because
+`triangular_matrix_matrix_left_solve()` solves AX = B,
+taking the transpose of both sides does not change the equation,
+and the transpose of a product of two matrices
+is the product of the reversed matrices in transposed order.
+
+--*end note]*
+
+* *Preconditions:* `A.extent(1)` equals `B.extent(1)`.
+
+* *Mandates:* If neither `A.static_extent(1)` nor `B.static_extent(1)`
+    equals `dynamic_extent`, then
+    `A.static_extent(1)` equals `B.static_extent(1)`.
+
+* *Effects:* Assigns to the elements of `X`
+    the result of solving the triangular linear system(s) XA=B for X.
+
+In-place right solve of multiple triangular systems
+
+```c++
+template<class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class inout_matrix_t,
+         class BinaryDivideOp>
+void triangular_matrix_matrix_right_solve(
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  inout_matrix_t B,
+  BinaryDivideOp divide);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class inout_matrix_t,
+         class BinaryDivideOp>
+void triangular_matrix_matrix_right_solve(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  inout_matrix_t B,
+  BinaryDivideOp divide);  
+
+template<class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class inout_matrix_t>
+void triangular_matrix_matrix_right_solve(
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  inout_matrix_t B);
+template<class ExecutionPolicy,
+         class in_matrix_1_t,
+         class Triangle,
+         class DiagonalStorage,
+         class inout_matrix_t>
+void triangular_matrix_matrix_right_solve(
+  ExecutionPolicy&& exec,
+  in_matrix_1_t A,
+  Triangle t,
+  DiagonalStorage d,
+  inout_matrix_t B);
+```
+
+*[Note:*
+
+This algorithm makes it possible to compute factorizations like
+Cholesky and LU in place.
+
+Performing triangular solve in place hinders parallelization.
+However, other `ExecutionPolicy`-specific optimizations,
+such as vectorization, are still possible.
+This is why the `ExecutionPolicy` overload exists.
+
+--*end note]*
+
+If `DiagonalStorage` is `explicit_diagonal_t`,
+then for `i,j` in the domain of `B`,
+the mathematical expression for the algorithm is
+
+* `B[i,j] = divide(B[i,j] - s, A[j,j])`
+   for overloads with a `divide` parameter, and
+
+* `B[i,j] = (B[i,j] - s) / A[j,j]` for all other overloads,
+
+where `s` is the sum of `B[i,k] * A[k,j]`
+for all `k` not equal to `j`
+in the subset of the domain of `A` specified by `t`.
+
+*[Note:*
+Since the triangular matrix is on the right,
+the desired `divide` implementation
+in the case of noncommutative multiplication
+would be mathematically equivalent to
+the product of the first argument, and
+(the inverse of the second argument),
+in that order.
+--*end note]*
+
+If `DiagonalStorage` is `implicit_unit_diagonal_t`,
+then for `i,j` in the domain of `B`,
+the mathematical expression for the algorithm is
+`B[i,j] = B[i,j] - s`,
+where `s` is the sum of `B[i,k] * A[k,j]`
+for all `k` not equal to `j`
+in the subset of the domain of `A` specified by `t`.
+
+* *Preconditions:* `A.extent(1)` equals `B.extent(1)`.
+
+* *Mandates:* If neither `A.static_extent(1)` nor `B.static_extent(1)`
+    equals `dynamic_extent`, then
+    `A.static_extent(1)` equals `B.static_extent(1)`.
+
+* *Effects:* Overwrites `B` with the result of solving the triangular
+     linear system(s) XA=B for X.
+
+# Examples
+
+## Cholesky factorization
+
+This example shows how to compute the Cholesky factorization of a real
+symmetric positive definite matrix A stored as an `mdspan` with a
+unique non-packed layout.
+The algorithm imitates `DPOTRF2` in LAPACK 3.9.0.
+If `Triangle` is `upper_triangle_t`,
+then it computes the factorization A = U^T U in place,
+with U stored in the upper triangle of A on output.
+Otherwise, it computes the factorization A = L L^T in place,
+with L stored in the lower triangle of A on output.
+The function returns 0 if success, else k+1
+if row/column k has a zero or NaN (not a number) diagonal entry.
+
+```c++
+#include <linalg>
+#include <cmath>
+
+// Flip upper to lower, and lower to upper
+lower_triangular_t opposite_triangle(upper_triangular_t) {
+  return {}
+}
+upper_triangular_t opposite_triangle(lower_triangular_t) {
+  return {}
+}
+
+// Returns nullopt if no bad pivots,
+// else the index of the first bad pivot.
+// A "bad" pivot is zero or NaN.
+template<class inout_matrix_t,
+         class Triangle>
+optional<typename inout_matrix_t::size_type>
+cholesky_factor(inout_matrix_t A, Triangle t)
+{
+  using value_type = typename inout_matrix_t::value_type;
+  using size_type = typename inout_matrix_t::size_type;
+  constexpr value_type ZERO {};
+  constexpr value_type ONE (1.0);
+  const size_type n = A.extent(0);
+
+  if (n == 0) {
+    return std::nullopt;
+  }
+  else if (n == 1) {
+    if (A[0,0] <= ZERO || isnan(A[0,0])) {
+      return {size_type(1)};
+    }
+    A[0,0] = sqrt(A[0,0]);
+  }
+  else {
+    // Partition A into [A11, A12,
+    //                   A21, A22],
+    // where A21 is the transpose of A12.
+    const size_type n1 = n / 2;
+    const size_type n2 = n - n1;
+    auto A11 = submdspan(A, pair{0, n1}, pair{0, n1});
+    auto A22 = submdspan(A, pair{n1, n}, pair{n1, n});
+
+    // Factor A11
+    const auto info1 = cholesky_factor(A11, t);
+    if (info1.has_value()) {
+      return info1;
+    }
+
+    using std::linalg::symmetric_matrix_rank_k_update;
+    using std::linalg::transposed;
+    if constexpr (std::is_same_v<Triangle, upper_triangle_t>) {
+      // Update and scale A12
+      auto A12 = submdspan(A, pair{0, n1}, pair{n1, n});
+      using std::linalg::triangular_matrix_matrix_left_solve;
+      // BLAS would use original triangle; we need to flip it
+      triangular_matrix_matrix_left_solve(transposed(A11),
+        opposite_triangle(t), explicit_diagonal, A12);
+      // A22 = A22 - A12^T * A12
+      //
+      // The Triangle argument applies to A22,
+      // not transposed(A12), so we don't flip it.
+      symmetric_matrix_rank_k_update(-ONE, transposed(A12),
+                                     A22, t);
+    }
+    else {
+      //
+      // Compute the Cholesky factorization A = L * L^T
+      //
+      // Update and scale A21
+      auto A21 = submdspan(A, pair{n1, n}, pair{0, n1});
+      using std::linalg::triangular_matrix_matrix_right_solve;
+      // BLAS would use original triangle; we need to flip it
+      triangular_matrix_matrix_right_solve(transposed(A11),
+        opposite_triangle(t), explicit_diagonal, A21);
+      // A22 = A22 - A21 * A21^T
+      symmetric_matrix_rank_k_update(-ONE, A21, A22, t);
+    }
+
+    // Factor A22
+    const auto info2 = cholesky_factor(A22, t);
+    if (info2.has_value()) {
+      return {info2.value() + n1};
+    }
+  }
+
+  return nullopt;
+}
+```
+
+## Solve linear system using Cholesky factorization
+
+This example shows how to solve a symmetric positive definite linear
+system Ax=b, using the Cholesky factorization computed in the previous
+example in-place in the matrix `A`.  The example assumes that
+`cholesky_factor(A, t)` returned `nullopt`, indicating no zero or NaN pivots.
+
+```c++
+template<class in_matrix_t,
+         class Triangle,
+         class in_vector_t,
+         class out_vector_t>
+void cholesky_solve(
+  in_matrix_t A,
+  Triangle t,
+  in_vector_t b,
+  out_vector_t x)
+{
+  using std::linalg::transposed;
+  using std::linalg::triangular_matrix_vector_solve;
+
+  if constexpr (std::is_same_v<Triangle, upper_triangle_t>) {
+    // Solve Ax=b where A = U^T U
+    //
+    // Solve U^T c = b, using x to store c.
+    triangular_matrix_vector_solve(transposed(A), opposite_triangle(t),
+                                   explicit_diagonal, b, x);
+    // Solve U x = c, overwriting x with result.
+    triangular_matrix_vector_solve(A, t, explicit_diagonal, x);
+  }
+  else {
+    // Solve Ax=b where A = L L^T
+    //
+    // Solve L c = b, using x to store c.
+    triangular_matrix_vector_solve(A, t, explicit_diagonal, b, x);
+    // Solve L^T x = c, overwriting x with result.
+    triangular_matrix_vector_solve(transposed(A), opposite_triangle(t),
+                                   explicit_diagonal, x);
+  }
+}
+```
+
+## Compute QR factorization of a tall skinny matrix
+
+This example shows how to compute the QR factorization of a "tall and
+skinny" matrix `V`, using a cache-blocked algorithm based on rank-k
+symmetric matrix update and Cholesky factorization.  "Tall and skinny"
+means that the matrix has many more rows than columns.
+
+```c++
+// Compute QR factorization A = Q R, with A storing Q.
+template<class inout_matrix_t,
+         class out_matrix_t>
+optional<typename inout_matrix_t::size_type>
+cholesky_tsqr_one_step(
+  inout_matrix_t A, // A on input, Q on output
+  out_matrix_t R)
+{
+  using size_type = typename inout_matrix_t::size_type;
+
+  // One might use cache size, sizeof(element_type), and A.extent(1)
+  // to pick the number of rows per block.  For now, we just pick
+  // some constant.
+  constexpr size_type max_num_rows_per_block = 500;
+
+  using R_element_type = typename out_matrix_t::element_type;
+  constexpr R_element_type ZERO {};
+  for(size_type j = 0; j < R.extent(1); ++j) {
+    for(size_type i = 0; i < R.extent(0); ++i) {
+      R[i,j] = ZERO;
+    }
+  }
+
+  // Cache-blocked version of R = R + A^T * A.
+  const auto num_rows = A.extent(0);
+  auto rest_num_rows = num_rows;
+  auto A_rest = A;
+  while(A_rest.extent(0) > 0) {
+    const size_type num_rows_per_block =
+      min(A.extent(0), max_num_rows_per_block);
+    auto A_cur = submdspan(A_rest, pair{0, num_rows_per_block}, full_extent);
+    A_rest = submdspan(A_rest,
+      pair{num_rows_per_block, A_rest.extent(0)}, full_extent);
+    // R = R + A_cur^T * A_cur
+    using std::linalg::symmetric_matrix_rank_k_update;
+    constexpr R_element_type ONE(1.0);
+    // The Triangle argument applies to R,
+    // not transposed(A_cur), so we don't flip it.
+    symmetric_matrix_rank_k_update(ONE, transposed(A_cur),
+                                   R, upper_triangle);
+  }
+
+  const auto info = cholesky_factor(R, upper_triangle);
+  if(info.has_value()) {
+    return info;
+  }
+  using std::linalg::triangular_matrix_matrix_left_solve;
+  triangular_matrix_matrix_left_solve(R, upper_triangle, A);
+  return nullopt;
+}
+
+// Compute QR factorization A = Q R.  Use R_tmp as temporary R factor
+// storage for iterative refinement.
+template<class in_matrix_t,
+         class out_matrix_1_t,
+         class out_matrix_2_t,
+         class out_matrix_3_t>
+optional<typename out_matrix_1_t::size_type>
+cholesky_tsqr(
+  in_matrix_t A,
+  out_matrix_1_t Q,
+  out_matrix_2_t R_tmp,
+  out_matrix_3_t R)
+{
+  assert(R.extent(0) == R.extent(1));
+  assert(A.extent(1) == R.extent(0));
+  assert(R_tmp.extent(0) == R_tmp.extent(1));
+  assert(A.extent(0) == Q.extent(0));
+  assert(A.extent(1) == Q.extent(1));
+
+  copy(A, Q);
+  const auto info1 = cholesky_tsqr_one_step(Q, R);
+  if(info1.has_value()) {
+    return info1;
+  }
+  // Use one step of iterative refinement to improve accuracy.
+  const auto info2 = cholesky_tsqr_one_step(Q, R_tmp);
+  if(info2.has_value()) {
+    return info2;
+  }
+  // R = R_tmp * R
+  using std::linalg::triangular_matrix_left_product;
+  triangular_matrix_left_product(R_tmp, upper_triangle,
+                                 explicit_diagonal, R);
+  return nullopt;
+}
+```

--- a/D1673/P1673.md
+++ b/D1673/P1673.md
@@ -436,6 +436,7 @@ toc: true
       vector / matrix / object template parameters
       may deduce a `const` lvalue reference
       or a (non-`const`) rvalue reference to an `mdspan`.
+      Add new section for exposition-only concepts and traits.
 
   * Fix `dot` Remarks to include both vector types
       and to use `value_type` instead of `element_type`.

--- a/D1673/P1673.md
+++ b/D1673/P1673.md
@@ -5679,17 +5679,17 @@ constexpr friend auto abs(const derived_type& x);
 The expression `abs(E)` for subexpression `E` whose type is `derived_type`
 is expression-equivalent to:
 
-    * `value_type(static_cast<const this_type&>(E))`,
-        if `value_type` is an unsigned integer;
+  * `value_type(static_cast<const this_type&>(E))`,
+      if `value_type` is an unsigned integer;
 
-    * else, `abs(value_type(static_cast<const this_type&>(E)))`,
-        if that expression is valid,
-	      with overload resolution performed in a context
-	      that includes the declaration
-        `template<class T> T abs(T) = delete;`.
-	      If the function selected by overload resolution
-	      does not return the absolute value of its input,
-	      the program is ill-formed, no diagnostic required.
+  * else, `abs(value_type(static_cast<const this_type&>(E)))`,
+      if that expression is valid,
+      with overload resolution performed in a context
+      that includes the declaration
+      `template<class T> T abs(T) = delete;`.
+	    If the function selected by overload resolution
+	    does not return the absolute value of its input,
+	    the program is ill-formed, no diagnostic required.
 
 <!-- TODO (mfh 2022/07/06) this lookup language will go into front matter. -->
 
@@ -5707,19 +5707,19 @@ constexpr friend auto real(const derived_type& x);
 The expression `real(E)` for subexpression `E` whose type is `derived_type`
 is expression-equivalent to:
 
-    * `value_type(static_cast<const this_type&>(E))`,
-        if `value_type` is an arithmetic type;
+  * `value_type(static_cast<const this_type&>(E))`,
+      if `value_type` is an arithmetic type;
 
-    * else, `real(value_type(static_cast<const this_type&>(E)))`,
-	      if that expression is valid,
-	      with overload resolution performed in a context
-	      that includes the declaration
-        `template<class T> T real(T) = delete;`;
-	      if the function selected by overload resolution
-	      does not return the absolute value of its input,
-	      the program is ill-formed, no diagnostic required;
+  * else, `real(value_type(static_cast<const this_type&>(E)))`,
+	    if that expression is valid,
+	    with overload resolution performed in a context
+	    that includes the declaration
+      `template<class T> T real(T) = delete;`;
+	    if the function selected by overload resolution
+	    does not return the absolute value of its input,
+	    the program is ill-formed, no diagnostic required;
 
-    * else, `value_type(static_cast<const this_type&>(E))`.
+  * else, `value_type(static_cast<const this_type&>(E))`.
 
 *[Note:*
 This function exists because of `vector_abs_sum`.
@@ -5740,19 +5740,19 @@ constexpr friend auto imag(const derived_type& x);
 The expression `imag(E)` for subexpression `E` whose type is `derived_type`
 is expression-equivalent to:
 
-    * `value_type{}`,
-        if `value_type` is an arithmetic type;
+  * `value_type{}`,
+      if `value_type` is an arithmetic type;
 
-    * else, `imag(value_type(static_cast<const this_type&>(E)))`,
-	      if that expression is valid,
-	      with overload resolution performed in a context
-	      that includes the declaration
-        `template<class T> T imag(T) = delete;`;
-	      if the function selected by overload resolution
-	      does not return the absolute value of its input,
-	      the program is ill-formed, no diagnostic required;
+  * else, `imag(value_type(static_cast<const this_type&>(E)))`,
+	    if that expression is valid,
+	    with overload resolution performed in a context
+	    that includes the declaration
+      `template<class T> T imag(T) = delete;`;
+	    if the function selected by overload resolution
+	    does not return the absolute value of its input,
+	    the program is ill-formed, no diagnostic required;
 
-    * else, `value_type{}`.
+  * else, `value_type{}`.
 
 *[Note:*
 This function exists because of `vector_abs_sum`.
@@ -5821,9 +5821,9 @@ It also makes fewer requirements of the reference type.
 
 *Mandates:*
 
-    * _`scalable`_`<ScalingFactor, ReferenceValue>`, and
+  * _`scalable`_`<ScalingFactor, ReferenceValue>`, and
 
-    * `value_type` is a complete object type that is neither an abstract class type nor an array type.
+  * `value_type` is a complete object type that is neither an abstract class type nor an array type.
 
 `ScalingFactor` models `semiregular`.
 
@@ -5835,9 +5835,9 @@ explicit scaled_scalar(const ScalingFactor& scaling_factor, const Reference& ref
 
 *Effects:*
 
-    * Direct non-list-initializes `static_cast<base_type&>(*this)` with `reference`, and
+  * Direct non-list-initializes `static_cast<base_type&>(*this)` with `reference`, and
 
-    * direct non-list-initializes _`scaling-factor`_ with `scaling_factor`.
+  * direct non-list-initializes _`scaling-factor`_ with `scaling_factor`.
 
 ```c++
 value_type to_value(Reference reference) const;
@@ -5881,11 +5881,13 @@ private:
 };
 ```
 
-*Mandates:*: `is_copy_constructible_v<typename Accessor::reference>` is `true`.
+*Mandates:*
 
-`ScalingFactor` models `semiregular`.
+  * `is_copy_constructible_v<typename Accessor::reference>` is `true`.
 
-`Accessor` meets the accessor policy requirements **[mdspan.accessor.reqmts]**.
+  * `ScalingFactor` models `semiregular`.
+
+  * `Accessor` meets the accessor policy requirements **[mdspan.accessor.reqmts]**.
 
 ```c++
 constexpr accessor_scaled(const ScalingFactor& s, const Accessor& a);
@@ -5893,9 +5895,9 @@ constexpr accessor_scaled(const ScalingFactor& s, const Accessor& a);
 
 *Effects:*
 
-    * Direct non-list-initializes _`scaling-factor`_ with `s`, and
+  * Direct non-list-initializes _`scaling-factor`_ with `s`, and
 
-    * direct non-list-initializes _`nested-accessor`_ with `a`.
+  * direct non-list-initializes _`nested-accessor`_ with `a`.
 
 ```c++
 constexpr reference access(data_handle_type p, size_t i) const noexcept;
@@ -6161,7 +6163,7 @@ Let `R` name the type
 `mdspan<ReturnElementType, Extents, Layout, ReturnAccessor>`,
 where
 
-* `ReturnElementType` is
+  * `ReturnElementType` is
 
     * if `Accessor` is `accessor_conjugate<NestedAccessor>`
         for some `NestedAccessor`, then
@@ -6173,7 +6175,7 @@ where
 
     * else `accessor_conjugate<Accessor>::element_type`;
 
-* and `ReturnAccessor` is:
+  * and `ReturnAccessor` is:
 
     * if `Accessor` is `accessor_conjugate<NestedAccessor>`
         for some `NestedAccessor`, then `NestedAccessor` *[Note:*
@@ -6188,16 +6190,16 @@ where
 
 *Effects:*
 
-    * If `Accessor` is `accessor_conjugate<NestedAccessor>`,
-        then equivalent to
-        `return R(a.data(), a.mapping(), a.nested_accessor());`;
+  * If `Accessor` is `accessor_conjugate<NestedAccessor>`,
+      then equivalent to
+      `return R(a.data(), a.mapping(), a.nested_accessor());`;
 
-    * else if `remove_cv_t<ElementType>` is an arithmetic type,
-        then equivalent to
-        `return R(a.data(), a.mapping(), a.accessor());`;
+  * else if `remove_cv_t<ElementType>` is an arithmetic type,
+      then equivalent to
+      `return R(a.data(), a.mapping(), a.accessor());`;
 
-    * else, equivalent to
-        `return R(a.data(), a.mapping(), ReturnAccessor(a.accessor()));`;
+  * else, equivalent to
+      `return R(a.data(), a.mapping(), ReturnAccessor(a.accessor()));`;
 
 *[Note:*
 The elements of the returned `mdspan` are read only.

--- a/D1673/P1673.md
+++ b/D1673/P1673.md
@@ -1,15 +1,38 @@
-<pre class='metadata'>
-Title: A free function linear algebra interface based on the BLAS
-Shortname: P1673
-Status: iso/P
-Level: 10
-Group: WG21
-URL: https://github.com/ORNL/cpp-proposals-pub/blob/master/D1673/P1673.bs
-Editor: Mark Hoemmen, NVIDIA, mhoemmen@nvidia.com
-Abstract: We propose a C++ Standard Library dense linear algebra interface based on the dense Basic Linear Algebra Subroutines (BLAS).  This corresponds to a subset of the BLAS Standard.
-Markup Shorthands: markdown yes
-Date: 2022-10-15
-</pre>
+
+---
+title: "A free function linear algebra interface based on the BLAS"
+document: P1673
+date: today
+audience: LEWG
+author:
+  - name: Mark Hoemmen
+    email: <mhoemmen@nvidia.com>
+  - name: Daisy Hollman
+    email: <cpp@dsh.fyi>
+  - name: Christian Trott
+    email: <crtrott@sandia.gov>
+  - name: Daniel Sunderland
+    email: <dansunderland@gmail.com>
+  - name: Nevin Liber
+    email: <nliber@anl.gov>
+  - name: Alicia Klinvex
+    email: <alicia.klinvex@unnpp.gov>
+  - name: Li-Ta Lo
+    email: <ollie@lanl.gov>
+  - name: Damien Lebrun-Grandie
+    email: <lebrungrandt@ornl.gov>
+  - name: Graham Lopez
+    email: <glopez@nvidia.com>
+  - name: Peter Caday
+    email: <peter.caday@intel.com>
+  - name: Sarah Knepper
+    email: <sarah.knepper@intel.com>
+  - name: Piotr Luszczek
+    email: <luszczek@icl.utk.edu>
+  - name: Timothy Costa
+    email: <tcosta@nvidia.com>
+toc: true
+---
 
 # Authors and contributors
 

--- a/D1673/P1673.md
+++ b/D1673/P1673.md
@@ -3367,9 +3367,17 @@ on constraints wording.
 > First, apply all wording from P2642R1.
 > (This proposal is a "rebase" atop the changes proposed by P2642R1.)
 > At the end of Table � ("Numerics library summary") in *[numerics.general]*, add the following: [linalg], Linear algebra, `<linalg>`.
-> At the end of *[numerics]*, add all the material that follows.
+> At the end of *[numerics]* (after subsection 28.8 *[numbers]*), add all the material that follows.
 
-## Header `<linalg>` synopsis [linalg.syn]
+## Add subsection 28.9 [linalg] with the following
+
+<b>28.9 Basic linear algebra algorithms [linalg]</b>
+
+<b>28.9.1 Overview [linalg.overview] </b>
+
+[1]{.pnum} Subclause [linalg] defines basic linear algebra algorithms.  The algorithms that access the elements of arrays view the arrays' elements through `mdspan` [mdspan].
+
+<b>28.9.2 Header `<linalg>` synopsis [linalg.syn]</b>
 
 ```c++
 namespace std::linalg {

--- a/D1673/P1673.md
+++ b/D1673/P1673.md
@@ -427,7 +427,24 @@ toc: true
 
 * Revision 11, to be submitted soon
 
-  * Remove requirement that `in_vector*_t` has unique layout.
+  * Remove requirement that `in_{vector,matrix,object}*_t`
+      have unique layout.
+
+  * Change from name-based requirements (`in_{vector,matrix,object}*_t`)
+      to exposition-only concepts (following LEWG feedback).
+
+  * Fix `dot` Remarks to include both vector types
+      and to use `value_type` instead of `element_type`.
+
+  * Fix `vector_sum_of_squares`, `vector_norm2`, and `vector_abs_sum`
+      Remarks to use `value_type` instead of `element_type`.
+
+  * Fix QR factorization example
+      to use `value_type` instead of `element_type`.
+
+  * Remove redundant unique layout constraints on
+      out and inout matrix parameter(s) of
+      *[linalg.algs.blas3.trmm]* and *[linalg.alg.blas3.trsm]*.
 
 # Purpose of this paper
 
@@ -3469,6 +3486,40 @@ template<class ElementType,
 constexpr auto conjugate_transposed(
   mdspan<ElementType, Extents, Layout, Accessor> a);
 
+// [linalg.concepts], exposition-only concepts
+
+template<class T>
+struct @_is-mdspan_@; // exposition only
+
+template<class T>
+concept @_in-vector_@; = // exposition only
+
+template<class T>
+concept @_out-vector_@; = // exposition only
+
+template<class T>
+concept @_inout-vector_@; = // exposition only
+
+template<class T>
+concept @_in-matrix_@; = // exposition only
+
+template<class T>
+concept @_out-matrix_@; = // exposition only
+
+template<class T>
+concept @_inout-matrix_@; = // exposition only
+
+template<class T>
+concept @_in-object_@; = // exposition only
+
+template<class T>
+concept @_out-object_@; = // exposition only
+
+template<class T>
+concept @_inout-object_@; = // exposition only
+
+// [linalg.algs], algorithms
+
 // [linalg.algs.blas1.givens.lartg], compute Givens rotation
 template<class Real>
 void givens_rotation_setup(const Real a,
@@ -3484,152 +3535,152 @@ void givens_rotation_setup(const complex<Real>& a,
                            complex<Real>& r);
 
 // [linalg.algs.blas1.givens.rot], apply computed Givens rotation
-template<class inout_vector_1_t,
-         class inout_vector_2_t,
+template<inout_vector InOutVec1,
+         inout_vector InOutVec2,
          class Real>
 void givens_rotation_apply(
-  inout_vector_1_t x,
-  inout_vector_2_t y,
+  InOutVec1 x,
+  InOutVec2 y,
   const Real c,
   const Real s);
 template<class ExecutionPolicy,
-         class inout_vector_1_t,
-         class inout_vector_2_t,
+         inout_vector InOutVec1,
+         inout_vector InOutVec2,
          class Real>
 void givens_rotation_apply(
   ExecutionPolicy&& exec,
-  inout_vector_1_t x,
-  inout_vector_2_t y,
+  InOutVec1 x,
+  InOutVec2 y,
   const Real c,
   const Real s);
-template<class inout_vector_1_t,
-         class inout_vector_2_t,
+template<inout_vector InOutVec1,
+         inout_vector InOutVec2,
          class Real>
 void givens_rotation_apply(
-  inout_vector_1_t x,
-  inout_vector_2_t y,
+  InOutVec1 x,
+  InOutVec2 y,
   const Real c,
   const complex<Real> s);
 template<class ExecutionPolicy,
-         class inout_vector_1_t,
-         class inout_vector_2_t,
+         inout_vector InOutVec1,
+         inout_vector InOutVec2,
          class Real>
 void givens_rotation_apply(
   ExecutionPolicy&& exec,
-  inout_vector_1_t x,
-  inout_vector_2_t y,
+  InOutVec1 x,
+  InOutVec2 y,
   const Real c,
   const complex<Real> s);
 }
 
 // [linalg.algs.blas1.swap], swap elements
-template<class inout_object_1_t,
-         class inout_object_2_t>
-void swap_elements(inout_object_1_t x,
-                   inout_object_2_t y);
+template<inout_object InOutObj1,
+         inout_object InOutObj2>
+void swap_elements(InOutObj1 x,
+                   InOutObj2 y);
 template<class ExecutionPolicy,
-         class inout_object_1_t,
-         class inout_object_2_t>
+         inout_object InOutObj1,
+         inout_object InOutObj2>
 void swap_elements(ExecutionPolicy&& exec,
-                   inout_object_1_t x,
-                   inout_object_2_t y);
+                   InOutObj1 x,
+                   InOutObj2 y);
 
 // [linalg.algs.blas1.scal], multiply elements by scalar
 template<class Scalar,
-         class inout_object_t>
+         inout_object InOutObj>
 void scale(const Scalar alpha,
-           inout_object_t obj);
+           InOutObj obj);
 template<class ExecutionPolicy,
          class Scalar,
-         class inout_object_t>
+         inout_object InOutObj>
 void scale(ExecutionPolicy&& exec,
            const Scalar alpha,
-           inout_object_t obj);
+           InOutObj obj);
 
 // [linalg.algs.blas1.copy], copy elements
-template<class in_object_t,
-         class out_object_t>
-void copy(in_object_t x,
-          out_object_t y);
+template<in_object InObj,
+         out_object OutObj>
+void copy(InObj x,
+          OutObj y);
 template<class ExecutionPolicy,
-         class in_object_t,
-         class out_object_t>
+         in_object InObj,
+         out_object OutObj>
 void copy(ExecutionPolicy&& exec,
-          in_object_t x,
-          out_object_t y);
+          InObj x,
+          OutObj y);
 
 // [linalg.algs.blas1.add], add elementwise
-template<class in_object_1_t,
-         class in_object_2_t,
-         class out_object_t>
-void add(in_object_1_t x,
-         in_object_2_t y,
-         out_object_t z);
+template<in_object InObj1,
+         in_object InObj2,
+         out_object OutObj>
+void add(InObj1 x,
+         InObj2 y,
+         OutObj z);
 template<class ExecutionPolicy,
-         class in_object_1_t,
-         class in_object_2_t,
-         class out_object_t>
+         in_object InObj1,
+         in_object InObj2,
+         out_object OutObj>
 void add(ExecutionPolicy&& exec,
-         in_object_1_t x,
-         in_object_2_t y,
-         out_object_t z);
+         InObj1 x,
+         InObj2 y,
+         OutObj z);
 
 // [linalg.algs.blas1.dot],
 // dot product of two vectors
 
 // [linalg.algs.blas1.dot.dotu],
 // nonconjugated dot product of two vectors
-template<class in_vector_1_t,
-         class in_vector_2_t,
+template<in_vector InVec1,
+         in_vector InVec2,
          class T>
-T dot(in_vector_1_t v1,
-      in_vector_2_t v2,
+T dot(InVec1 v1,
+      InVec2 v2,
       T init);
 template<class ExecutionPolicy,
-         class in_vector_1_t,
-         class in_vector_2_t,
+         in_vector InVec1,
+         in_vector InVec2,
          class T>
 T dot(ExecutionPolicy&& exec,
-      in_vector_1_t v1,
-      in_vector_2_t v2,
+      InVec1 v1,
+      InVec2 v2,
       T init);
-template<class in_vector_1_t,
-         class in_vector_2_t>
-auto dot(in_vector_1_t v1,
-         in_vector_2_t v2) -> /* see-below */;
+template<in_vector InVec1,
+         in_vector InVec2>
+auto dot(InVec1 v1,
+         InVec2 v2) -> /* see-below */;
 template<class ExecutionPolicy,
-         class in_vector_1_t,
-         class in_vector_2_t>
+         in_vector InVec1,
+         in_vector InVec2>
 auto dot(ExecutionPolicy&& exec,
-         in_vector_1_t v1,
-         in_vector_2_t v2) -> /* see-below */;
+         InVec1 v1,
+         InVec2 v2) -> /* see-below */;
 
 // [linalg.algs.blas1.dot.dotc],
 // conjugated dot product of two vectors
-template<class in_vector_1_t,
-         class in_vector_2_t,
+template<in_vector InVec1,
+         in_vector InVec2,
          class T>
-T dotc(in_vector_1_t v1,
-       in_vector_2_t v2,
+T dotc(InVec1 v1,
+       InVec2 v2,
        T init);
 template<class ExecutionPolicy,
-         class in_vector_1_t,
-         class in_vector_2_t,
+         in_vector InVec1,
+         in_vector InVec2,
          class T>
 T dotc(ExecutionPolicy&& exec,
-       in_vector_1_t v1,
-       in_vector_2_t v2,
+       InVec1 v1,
+       InVec2 v2,
        T init);
-template<class in_vector_1_t,
-         class in_vector_2_t>
-auto dotc(in_vector_1_t v1,
-          in_vector_2_t v2) -> /* see-below */;
+template<in_vector InVec1,
+         in_vector InVec2>
+auto dotc(InVec1 v1,
+          InVec2 v2) -> /* see-below */;
 template<class ExecutionPolicy,
-         class in_vector_1_t,
-         class in_vector_2_t>
+         in_vector InVec1,
+         in_vector InVec2>
 auto dotc(ExecutionPolicy&& exec,
-          in_vector_1_t v1,
-          in_vector_2_t v2) -> /* see-below */;
+          InVec1 v1,
+          InVec2 v2) -> /* see-below */;
 
 // [linalg.algs.blas1.ssq],
 // Scaled sum of squares of a vector's elements
@@ -3638,63 +3689,63 @@ struct sum_of_squares_result {
   T scaling_factor;
   T scaled_sum_of_squares;
 };
-template<class in_vector_t,
+template<in_vector InVec,
          class T>
 sum_of_squares_result<T> vector_sum_of_squares(
-  in_vector_t v,
+  InVec v,
   sum_of_squares_result<T> init);
 sum_of_squares_result<T> vector_sum_of_squares(
   ExecutionPolicy&& exec,
-  in_vector_t v,
+  InVec v,
   sum_of_squares_result<T> init);
 
 // [linalg.algs.blas1.nrm2],
 // Euclidean norm of a vector
-template<class in_vector_t,
+template<in_vector InVec,
          class T>
-T vector_norm2(in_vector_t v,
+T vector_norm2(InVec v,
                T init);
 template<class ExecutionPolicy,
-         class in_vector_t,
+         in_vector InVec,
          class T>
 T vector_norm2(ExecutionPolicy&& exec,
-               in_vector_t v,
+               InVec v,
                T init);
-template<class in_vector_t>
-auto vector_norm2(in_vector_t v) -> /* see-below */;
+template<in_vector InVec>
+auto vector_norm2(InVec v) -> /* see-below */;
 template<class ExecutionPolicy,
-         class in_vector_t>
+         in_vector InVec>
 auto vector_norm2(ExecutionPolicy&& exec,
-                  in_vector_t v) -> /* see-below */;
+                  InVec v) -> /* see-below */;
 
 // [linalg.algs.blas1.asum],
 // sum of absolute values of vector elements
-template<class in_vector_t,
+template<in_vector InVec,
          class T>
-T vector_abs_sum(in_vector_t v,
+T vector_abs_sum(InVec v,
                  T init);
 template<class ExecutionPolicy,
-         class in_vector_t,
+         in_vector InVec,
          class T>
 T vector_abs_sum(ExecutionPolicy&& exec,
-                 in_vector_t v,
+                 InVec v,
                  T init);
-template<class in_vector_t>
-auto vector_abs_sum(in_vector_t v) -> /* see-below */;
+template<in_vector InVec>
+auto vector_abs_sum(InVec v) -> /* see-below */;
 template<class ExecutionPolicy,
-         class in_vector_t>
+         in_vector InVec>
 auto vector_abs_sum(ExecutionPolicy&& exec,
-                    in_vector_t v) -> /* see-below */;
+                    InVec v) -> /* see-below */;
 
 // [linalg.algs.blas1.iamax],
 // index of maximum absolute value of vector elements
-template<class in_vector_t>
-typename in_vector_t::extents_type idx_abs_max(in_vector_t v);
+template<in_vector InVec>
+typename InVec::extents_type idx_abs_max(InVec v);
 template<class ExecutionPolicy,
-         class in_vector_t>
-typename in_vector_t::extents_type idx_abs_max(
+         in_vector InVec>
+typename InVec::extents_type idx_abs_max(
   ExecutionPolicy&& exec,
-  in_vector_t v);
+  InVec v);
 
 // [linalg.algs.blas1.matfrobnorm],
 // Frobenius norm of a matrix
@@ -3767,127 +3818,127 @@ auto matrix_inf_norm(
 
 // [linalg.algs.blas2.gemv],
 // general matrix-vector product
-template<class in_vector_t,
+template<in_vector InVec,
          class in_matrix_t,
          class out_vector_t>
 void matrix_vector_product(in_matrix_t A,
-                           in_vector_t x,
+                           InVec x,
                            out_vector_t y);
 template<class ExecutionPolicy,
-         class in_vector_t,
+         in_vector InVec,
          class in_matrix_t,
          class out_vector_t>
 void matrix_vector_product(ExecutionPolicy&& exec,
                            in_matrix_t A,
-                           in_vector_t x,
+                           InVec x,
                            out_vector_t y);
-template<class in_vector_1_t,
+template<in_vector InVec1,
          class in_matrix_t,
-         class in_vector_2_t,
+         in_vector InVec2,
          class out_vector_t>
 void matrix_vector_product(in_matrix_t A,
-                           in_vector_1_t x,
-                           in_vector_2_t y,
+                           InVec1 x,
+                           InVec2 y,
                            out_vector_t z);
 template<class ExecutionPolicy,
-         class in_vector_1_t,
+         in_vector InVec1,
          class in_matrix_t,
-         class in_vector_2_t,
+         in_vector InVec2,
          class out_vector_t>
 void matrix_vector_product(ExecutionPolicy&& exec,
                            in_matrix_t A,
-                           in_vector_1_t x,
-                           in_vector_2_t y,
+                           InVec1 x,
+                           InVec2 y,
                            out_vector_t z);
 
 // [linalg.algs.blas2.symv],
 // symmetric matrix-vector product
 template<class in_matrix_t,
          class Triangle,
-         class in_vector_t,
+         in_vector InVec,
          class out_vector_t>
 void symmetric_matrix_vector_product(in_matrix_t A,
                                      Triangle t,
-                                     in_vector_t x,
+                                     InVec x,
                                      out_vector_t y);
 template<class ExecutionPolicy,
          class in_matrix_t,
          class Triangle,
-         class in_vector_t,
+         in_vector InVec,
          class out_vector_t>
 void symmetric_matrix_vector_product(ExecutionPolicy&& exec,
                                      in_matrix_t A,
                                      Triangle t,
-                                     in_vector_t x,
+                                     InVec x,
                                      out_vector_t y);
 template<class in_matrix_t,
          class Triangle,
-         class in_vector_1_t,
-         class in_vector_2_t,
+         in_vector InVec1,
+         in_vector InVec2,
          class out_vector_t>
 void symmetric_matrix_vector_product(
   in_matrix_t A,
   Triangle t,
-  in_vector_1_t x,
-  in_vector_2_t y,
+  InVec1 x,
+  InVec2 y,
   out_vector_t z);
 
 template<class ExecutionPolicy,
          class in_matrix_t,
          class Triangle,
-         class in_vector_1_t,
-         class in_vector_2_t,
+         in_vector InVec1,
+         in_vector InVec2,
          class out_vector_t>
 void symmetric_matrix_vector_product(
   ExecutionPolicy&& exec,
   in_matrix_t A,
   Triangle t,
-  in_vector_1_t x,
-  in_vector_2_t y,
+  InVec1 x,
+  InVec2 y,
   out_vector_t z);
 
 // [linalg.algs.blas2.hemv],
 // Hermitian matrix-vector product
 template<class in_matrix_t,
          class Triangle,
-         class in_vector_t,
+         in_vector InVec,
          class out_vector_t>
 void hermitian_matrix_vector_product(in_matrix_t A,
                                      Triangle t,
-                                     in_vector_t x,
+                                     InVec x,
                                      out_vector_t y);
 template<class ExecutionPolicy,
          class in_matrix_t,
          class Triangle,
-         class in_vector_t,
+         in_vector InVec,
          class out_vector_t>
 void hermitian_matrix_vector_product(ExecutionPolicy&& exec,
                                      in_matrix_t A,
                                      Triangle t,
-                                     in_vector_t x,
+                                     InVec x,
                                      out_vector_t y);
 template<class in_matrix_t,
          class Triangle,
-         class in_vector_1_t,
-         class in_vector_2_t,
+         in_vector InVec1,
+         in_vector InVec2,
          class out_vector_t>
 void hermitian_matrix_vector_product(in_matrix_t A,
                                      Triangle t,
-                                     in_vector_1_t x,
-                                     in_vector_2_t y,
+                                     InVec1 x,
+                                     InVec2 y,
                                      out_vector_t z);
 
 template<class ExecutionPolicy,
          class in_matrix_t,
          class Triangle,
-         class in_vector_1_t,
-         class in_vector_2_t,
+         in_vector InVec1,
+         in_vector InVec2,
          class out_vector_t>
 void hermitian_matrix_vector_product(ExecutionPolicy&& exec,
                                      in_matrix_t A,
                                      Triangle t,
-                                     in_vector_1_t x,
-                                     in_vector_2_t y,
+                                     InVec1 x,
+                                     InVec2 y,
                                      out_vector_t z);
 
 // [linalg.algs.blas2.trmv],
@@ -3898,26 +3949,26 @@ void hermitian_matrix_vector_product(ExecutionPolicy&& exec,
 template<class in_matrix_t,
          class Triangle,
          class DiagonalStorage,
-         class in_vector_t,
+         in_vector InVec,
          class out_vector_t>
 void triangular_matrix_vector_product(
   in_matrix_t A,
   Triangle t,
   DiagonalStorage d,
-  in_vector_t x,
+  InVec x,
   out_vector_t y);
 template<class ExecutionPolicy,
          class in_matrix_t,
          class Triangle,
          class DiagonalStorage,
-         class in_vector_t,
+         in_vector InVec,
          class out_vector_t>
 void triangular_matrix_vector_product(
   ExecutionPolicy&& exec,
   in_matrix_t A,
   Triangle t,
   DiagonalStorage d,
-  in_vector_t x,
+  InVec x,
   out_vector_t y);
 
 // [linalg.algs.blas2.trmv.in-place],
@@ -3925,51 +3976,51 @@ void triangular_matrix_vector_product(
 template<class in_matrix_t,
          class Triangle,
          class DiagonalStorage,
-         class inout_vector_t>
+         inout_vector InOutVec>
 void triangular_matrix_vector_product(
   in_matrix_t A,
   Triangle t,
   DiagonalStorage d,
-  inout_vector_t y);
+  InOutVec y);
 template<class ExecutionPolicy,
          class in_matrix_t,
          class Triangle,
          class DiagonalStorage,
-         class inout_vector_t>
+         inout_vector InOutVec>
 void triangular_matrix_vector_product(
   ExecutionPolicy&& exec,
   in_matrix_t A,
   Triangle t,
   DiagonalStorage d,
-  inout_vector_t y);
+  InOutVec y);
 
 // [linalg.algs.blas2.trmv.up],
 // Updating triangular matrix-vector product
 template<class in_matrix_t,
          class Triangle,
          class DiagonalStorage,
-         class in_vector_1_t,
-         class in_vector_2_t,
+         in_vector InVec1,
+         in_vector InVec2,
          class out_vector_t>
 void triangular_matrix_vector_product(in_matrix_t A,
                                       Triangle t,
                                       DiagonalStorage d,
-                                      in_vector_1_t x,
-                                      in_vector_2_t y,
+                                      InVec1 x,
+                                      InVec2 y,
                                       out_vector_t z);
 template<class ExecutionPolicy,
          class in_matrix_t,
          class Triangle,
          class DiagonalStorage,
-         class in_vector_1_t,
-         class in_vector_2_t,
+         in_vector InVec1,
+         in_vector InVec2,
          class out_vector_t>
 void triangular_matrix_vector_product(ExecutionPolicy&& exec,
                                       in_matrix_t A,
                                       Triangle t,
                                       DiagonalStorage d,
-                                      in_vector_1_t x,
-                                      in_vector_2_t y,
+                                      InVec1 x,
+                                      InVec2 y,
                                       out_vector_t z);
 
 // [linalg.algs.blas2.trsv],
@@ -3980,21 +4031,21 @@ void triangular_matrix_vector_product(ExecutionPolicy&& exec,
 template<class in_matrix_t,
          class Triangle,
          class DiagonalStorage,
-         class in_vector_t,
+         in_vector InVec,
          class out_vector_t,
          class BinaryDivideOp>
 void triangular_matrix_vector_solve(
   in_matrix_t A,
   Triangle t,
   DiagonalStorage d,
-  in_vector_t b,
+  InVec b,
   out_vector_t x,
   BinaryDivideOp divide);
 template<class ExecutionPolicy,
          class in_matrix_t,
          class Triangle,
          class DiagonalStorage,
-         class in_vector_t,
+         in_vector InVec,
          class out_vector_t,
          class BinaryDivideOp>
 void triangular_matrix_vector_solve(
@@ -4002,32 +4053,32 @@ void triangular_matrix_vector_solve(
   in_matrix_t A,
   Triangle t,
   DiagonalStorage d,
-  in_vector_t b,
+  InVec b,
   out_vector_t x,
   BinaryDivideOp divide);
 template<class in_matrix_t,
          class Triangle,
          class DiagonalStorage,
-         class in_vector_t,
+         in_vector InVec,
          class out_vector_t>
 void triangular_matrix_vector_solve(
   in_matrix_t A,
   Triangle t,
   DiagonalStorage d,
-  in_vector_t b,
+  InVec b,
   out_vector_t x);
 template<class ExecutionPolicy,
          class in_matrix_t,
          class Triangle,
          class DiagonalStorage,
-         class in_vector_t,
+         in_vector InVec,
          class out_vector_t>
 void triangular_matrix_vector_solve(
   ExecutionPolicy&& exec,
   in_matrix_t A,
   Triangle t,
   DiagonalStorage d,
-  in_vector_t b,
+  InVec b,
   out_vector_t x);
 
 // [linalg.algs.blas2.trsv.in-place],
@@ -4035,208 +4086,208 @@ void triangular_matrix_vector_solve(
 template<class in_matrix_t,
          class Triangle,
          class DiagonalStorage,
-         class inout_vector_t,
+         inout_vector InOutVec,
          class BinaryDivideOp>
 void triangular_matrix_vector_solve(
   in_matrix_t A,
   Triangle t,
   DiagonalStorage d,
-  inout_vector_t b,
+  InOutVec b,
   BinaryDivideOp divide);
 template<class ExecutionPolicy,
          class in_matrix_t,
          class Triangle,
          class DiagonalStorage,
-         class inout_vector_t,
+         inout_vector InOutVec,
          class BinaryDivideOp>
 void triangular_matrix_vector_solve(
   ExecutionPolicy&& exec,
   in_matrix_t A,
   Triangle t,
   DiagonalStorage d,
-  inout_vector_t b,
+  InOutVec b,
   BinaryDivideOp divide);
 template<class in_matrix_t,
          class Triangle,
          class DiagonalStorage,
-         class inout_vector_t>
+         inout_vector InOutVec>
 void triangular_matrix_vector_solve(
   in_matrix_t A,
   Triangle t,
   DiagonalStorage d,
-  inout_vector_t b);
+  InOutVec b);
 template<class ExecutionPolicy,
          class in_matrix_t,
          class Triangle,
          class DiagonalStorage,
-         class inout_vector_t>
+         inout_vector InOutVec>
 void triangular_matrix_vector_solve(
   ExecutionPolicy&& exec,
   in_matrix_t A,
   Triangle t,
   DiagonalStorage d,
-  inout_vector_t b);
+  InOutVec b);
 
 // [linalg.algs.blas2.rank1.geru],
 // nonconjugated rank-1 matrix update
-template<class in_vector_1_t,
-         class in_vector_2_t,
-         class inout_matrix_t>
+template<in_vector InVec1,
+         in_vector InVec2,
+         inout_matrix InOutMat>
 void matrix_rank_1_update(
-  in_vector_1_t x,
-  in_vector_2_t y,
-  inout_matrix_t A);
+  InVec1 x,
+  InVec2 y,
+  InOutMat A);
 template<class ExecutionPolicy,
-         class in_vector_1_t,
-         class in_vector_2_t,
-         class inout_matrix_t>
+         in_vector InVec1,
+         in_vector InVec2,
+         inout_matrix InOutMat>
 void matrix_rank_1_update(
   ExecutionPolicy&& exec,
-  in_vector_1_t x,
-  in_vector_2_t y,
-  inout_matrix_t A);
+  InVec1 x,
+  InVec2 y,
+  InOutMat A);
 
 // [linalg.algs.blas2.rank1.gerc],
 // conjugated rank-1 matrix update
-template<class in_vector_1_t,
-         class in_vector_2_t,
-         class inout_matrix_t>
+template<in_vector InVec1,
+         in_vector InVec2,
+         inout_matrix InOutMat>
 void matrix_rank_1_update_c(
-  in_vector_1_t x,
-  in_vector_2_t y,
-  inout_matrix_t A);
+  InVec1 x,
+  InVec2 y,
+  InOutMat A);
 template<class ExecutionPolicy,
-         class in_vector_1_t,
-         class in_vector_2_t,
-         class inout_matrix_t>
+         in_vector InVec1,
+         in_vector InVec2,
+         inout_matrix InOutMat>
 void matrix_rank_1_update_c(
   ExecutionPolicy&& exec,
-  in_vector_1_t x,
-  in_vector_2_t y,
-  inout_matrix_t A);
+  InVec1 x,
+  InVec2 y,
+  InOutMat A);
 
 // [linalg.algs.blas2.rank1.syr],
 // symmetric rank-1 matrix update
-template<class in_vector_t,
-         class inout_matrix_t,
+template<in_vector InVec,
+         inout_matrix InOutMat,
          class Triangle>
 void symmetric_matrix_rank_1_update(
-  in_vector_t x,
-  inout_matrix_t A,
+  InVec x,
+  InOutMat A,
   Triangle t);
 template<class ExecutionPolicy,
-         class in_vector_t,
-         class inout_matrix_t,
+         in_vector InVec,
+         inout_matrix InOutMat,
          class Triangle>
 void symmetric_matrix_rank_1_update(
   ExecutionPolicy&& exec,
-  in_vector_t x,
-  inout_matrix_t A,
+  InVec x,
+  InOutMat A,
   Triangle t);
 template<class T,
-         class in_vector_t,
-         class inout_matrix_t,
+         in_vector InVec,
+         inout_matrix InOutMat,
          class Triangle>
 void symmetric_matrix_rank_1_update(
   T alpha,
-  in_vector_t x,
-  inout_matrix_t A,
+  InVec x,
+  InOutMat A,
   Triangle t);
 template<class ExecutionPolicy,
          class T,
-         class in_vector_t,
-         class inout_matrix_t,
+         in_vector InVec,
+         inout_matrix InOutMat,
          class Triangle>
 void symmetric_matrix_rank_1_update(
   ExecutionPolicy&& exec,
   T alpha,
-  in_vector_t x,
-  inout_matrix_t A,
+  InVec x,
+  InOutMat A,
   Triangle t);
 
 // [linalg.algs.blas2.rank1.her],
 // Hermitian rank-1 matrix update
-template<class in_vector_t,
-         class inout_matrix_t,
+template<in_vector InVec,
+         inout_matrix InOutMat,
          class Triangle>
 void hermitian_matrix_rank_1_update(
-  in_vector_t x,
-  inout_matrix_t A,
+  InVec x,
+  InOutMat A,
   Triangle t);
 template<class ExecutionPolicy,
-         class in_vector_t,
-         class inout_matrix_t,
+         in_vector InVec,
+         inout_matrix InOutMat,
          class Triangle>
 void hermitian_matrix_rank_1_update(
   ExecutionPolicy&& exec,
-  in_vector_t x,
-  inout_matrix_t A,
+  InVec x,
+  InOutMat A,
   Triangle t);
 template<class T,
-         class in_vector_t,
-         class inout_matrix_t,
+         in_vector InVec,
+         inout_matrix InOutMat,
          class Triangle>
 void hermitian_matrix_rank_1_update(
   T alpha,
-  in_vector_t x,
-  inout_matrix_t A,
+  InVec x,
+  InOutMat A,
   Triangle t);
 template<class ExecutionPolicy,
          class T,
-         class in_vector_t,
-         class inout_matrix_t,
+         in_vector InVec,
+         inout_matrix InOutMat,
          class Triangle>
 void hermitian_matrix_rank_1_update(
   ExecutionPolicy&& exec,
   T alpha,
-  in_vector_t x,
-  inout_matrix_t A,
+  InVec x,
+  InOutMat A,
   Triangle t);
 
 // [linalg.algs.blas2.rank2.syr2],
 // symmetric rank-2 matrix update
-template<class in_vector_1_t,
-         class in_vector_2_t,
-         class inout_matrix_t,
+template<in_vector InVec1,
+         in_vector InVec2,
+         inout_matrix InOutMat,
          class Triangle>
 void symmetric_matrix_rank_2_update(
-  in_vector_1_t x,
-  in_vector_2_t y,
-  inout_matrix_t A,
+  InVec1 x,
+  InVec2 y,
+  InOutMat A,
   Triangle t);
 template<class ExecutionPolicy,
-         class in_vector_1_t,
-         class in_vector_2_t,
-         class inout_matrix_t,
+         in_vector InVec1,
+         in_vector InVec2,
+         inout_matrix InOutMat,
          class Triangle>
 void symmetric_matrix_rank_2_update(
   ExecutionPolicy&& exec,
-  in_vector_1_t x,
-  in_vector_2_t y,
-  inout_matrix_t A,
+  InVec1 x,
+  InVec2 y,
+  InOutMat A,
   Triangle t);
 
 // [linalg.algs.blas2.rank2.her2],
 // Hermitian rank-2 matrix update
-template<class in_vector_1_t,
-         class in_vector_2_t,
-         class inout_matrix_t,
+template<in_vector InVec1,
+         in_vector InVec2,
+         inout_matrix InOutMat,
          class Triangle>
 void hermitian_matrix_rank_2_update(
-  in_vector_1_t x,
-  in_vector_2_t y,
-  inout_matrix_t A,
+  InVec1 x,
+  InVec2 y,
+  InOutMat A,
   Triangle t);
 template<class ExecutionPolicy,
-         class in_vector_1_t,
-         class in_vector_2_t,
-         class inout_matrix_t,
+         in_vector InVec1,
+         in_vector InVec2,
+         inout_matrix InOutMat,
          class Triangle>
 void hermitian_matrix_rank_2_update(
   ExecutionPolicy&& exec,
-  in_vector_1_t x,
-  in_vector_2_t y,
-  inout_matrix_t A,
+  InVec1 x,
+  InVec2 y,
+  InOutMat A,
   Triangle t);
 
 // [linalg.algs.blas3.gemm],
@@ -4512,23 +4563,23 @@ void triangular_matrix_left_product(
 template<class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
-         class inout_matrix_t>
+         inout_matrix InOutMat>
 void triangular_matrix_left_product(
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
-  inout_matrix_t C);
+  InOutMat C);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
-         class inout_matrix_t>
+         inout_matrix InOutMat>
 void triangular_matrix_left_product(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
-  inout_matrix_t C);
+  InOutMat C);
 
 // [linalg.algs.blas3.trmm.ov.right],
 // overwriting triangular matrix-matrix right product
@@ -4559,23 +4610,23 @@ void triangular_matrix_right_product(
 template<class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
-         class inout_matrix_t>
+         inout_matrix InOutMat>
 void triangular_matrix_right_product(
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
-  inout_matrix_t C);
+  InOutMat C);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
-         class inout_matrix_t>
+         inout_matrix InOutMat>
 void triangular_matrix_right_product(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
-  inout_matrix_t C);
+  InOutMat C);
 
 // [linalg.algs.blas3.trmm.up.left],
 // updating triangular matrix-matrix left product
@@ -4643,92 +4694,92 @@ void triangular_matrix_right_product(
 // rank-k symmetric matrix update
 template<class T,
          class in_matrix_1_t,
-         class inout_matrix_t,
+         inout_matrix InOutMat,
          class Triangle>
 void symmetric_matrix_rank_k_update(
   T alpha,
   in_matrix_1_t A,
-  inout_matrix_t C,
+  InOutMat C,
   Triangle t);
 template<class T,
          class ExecutionPolicy,
          class in_matrix_1_t,
-         class inout_matrix_t,
+         inout_matrix InOutMat,
          class Triangle>
 void symmetric_matrix_rank_k_update(
   ExecutionPolicy&& exec,
   T alpha,
   in_matrix_1_t A,
-  inout_matrix_t C,
+  InOutMat C,
   Triangle t);
 
 // [linalg.alg.blas3.rank-k.herk],
 // rank-k Hermitian matrix update
 template<class T,
          class in_matrix_1_t,
-         class inout_matrix_t,
+         inout_matrix InOutMat,
          class Triangle>
 void hermitian_matrix_rank_k_update(
   T alpha,
   in_matrix_1_t A,
-  inout_matrix_t C,
+  InOutMat C,
   Triangle t);
 template<class ExecutionPolicy,
          class T,
          class in_matrix_1_t,
-         class inout_matrix_t,
+         inout_matrix InOutMat,
          class Triangle>
 void hermitian_matrix_rank_k_update(
   ExecutionPolicy&& exec,
   T alpha,
   in_matrix_1_t A,
-  inout_matrix_t C,
+  InOutMat C,
   Triangle t);
 
 // [linalg.alg.blas3.rank2k.syr2k],
 // rank-2k symmetric matrix update
 template<class in_matrix_1_t,
          class in_matrix_2_t,
-         class inout_matrix_t,
+         inout_matrix InOutMat,
          class Triangle>
 void symmetric_matrix_rank_2k_update(
   in_matrix_1_t A,
   in_matrix_2_t B,
-  inout_matrix_t C,
+  InOutMat C,
   Triangle t);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class in_matrix_2_t,
-         class inout_matrix_t,
+         inout_matrix InOutMat,
          class Triangle>
 void symmetric_matrix_rank_2k_update(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   in_matrix_2_t B,
-  inout_matrix_t C,
+  InOutMat C,
   Triangle t);
 
 // [linalg.alg.blas3.rank2k.her2k],
 // rank-2k Hermitian matrix update
 template<class in_matrix_1_t,
          class in_matrix_2_t,
-         class inout_matrix_t,
+         inout_matrix InOutMat,
          class Triangle>
 void hermitian_matrix_rank_2k_update(
   in_matrix_1_t A,
   in_matrix_2_t B,
-  inout_matrix_t C,
+  InOutMat C,
   Triangle t);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class in_matrix_2_t,
-         class inout_matrix_t,
+         inout_matrix InOutMat,
          class Triangle>
 void hermitian_matrix_rank_2k_update(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   in_matrix_2_t B,
-  inout_matrix_t C,
+  InOutMat C,
   Triangle t);
 
 // [linalg.alg.blas3.trsm],
@@ -4768,26 +4819,26 @@ void triangular_matrix_matrix_left_solve(
 template<class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
-         class inout_matrix_t,
+         inout_matrix InOutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_left_solve(
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
-  inout_matrix_t B,
+  InOutMat B,
   BinaryDivideOp divide);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
-         class inout_matrix_t,
+         inout_matrix InOutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_left_solve(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
-  inout_matrix_t B,
+  InOutMat B,
   BinaryDivideOp divide);
 
 template<class in_matrix_1_t,
@@ -4817,23 +4868,23 @@ void triangular_matrix_matrix_left_solve(
 template<class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
-         class inout_matrix_t>
+         inout_matrix InOutMat>
 void triangular_matrix_matrix_left_solve(
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
-  inout_matrix_t B);
+  InOutMat B);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
-         class inout_matrix_t>
+         inout_matrix InOutMat>
 void triangular_matrix_matrix_left_solve(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
-  inout_matrix_t B);
+  InOutMat B);
 
 // [linalg.alg.blas3.trsm.right],
 // solve multiple triangular linear systems
@@ -4869,26 +4920,26 @@ void triangular_matrix_matrix_right_solve(
 template<class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
-         class inout_matrix_t,
+         inout_matrix InOutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_right_solve(
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
-  inout_matrix_t B,
+  InOutMat B,
   BinaryDivideOp divide);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
-         class inout_matrix_t,
+         inout_matrix InOutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_right_solve(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
-  inout_matrix_t B,
+  InOutMat B,
   BinaryDivideOp divide);
 
 template<class in_matrix_1_t,
@@ -4918,23 +4969,23 @@ void triangular_matrix_matrix_right_solve(
 template<class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
-         class inout_matrix_t>
+         inout_matrix InOutMat>
 void triangular_matrix_matrix_right_solve(
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
-  inout_matrix_t B);
+  InOutMat B);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
-         class inout_matrix_t>
+         inout_matrix InOutMat>
 void triangular_matrix_matrix_right_solve(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
-  inout_matrix_t B);
+  InOutMat B);
 }
 ```
 
@@ -6601,6 +6652,90 @@ void test_conjugate_transposed(
 ```
 --*end example*]
 
+## Exposition-only concepts [linalg.concepts]
+
+The exposition-only concepts defined in this section
+constrain the algorithms in *[linalg.algs]*.
+
+```c++
+template<class T>
+struct @_is-mdspan_@ : false_type {}; // exposition only
+
+template<class ElementType, class Extents, class Layout, class Accessor>
+struct @_is-mdspan_@<mdspan<ElementType, Extents, Layout, Accessor>> : true_type {}; // exposition only
+
+template<class T>
+concept @_in-vector_@ = // exposition only
+  @_is-mdspan_@<T>::value &&
+  T::rank() == 1;
+
+template<class T>
+concept @_out-vector_@ = // exposition only
+  @_is-mdspan_@<T>::value &&
+  T::rank() == 1 &&
+  is_same_v<remove_const_t<typename T::element_type>, typename T::element_type> &&
+  T::is_always_unique();
+
+template<class T>
+concept @_inout-vector_@ = // exposition only
+  @_is-mdspan_@<T>::value &&
+  T::rank() == 1 &&
+  is_same_v<remove_const_t<typename T::element_type>, typename T::element_type> &&
+  T::is_always_unique();
+
+template<class T>
+concept @_in-matrix_@ = // exposition only
+  @_is-mdspan_@<T>::value &&
+  T::rank() == 2;
+
+template<class T>
+concept @_out-matrix_@ = // exposition only
+  @_is-mdspan_@<T>::value &&
+  T::rank() == 2 &&
+  is_same_v<remove_const_t<typename T::element_type>, typename T::element_type> &&
+  T::is_always_unique();
+
+template<class T>
+concept @_inout-matrix_@ = // exposition only
+  @_is-mdspan_@<T>::value &&
+  T::rank() == 2 &&
+  is_same_v<remove_const_t<typename T::element_type>, typename T::element_type> &&
+  T::is_always_unique();
+
+template<class T>
+concept @_in-object_@ = // exposition only
+  @_is-mdspan_@<T>::value &&
+  (T::rank() == 1 || T::rank() == 2);
+
+template<class T>
+concept @_out-object_@ = // exposition only
+  @_is-mdspan_@<T>::value &&
+  (T::rank() == 1 || T::rank() == 2) &&
+  is_same_v<remove_const_t<typename T::element_type>, typename T::element_type> &&
+  T::is_always_unique();
+
+template<class T>
+concept @_inout-object_@ = // exposition only
+  @_is-mdspan_@<T>::value &&
+  (T::rank() == 1 || T::rank() == 2) &&
+  is_same_v<remove_const_t<typename T::element_type>, typename T::element_type> &&
+  T::is_always_unique();
+```
+
+If an algorithm in *[linalg.algs]* accesses the elements
+of an _`in-vector`_, `in-matrix`, or `in-object`,
+it will do so in read-only fashion.
+
+*[Note:* The `element_type` of an
+_`in-vector`_, _`in-matrix`_, or _`in-object`_ need not be `const`,
+because an mdspan accessor with a nonconst `element_type`
+need not necessarily be convertible to an accessor
+with a const `element_type`. --*end note]*
+
+If an algorithm in *[linalg.algs]* accesses the elements
+of an _`out-vector`_, `out-matrix`, or `out-object`,
+it will do so in write-only fashion.
+
 ## Algorithms [linalg.algs]
 
 ### Requirements based on template parameter name [linalg.algs.reqs]
@@ -6616,76 +6751,6 @@ or other things as appropriate.
 
 * `Real` is any type such that `complex<Real>` is specified.
     *[Note:* See **[complex.numbers.general]**. --*end note]*
-
-
-```c++
-template<class T>
-struct @_is-mdspan_@ : false_type {};
-
-template<class ElementType, class Extents, class Layout, class Accessor>
-struct @_is-mdspan_@<mdspan<ElementType, Extents, Layout, Accessor>> : true_type {};
-
-template<class T>
-concept @_in-vector_@ = // exposition only
-  @_is-mdspan_@<T>::value &&
-  T::rank() == 1;
-```
-
-* `in_vector*_t` is a rank-1 `mdspan` with a
-    potentially `const` element type and a unique layout.
-    If the algorithm accesses the object, it will do so in read-only fashion.  (TODO MOVE THIS LAST SENTENCE TO A COMMON PLACE)
-
-```c++
-template<class T>
-concept @_inout-vector_@ = // exposition only
-  @_is-mdspan_@<T>::value &&
-  T::rank() == 1 &&
-  is_same_v<remove_const_t<typename T::element_type>, typename T::element_type> &&
-  T::is_always_unique();
-```
-
-```c++
-template<class T>
-concept @_inout-vector_@ = // exposition only
-  @_is-mdspan_@<T>::value &&
-  T::rank() == 1 &&
-  is_same_v<remove_const_t<typename T::element_type>, typename T::element_type> &&
-  T::is_always_unique();
-```
-
-* `out_vector*_t` is a rank-1 `mdspan`
-    with a non-`const` element type,
-    and whose layout is always unique
-    (`layout_type::is_always_unique()` equals `true`).
-    If the algorithm accesses the object, it will do so in write-only fashion.
-
-* `in_matrix*_t` is a rank-2 `mdspan` with a
-    `const` element type.
-    If the algorithm accesses the object, it will do so in read-only fashion.
-
-* `inout_matrix*_t` is a rank-2 `mdspan`
-    with a non-`const` element type.
-
-* `out_matrix*_t` is a rank-2 `mdspan` with
-    a non-`const` element type.
-    If the algorithm accesses the object, it will do so in write-only fashion.
-
-* `in_object*_t` is a rank-1 or rank-2
-    `mdspan` with a potentially `const` element type,
-    and whose layout is always unique
-    (`layout_type::is_always_unique()` equals `true`).
-    If the algorithm accesses the object,
-    it will do so in read-only fashion.
-
-* `inout_object*_t` is a rank-1 or rank-2
-    `mdspan` with a non-`const` element type,
-    and whose layout is always unique
-    (`layout_type::is_always_unique()` equals `true`).
-
-* `out_object*_t` is a rank-1 or rank-2
-    `mdspan` with a non-`const` element type,
-    and whose layout is always unique
-    (`layout_type::is_always_unique()` equals `true`).
 
 * `Triangle` is either `upper_triangle_t` or `lower_triangle_t`.
 
@@ -6778,43 +6843,43 @@ because the output argument `c` (cosine) is a signed magnitude.
 ##### Apply a computed Givens rotation to vectors [linalg.algs.blas1.givens.rot]
 
 ```c++
-template<class inout_vector_1_t,
-         class inout_vector_2_t,
+template<inout_vector InOutVec1,
+         inout_vector InOutVec2,
          class Real>
 void givens_rotation_apply(
-  inout_vector_1_t x,
-  inout_vector_2_t y,
+  InOutVec1 x,
+  InOutVec2 y,
   const Real c,
   const Real s);
 
 template<class ExecutionPolicy,
-         class inout_vector_1_t,
-         class inout_vector_2_t,
+         inout_vector InOutVec1,
+         inout_vector InOutVec2,
          class Real>
 void givens_rotation_apply(
   ExecutionPolicy&& exec,
-  inout_vector_1_t x,
-  inout_vector_2_t y,
+  InOutVec1 x,
+  InOutVec2 y,
   const Real c,
   const Real s);
 
-template<class inout_vector_1_t,
-         class inout_vector_2_t,
+template<inout_vector InOutVec1,
+         inout_vector InOutVec2,
          class Real>
 void givens_rotation_apply(
-  inout_vector_1_t x,
-  inout_vector_2_t y,
+  InOutVec1 x,
+  InOutVec2 y,
   const Real c,
   const complex<Real> s);
 
 template<class ExecutionPolicy,
-         class inout_vector_1_t,
-         class inout_vector_2_t,
+         inout_vector InOutVec1,
+         inout_vector InOutVec2,
          class Real>
 void givens_rotation_apply(
   ExecutionPolicy&& exec,
-  inout_vector_1_t x,
-  inout_vector_2_t y,
+  InOutVec1 x,
+  InOutVec2 y,
   const Real c,
   const complex<Real> s);
 ```
@@ -6845,17 +6910,17 @@ the mathematical expressions for the algorithm are
 #### Swap matrix or vector elements [linalg.algs.blas1.swap]
 
 ```c++
-template<class inout_object_1_t,
-         class inout_object_2_t>
-void swap_elements(inout_object_1_t x,
-                   inout_object_2_t y);
+template<inout_object InOutObj1,
+         inout_object InOutObj2>
+void swap_elements(InOutObj1 x,
+                   InOutObj2 y);
 
 template<class ExecutionPolicy,
-         class inout_object_1_t,
-         class inout_object_2_t>
+         inout_object InOutObj1,
+         inout_object InOutObj2>
 void swap_elements(ExecutionPolicy&& exec,
-                   inout_object_1_t x,
-                   inout_object_2_t y);
+                   InOutObj1 x,
+                   InOutObj2 y);
 ```
 
 *[Note:* These functions correspond to the BLAS function `xSWAP`.
@@ -6885,16 +6950,16 @@ void swap_elements(ExecutionPolicy&& exec,
 
 ```c++
 template<class Scalar,
-         class inout_object_t>
+         inout_object InOutObj>
 void scale(const Scalar alpha,
-           inout_object_t obj);
+           InOutObj obj);
 
 template<class ExecutionPolicy,
          class Scalar,
-         class inout_object_t>
+         inout_object InOutObj>
 void scale(ExecutionPolicy&& exec,
            const Scalar alpha,
-           inout_object_t obj);
+           InOutObj obj);
 ```
 
 *[Note:* These functions correspond to the BLAS function `xSCAL`.
@@ -6911,17 +6976,17 @@ the mathematical expression for the algorithm is `obj[i...] = alpha * obj[i...]`
 #### Copy elements of one matrix or vector into another [linalg.algs.blas1.copy]
 
 ```c++
-template<class in_object_t,
-         class out_object_t>
-void copy(in_object_t x,
-          out_object_t y);
+template<in_object InObj,
+         out_object OutObj>
+void copy(InObj x,
+          OutObj y);
 
 template<class ExecutionPolicy,
-         class in_object_t,
-         class out_object_t>
+         in_object InObj,
+         out_object OutObj>
 void copy(ExecutionPolicy&& exec,
-          in_object_t x,
-          out_object_t y);
+          InObj x,
+          OutObj y);
 ```
 
 *[Note:* These functions correspond to the BLAS function `xCOPY`.
@@ -6948,21 +7013,21 @@ void copy(ExecutionPolicy&& exec,
 #### Add vectors or matrices elementwise [linalg.algs.blas1.add]
 
 ```c++
-template<class in_object_1_t,
-         class in_object_2_t,
-         class out_object_t>
-void add(in_object_1_t x,
-         in_object_2_t y,
-         out_object_t z);
+template<in_object InObj1,
+         in_object InObj2,
+         out_object OutObj>
+void add(InObj1 x,
+         InObj2 y,
+         OutObj z);
 
 template<class ExecutionPolicy,
-         class in_object_1_t,
-         class in_object_2_t,
-         class out_object_t>
+         in_object InObj1,
+         in_object InObj2,
+         out_object OutObj>
 void add(ExecutionPolicy&& exec,
-         in_object_1_t x,
-         in_object_2_t y,
-         out_object_t z);
+         InObj1 x,
+         InObj2 y,
+         OutObj z);
 ```
 
 *[Note:* These functions correspond to the BLAS function `xAXPY`.
@@ -7006,19 +7071,19 @@ element types).  --*end note]*
 Nonconjugated dot product with specified result type
 
 ```c++
-template<class in_vector_1_t,
-         class in_vector_2_t,
+template<in_vector InVec1,
+         in_vector InVec2,
          class T>
-T dot(in_vector_1_t v1,
-      in_vector_2_t v2,
+T dot(InVec1 v1,
+      InVec2 v2,
       T init);
 template<class ExecutionPolicy,
-         class in_vector_1_t,
-         class in_vector_2_t,
+         in_vector InVec1,
+         in_vector InVec2,
          class T>
 T dot(ExecutionPolicy&& exec,
-      in_vector_1_t v1,
-      in_vector_2_t v2,
+      InVec1 v1,
+      InVec2 v2,
       T init);
 ```
 
@@ -7037,9 +7102,9 @@ for all `i` in the domain of `v1`.
     If `N` is zero, returns `init`, else returns
     *GENERALIZED_SUM*(`plus<>()`, `init`, `v1[0]*v2[0]`, ..., `v1[N-1]*v2[N-1]`).
 
-* *Remarks:* If `in_vector_t::element_type` and `T` are both
+* *Remarks:* If `InVec1::value_type`, `InVec2::value_type`, and `T` are all
     floating-point types or complex versions thereof, and if `T` has
-    higher precision than `in_vector_type::element_type`, then
+    higher precision than `InVec1::value_type` or `InVec2::value_type`, then
     intermediate terms in the sum use `T`'s precision or greater.
 
 *[Note:* Like `reduce`, `dot` applies binary `operator+` in an
@@ -7056,16 +7121,16 @@ below. --*end note]*
 Nonconjugated dot product with default result type
 
 ```c++
-template<class in_vector_1_t,
-         class in_vector_2_t>
-auto dot(in_vector_1_t v1,
-         in_vector_2_t v2) -> /* see-below */;
+template<in_vector InVec1,
+         in_vector InVec2>
+auto dot(InVec1 v1,
+         InVec2 v2) -> /* see-below */;
 template<class ExecutionPolicy,
-         class in_vector_1_t,
-         class in_vector_2_t>
+         in_vector InVec1,
+         in_vector InVec2>
 auto dot(ExecutionPolicy&& exec,
-         in_vector_1_t v1,
-         in_vector_2_t v2) -> /* see-below */;
+         InVec1 v1,
+         InVec2 v2) -> /* see-below */;
 ```
 
 * *Effects:* Let `T` be `decltype(v1[0]*v2[0])`.  Then, the
@@ -7087,19 +7152,19 @@ for both real and complex element types.
 Conjugated dot product with specified result type
 
 ```c++
-template<class in_vector_1_t,
-         class in_vector_2_t,
+template<in_vector InVec1,
+         in_vector InVec2,
          class T>
-T dotc(in_vector_1_t v1,
-       in_vector_2_t v2,
+T dotc(InVec1 v1,
+       InVec2 v2,
        T init);
 template<class ExecutionPolicy,
-         class in_vector_1_t,
-         class in_vector_2_t,
+         in_vector InVec1,
+         in_vector InVec2,
          class T>
 T dotc(ExecutionPolicy&& exec,
-       in_vector_1_t v1,
-       in_vector_2_t v2,
+       InVec1 v1,
+       InVec2 v2,
        T init);
 ```
 
@@ -7111,16 +7176,16 @@ T dotc(ExecutionPolicy&& exec,
 Conjugated dot product with default result type
 
 ```c++
-template<class in_vector_1_t,
-         class in_vector_2_t>
-auto dotc(in_vector_1_t v1,
-          in_vector_2_t v2) -> /* see-below */;
+template<in_vector InVec1,
+         in_vector InVec2>
+auto dotc(InVec1 v1,
+          InVec2 v2) -> /* see-below */;
 template<class ExecutionPolicy,
-         class in_vector_1_t,
-         class in_vector_2_t>
+         in_vector InVec1,
+         in_vector InVec2>
 auto dotc(ExecutionPolicy&& exec,
-          in_vector_1_t v1,
-          in_vector_2_t v2) -> /* see-below */;
+          InVec1 v1,
+          InVec2 v2) -> /* see-below */;
 ```
 
 * *Effects:* Let `T` be `decltype(`_`conj-if-needed`_`(v1[0]) * v2[0])`.
@@ -7136,17 +7201,17 @@ struct sum_of_squares_result {
   T scaling_factor;
   T scaled_sum_of_squares;
 };
-template<class in_vector_t,
+template<in_vector InVec,
          class T>
 sum_of_squares_result<T> vector_sum_of_squares(
-  in_vector_t v,
+  InVec v,
   sum_of_squares_result<T> init);
 template<class ExecutionPolicy,
-         class in_vector_t,
+         in_vector InVec,
          class T>
 sum_of_squares_result<T> vector_sum_of_squares(
   ExecutionPolicy&& exec,
-  in_vector_t v,
+  InVec v,
   sum_of_squares_result<T> init);
 ```
 
@@ -7173,11 +7238,11 @@ sum_of_squares_result<T> vector_sum_of_squares(
         equals the sum of squares of `abs(x[i])` plus
         `init.scaling_factor * init.scaling_factor * init.scaled_sum_of_squares`.
 
-* *Remarks:* If `in_vector_t::element_type` is either a floating-point type
+* *Remarks:* If `InVec::value_type` is either a floating-point type
     or `complex<R>` for some floating-point type `R`,
     and if `T` is a floating-point type, then
 
-    * if `T` has higher precision than `in_vector_type::element_type`, then
+    * if `T` has higher precision than `InVec::value_type`, then
         intermediate terms in the sum use `T`'s precision or greater; and
     * any guarantees regarding overflow and underflow of `vector_sum_of_squares`
         are implementation-defined.
@@ -7187,15 +7252,15 @@ sum_of_squares_result<T> vector_sum_of_squares(
 ##### Euclidean norm with specified result type
 
 ```c++
-template<class in_vector_t,
+template<in_vector InVec,
          class T>
-T vector_norm2(in_vector_t v,
+T vector_norm2(InVec v,
                T init);
 template<class ExecutionPolicy,
-         class in_vector_t,
+         in_vector InVec,
          class T>
 T vector_norm2(ExecutionPolicy&& exec,
-               in_vector_t v,
+               InVec v,
                T init);
 ```
 
@@ -7212,7 +7277,7 @@ This does not imply a recommended implementation for floating-point types.
 See *Remarks* below.
 --*end note]*
 
-* *Preconditions:* `init + abs(declval<in_vector_t::value_type>())*abs(declval<in_vector_t::value_type>())`
+* *Preconditions:* `init + abs(declval<InVec::value_type>())*abs(declval<InVec::value_type>())`
     shall be convertible to `T`.
 
 * *Effects:* Returns the square root of the sum of squares
@@ -7226,10 +7291,10 @@ See *Remarks* below.
     See *Remarks* below.
     --*end note]*
 
-* *Remarks:* If `in_vector_t::element_type` is a floating-point type
+* *Remarks:* If `InVec::value_type` is a floating-point type
     or a complex version thereof, and if `T` is a floating-point type, then
 
-    * if `T` has higher precision than `in_vector_type::element_type`, then
+    * if `T` has higher precision than `InVec::value_type`, then
         intermediate terms in the sum use `T`'s precision or greater; and
 
     * any guarantees regarding overflow and underflow of `vector_norm2`
@@ -7246,12 +7311,12 @@ from `vector_sum_of_squares(x, {.scaling_factor=1.0, .scaled_sum_of_squares=init
 ##### Euclidean norm with default result type
 
 ```c++
-template<class in_vector_t>
-auto vector_norm2(in_vector_t v) -> /* see-below */;
+template<in_vector InVec>
+auto vector_norm2(InVec v) -> /* see-below */;
 template<class ExecutionPolicy,
-         class in_vector_t>
+         in_vector InVec>
 auto vector_norm2(ExecutionPolicy&& exec,
-                  in_vector_t v) -> /* see-below */;
+                  InVec v) -> /* see-below */;
 ```
 
 * *Effects:* Let `T` be `decltype(abs(v[0]) * abs(v[0]))`.
@@ -7265,15 +7330,15 @@ auto vector_norm2(ExecutionPolicy&& exec,
 ##### Sum of absolute values with specified result type
 
 ```c++
-template<class in_vector_t,
+template<in_vector InVec,
          class T>
-T vector_abs_sum(in_vector_t v,
+T vector_abs_sum(InVec v,
                  T init);
 template<class ExecutionPolicy,
-         class in_vector_t,
+         in_vector InVec,
          class T>
 T vector_abs_sum(ExecutionPolicy&& exec,
-                 in_vector_t v,
+                 InVec v,
                  T init);
 ```
 
@@ -7295,7 +7360,7 @@ for all `i` in the domain of `v`.
 
     * If `N` is zero, returns `init`;
 
-    * else, if `in_vector_t::element_type` is `complex<R>` for some `R`,
+    * else, if `InVec::value_type` is `complex<R>` for some `R`,
         then returns *GENERALIZED_SUM*(`plus<>()`, `init`,
         `abs(real(v[0])) + abs(imag(v[0]))`, ...,
         `abs(real(v[N-1])) + abs(imag(v[N-1]))`).
@@ -7303,9 +7368,9 @@ for all `i` in the domain of `v`.
     * else, returns *GENERALIZED_SUM*(`plus<>()`, `init`,
         `abs(v[0])`, ..., `abs(v[N-1])`).
 
-* *Remarks:* If `in_vector_t::element_type` is a floating-point type
+* *Remarks:* If `InVec::value_type` is a floating-point type
     or a complex version thereof, if `T` is a floating-point type,
-    and if `T` has higher precision than `in_vector_type::element_type`,
+    and if `T` has higher precision than `InVec::value_type`,
     then intermediate terms in the sum use `T`'s precision or greater.
 
 *[Note:*
@@ -7315,12 +7380,12 @@ The `abs`, `real`, and `imag` functions are invoked via unqualified lookup.
 ##### Sum of absolute values with default result type
 
 ```c++
-template<class in_vector_t>
-auto vector_abs_sum(in_vector_t v) -> /* see-below */;
+template<in_vector InVec>
+auto vector_abs_sum(InVec v) -> /* see-below */;
 template<class ExecutionPolicy,
-         class in_vector_t>
+         in_vector InVec>
 auto vector_abs_sum(ExecutionPolicy&& exec,
-                    in_vector_t v) -> /* see-below */;
+                    InVec v) -> /* see-below */;
 ```
 
 * *Effects:* Let `T` be `decltype(abs(v[0]))`.  Then, the
@@ -7331,14 +7396,14 @@ auto vector_abs_sum(ExecutionPolicy&& exec,
 #### Index of maximum absolute value of vector elements [linalg.algs.blas1.iamax]
 
 ```c++
-template<class in_vector_t>
-typename in_vector_t::size_type idx_abs_max(in_vector_t v);
+template<in_vector InVec>
+typename InVec::size_type idx_abs_max(InVec v);
 
 template<class ExecutionPolicy,
-         class in_vector_t>
-typename in_vector_t::size_type	idx_abs_max(
+         in_vector InVec>
+typename InVec::size_type idx_abs_max(
   ExecutionPolicy&& exec,
-  in_vector_t v);
+  InVec v);
 ```
 
 *[Note:* These functions correspond to the BLAS function `IxAMAX`.
@@ -7351,7 +7416,7 @@ typename in_vector_t::size_type	idx_abs_max(
 * *Effects:* Returns the index (in the domain of `v`) of
     the first element of `v` having largest absolute value.  If `v` has
     zero elements, then returns
-    `numeric_limits<typename in_vector_t::size_type>::max()`.
+    `numeric_limits<typename InVec::size_type>::max()`.
 
 *[Note:*
 The `abs` function is invoked via unqualified lookup.
@@ -7583,20 +7648,20 @@ The following requirements apply to all functions in this section.
 ##### Overwriting matrix-vector product
 
 ```c++
-template<class in_vector_t,
+template<in_vector InVec,
          class in_matrix_t,
          class out_vector_t>
 void matrix_vector_product(in_matrix_t A,
-                           in_vector_t x,
+                           InVec x,
                            out_vector_t y);
 
 template<class ExecutionPolicy,
-         class in_vector_t,
+         in_vector InVec,
          class in_matrix_t,
          class out_vector_t>
 void matrix_vector_product(ExecutionPolicy&& exec,
                            in_matrix_t A,
-                           in_vector_t x,
+                           InVec x,
                            out_vector_t y);
 ```
 
@@ -7639,24 +7704,24 @@ void scaled_matvec_2(mdspan<double, extents<size_t, num_rows, num_cols>> A,
 ##### Updating matrix-vector product
 
 ```c++
-template<class in_vector_1_t,
+template<in_vector InVec1,
          class in_matrix_t,
-         class in_vector_2_t,
+         in_vector InVec2,
          class out_vector_t>
 void matrix_vector_product(in_matrix_t A,
-                           in_vector_1_t x,
-                           in_vector_2_t y,
+                           InVec1 x,
+                           InVec2 y,
                            out_vector_t z);
 
 template<class ExecutionPolicy,
-         class in_vector_1_t,
+         in_vector InVec1,
          class in_matrix_t,
-         class in_vector_2_t,
+         in_vector InVec2,
          class out_vector_t>
 void matrix_vector_product(ExecutionPolicy&& exec,
                            in_matrix_t A,
-                           in_vector_1_t x,
-                           in_vector_2_t y,
+                           InVec1 x,
+                           InVec2 y,
                            out_vector_t z);
 ```
 
@@ -7722,22 +7787,22 @@ The following requirements apply to all functions in this section.
 ```c++
 template<class in_matrix_t,
          class Triangle,
-         class in_vector_t,
+         in_vector InVec,
          class out_vector_t>
 void symmetric_matrix_vector_product(in_matrix_t A,
                                      Triangle t,
-                                     in_vector_t x,
+                                     InVec x,
                                      out_vector_t y);
 
 template<class ExecutionPolicy,
          class in_matrix_t,
          class Triangle,
-         class in_vector_t,
+         in_vector InVec,
          class out_vector_t>
 void symmetric_matrix_vector_product(ExecutionPolicy&& exec,
                                      in_matrix_t A,
                                      Triangle t,
-                                     in_vector_t x,
+                                     InVec x,
                                      out_vector_t y);
 ```
 
@@ -7748,28 +7813,28 @@ void symmetric_matrix_vector_product(ExecutionPolicy&& exec,
 ```c++
 template<class in_matrix_t,
          class Triangle,
-         class in_vector_1_t,
-         class in_vector_2_t,
+         in_vector InVec1,
+         in_vector InVec2,
          class out_vector_t>
 void symmetric_matrix_vector_product(
   in_matrix_t A,
   Triangle t,
-  in_vector_1_t x,
-  in_vector_2_t y,
+  InVec1 x,
+  InVec2 y,
   out_vector_t z);
 
 template<class ExecutionPolicy,
          class in_matrix_t,
          class Triangle,
-         class in_vector_1_t,
-         class in_vector_2_t,
+         in_vector InVec1,
+         in_vector InVec2,
          class out_vector_t>
 void symmetric_matrix_vector_product(
   ExecutionPolicy&& exec,
   in_matrix_t A,
   Triangle t,
-  in_vector_1_t x,
-  in_vector_2_t y,
+  InVec1 x,
+  InVec2 y,
   out_vector_t z);
 ```
 
@@ -7835,22 +7900,22 @@ The following requirements apply to all functions in this section.
 ```c++
 template<class in_matrix_t,
          class Triangle,
-         class in_vector_t,
+         in_vector InVec,
          class out_vector_t>
 void hermitian_matrix_vector_product(in_matrix_t A,
                                      Triangle t,
-                                     in_vector_t x,
+                                     InVec x,
                                      out_vector_t y);
 
 template<class ExecutionPolicy,
          class in_matrix_t,
          class Triangle,
-         class in_vector_t,
+         in_vector InVec,
          class out_vector_t>
 void hermitian_matrix_vector_product(ExecutionPolicy&& exec,
                                      in_matrix_t A,
                                      Triangle t,
-                                     in_vector_t x,
+                                     InVec x,
                                      out_vector_t y);
 ```
 
@@ -7861,26 +7926,26 @@ void hermitian_matrix_vector_product(ExecutionPolicy&& exec,
 ```c++
 template<class in_matrix_t,
          class Triangle,
-         class in_vector_1_t,
-         class in_vector_2_t,
+         in_vector InVec1,
+         in_vector InVec2,
          class out_vector_t>
 void hermitian_matrix_vector_product(in_matrix_t A,
                                      Triangle t,
-                                     in_vector_1_t x,
-                                     in_vector_2_t y,
+                                     InVec1 x,
+                                     InVec2 y,
                                      out_vector_t z);
 
 template<class ExecutionPolicy,
          class in_matrix_t,
          class Triangle,
-         class in_vector_1_t,
-         class in_vector_2_t,
+         in_vector InVec1,
+         in_vector InVec2,
          class out_vector_t>
 void hermitian_matrix_vector_product(ExecutionPolicy&& exec,
                                      in_matrix_t A,
                                      Triangle t,
-                                     in_vector_1_t x,
-                                     in_vector_2_t y,
+                                     InVec1 x,
+                                     InVec2 y,
                                      out_vector_t z);
 ```
 
@@ -7958,26 +8023,26 @@ The following requirements apply to all functions in this section.
 template<class in_matrix_t,
          class Triangle,
          class DiagonalStorage,
-         class in_vector_t,
+         in_vector InVec,
          class out_vector_t>
 void triangular_matrix_vector_product(
   in_matrix_t A,
   Triangle t,
   DiagonalStorage d,
-  in_vector_t x,
+  InVec x,
   out_vector_t y);
 template<class ExecutionPolicy,
          class in_matrix_t,
          class Triangle,
          class DiagonalStorage,
-         class in_vector_t,
+         in_vector InVec,
          class out_vector_t>
 void triangular_matrix_vector_product(
   ExecutionPolicy&& exec,
   in_matrix_t A,
   Triangle t,
   DiagonalStorage d,
-  in_vector_t x,
+  InVec x,
   out_vector_t y);
 ```
 
@@ -7989,23 +8054,23 @@ void triangular_matrix_vector_product(
 template<class in_matrix_t,
          class Triangle,
          class DiagonalStorage,
-         class inout_vector_t>
+         inout_vector InOutVec>
 void triangular_matrix_vector_product(
   in_matrix_t A,
   Triangle t,
   DiagonalStorage d,
-  inout_vector_t y);
+  InOutVec y);
 template<class ExecutionPolicy,
          class in_matrix_t,
          class Triangle,
          class DiagonalStorage,
-         class inout_vector_t>
+         inout_vector InOutVec>
 void triangular_matrix_vector_product(
   ExecutionPolicy&& exec,
   in_matrix_t A,
   Triangle t,
   DiagonalStorage d,
-  inout_vector_t y);
+  InOutVec y);
 ```
 
 *[Note:*
@@ -8031,29 +8096,29 @@ This is why the `ExecutionPolicy` overload exists.
 template<class in_matrix_t,
          class Triangle,
          class DiagonalStorage,
-         class in_vector_1_t,
-         class in_vector_2_t,
+         in_vector InVec1,
+         in_vector InVec2,
          class out_vector_t>
 void triangular_matrix_vector_product(in_matrix_t A,
                                       Triangle t,
                                       DiagonalStorage d,
-                                      in_vector_1_t x,
-                                      in_vector_2_t y,
+                                      InVec1 x,
+                                      InVec2 y,
                                       out_vector_t z);
 
 template<class ExecutionPolicy,
          class in_matrix_t,
          class Triangle,
          class DiagonalStorage,
-         class in_vector_1_t,
-         class in_vector_2_t,
+         in_vector InVec1,
+         in_vector InVec2,
          class out_vector_t>
 void triangular_matrix_vector_product(ExecutionPolicy&& exec,
                                       in_matrix_t A,
                                       Triangle t,
                                       DiagonalStorage d,
-                                      in_vector_1_t x,
-                                      in_vector_2_t y,
+                                      InVec1 x,
+                                      InVec2 y,
                                       out_vector_t z);
 ```
 
@@ -8115,21 +8180,21 @@ The following requirements apply to all functions in this section.
 template<class in_matrix_t,
          class Triangle,
          class DiagonalStorage,
-         class in_vector_t,
+         in_vector InVec,
          class out_vector_t,
          class BinaryDivideOp>
 void triangular_matrix_vector_solve(
   in_matrix_t A,
   Triangle t,
   DiagonalStorage d,
-  in_vector_t b,
+  InVec b,
   out_vector_t x,
   BinaryDivideOp divide);
 template<class ExecutionPolicy,
          class in_matrix_t,
          class Triangle,
          class DiagonalStorage,
-         class in_vector_t,
+         in_vector InVec,
          class out_vector_t,
          class BinaryDivideOp>
 void triangular_matrix_vector_solve(
@@ -8137,7 +8202,7 @@ void triangular_matrix_vector_solve(
   in_matrix_t A,
   Triangle t,
   DiagonalStorage d,
-  in_vector_t b,
+  InVec b,
   out_vector_t x,
   BinaryDivideOp divide);
 ```
@@ -8155,13 +8220,13 @@ void triangular_matrix_vector_solve(
 template<class in_matrix_t,
          class Triangle,
          class DiagonalStorage,
-         class in_vector_t,
+         in_vector InVec,
          class out_vector_t>
 void triangular_matrix_vector_solve(
   in_matrix_t A,
   Triangle t,
   DiagonalStorage d,
-  in_vector_t b,
+  InVec b,
   out_vector_t x);
 ```
 
@@ -8172,14 +8237,14 @@ template<class ExecutionPolicy,
          class in_matrix_t,
          class Triangle,
          class DiagonalStorage,
-         class in_vector_t,
+         in_vector InVec,
          class out_vector_t>
 void triangular_matrix_vector_solve(
   ExecutionPolicy&& exec,
   in_matrix_t A,
   Triangle t,
   DiagonalStorage d,
-  in_vector_t b,
+  InVec b,
   out_vector_t x);
 ```
 
@@ -8191,26 +8256,26 @@ void triangular_matrix_vector_solve(
 template<class in_matrix_t,
          class Triangle,
          class DiagonalStorage,
-         class inout_vector_t,
+         inout_vector InOutVec,
          class BinaryDivideOp>
 void triangular_matrix_vector_solve(
   in_matrix_t A,
   Triangle t,
   DiagonalStorage d,
-  inout_vector_t b,
+  InOutVec b,
   BinaryDivideOp divide);
 template<class ExecutionPolicy,
          class in_matrix_t,
          class Triangle,
          class DiagonalStorage,
-         class inout_vector_t,
+         inout_vector InOutVec,
          class BinaryDivideOp>
 void triangular_matrix_vector_solve(
   ExecutionPolicy&& exec,
   in_matrix_t A,
   Triangle t,
   DiagonalStorage d,
-  inout_vector_t b,
+  InOutVec b,
   BinaryDivideOp divide);
 ```
 
@@ -8235,12 +8300,12 @@ This is why the `ExecutionPolicy` overload exists.
 template<class in_matrix_t,
          class Triangle,
          class DiagonalStorage,
-         class inout_vector_t>
+         inout_vector InOutVec>
 void triangular_matrix_vector_solve(
   in_matrix_t A,
   Triangle t,
   DiagonalStorage d,
-  inout_vector_t b);
+  InOutVec b);
 ```
 
 * *Effects:* Equivalent to `triangular_matrix_vector_solve(A, t, d, b, [](const auto& A_ii, const auto& b_i){ return A_ii / b_i; });`.
@@ -8250,13 +8315,13 @@ template<class ExecutionPolicy,
          class in_matrix_t,
          class Triangle,
          class DiagonalStorage,
-         class inout_vector_t>
+         inout_vector InOutVec>
 void triangular_matrix_vector_solve(
   ExecutionPolicy&& exec,
   in_matrix_t A,
   Triangle t,
   DiagonalStorage d,
-  inout_vector_t b);
+  InOutVec b);
 ```
 
 * *Effects:* Equivalent to `triangular_matrix_vector_solve(forward<ExecutionPolicy>(exec), A, t, d, b, [](const auto& A_ii, const auto& b_i){ return A_ii / b_i; });`.
@@ -8266,23 +8331,23 @@ void triangular_matrix_vector_solve(
 ##### Nonsymmetric nonconjugated rank-1 update [linalg.algs.blas2.rank1.geru]
 
 ```c++
-template<class in_vector_1_t,
-         class in_vector_2_t,
-         class inout_matrix_t>
+template<in_vector InVec1,
+         in_vector InVec2,
+         inout_matrix InOutMat>
 void matrix_rank_1_update(
-  in_vector_1_t x,
-  in_vector_2_t y,
-  inout_matrix_t A);
+  InVec1 x,
+  InVec2 y,
+  InOutMat A);
 
 template<class ExecutionPolicy,
-         class in_vector_1_t,
-         class in_vector_2_t,
-         class inout_matrix_t>
+         in_vector InVec1,
+         in_vector InVec2,
+         inout_matrix InOutMat>
 void matrix_rank_1_update(
   ExecutionPolicy&& exec,
-  in_vector_1_t x,
-  in_vector_2_t y,
-  inout_matrix_t A);
+  InVec1 x,
+  InVec2 y,
+  InOutMat A);
 ```
 
 *[Note:* This function corresponds to the BLAS functions `xGER` (for
@@ -8325,23 +8390,23 @@ as the result of `conjugated`.  Alternately, they can use the shortcut
 ##### Nonsymmetric conjugated rank-1 update [linalg.algs.blas2.rank1.gerc]
 
 ```c++
-template<class in_vector_1_t,
-         class in_vector_2_t,
-         class inout_matrix_t>
+template<in_vector InVec1,
+         in_vector InVec2,
+         inout_matrix InOutMat>
 void matrix_rank_1_update_c(
-  in_vector_1_t x,
-  in_vector_2_t y,
-  inout_matrix_t A);
+  InVec1 x,
+  InVec2 y,
+  InOutMat A);
 
 template<class ExecutionPolicy,
-         class in_vector_1_t,
-         class in_vector_2_t,
-         class inout_matrix_t>
+         in_vector InVec1,
+         in_vector InVec2,
+         inout_matrix InOutMat>
 void matrix_rank_1_update_c(
   ExecutionPolicy&& exec,
-  in_vector_1_t x,
-  in_vector_2_t y,
-  inout_matrix_t A);
+  InVec1 x,
+  InVec2 y,
+  InOutMat A);
 ```
 
 *[Note:* This function corresponds to the BLAS functions `xGER` (for
@@ -8353,41 +8418,41 @@ note]*
 ##### Rank-1 update of a Symmetric matrix [linalg.algs.blas2.rank1.syr]
 
 ```c++
-template<class in_vector_t,
-         class inout_matrix_t,
+template<in_vector InVec,
+         inout_matrix InOutMat,
          class Triangle>
 void symmetric_matrix_rank_1_update(
-  in_vector_t x,
-  inout_matrix_t A,
+  InVec x,
+  InOutMat A,
   Triangle t);
 template<class ExecutionPolicy,
-         class in_vector_t,
-         class inout_matrix_t,
+         in_vector InVec,
+         inout_matrix InOutMat,
          class Triangle>
 void symmetric_matrix_rank_1_update(
   ExecutionPolicy&& exec,
-  in_vector_t x,
-  inout_matrix_t A,
+  InVec x,
+  InOutMat A,
   Triangle t);
 template<class T,
-         class in_vector_t,
-         class inout_matrix_t,
+         in_vector InVec,
+         inout_matrix InOutMat,
          class Triangle>
 void symmetric_matrix_rank_1_update(
   T alpha,
-  in_vector_t x,
-  inout_matrix_t A,
+  InVec x,
+  InOutMat A,
   Triangle t);
 template<class ExecutionPolicy,
          class T,
-         class in_vector_t,
-         class inout_matrix_t,
+         in_vector InVec,
+         inout_matrix InOutMat,
          class Triangle>
 void symmetric_matrix_rank_1_update(
   ExecutionPolicy&& exec,
   T alpha,
-  in_vector_t x,
-  inout_matrix_t A,
+  InVec x,
+  InOutMat A,
   Triangle t);
 ```
 
@@ -8453,41 +8518,41 @@ the mathematical expression for the algorithm is
 ##### Rank-1 update of a Hermitian matrix [linalg.algs.blas2.rank1.her]
 
 ```c++
-template<class in_vector_t,
-         class inout_matrix_t,
+template<in_vector InVec,
+         inout_matrix InOutMat,
          class Triangle>
 void hermitian_matrix_rank_1_update(
-  in_vector_t x,
-  inout_matrix_t A,
+  InVec x,
+  InOutMat A,
   Triangle t);
 template<class ExecutionPolicy,
-         class in_vector_t,
-         class inout_matrix_t,
+         in_vector InVec,
+         inout_matrix InOutMat,
          class Triangle>
 void hermitian_matrix_rank_1_update(
   ExecutionPolicy&& exec,
-  in_vector_t x,
-  inout_matrix_t A,
+  InVec x,
+  InOutMat A,
   Triangle t);
 template<class T,
-         class in_vector_t,
-         class inout_matrix_t,
+         in_vector InVec,
+         inout_matrix InOutMat,
          class Triangle>
 void hermitian_matrix_rank_1_update(
   T alpha,
-  in_vector_t x,
-  inout_matrix_t A,
+  InVec x,
+  InOutMat A,
   Triangle t);
 template<class ExecutionPolicy,
          class T,
-         class in_vector_t,
-         class inout_matrix_t,
+         in_vector InVec,
+         inout_matrix InOutMat,
          class Triangle>
 void hermitian_matrix_rank_1_update(
   ExecutionPolicy&& exec,
   T alpha,
-  in_vector_t x,
-  inout_matrix_t A,
+  InVec x,
+  InOutMat A,
   Triangle t);
 ```
 
@@ -8558,26 +8623,26 @@ the mathematical expression for the algorithm is
 #### Rank-2 update of a symmetric matrix [linalg.algs.blas2.rank2.syr2]
 
 ```c++
-template<class in_vector_1_t,
-         class in_vector_2_t,
-         class inout_matrix_t,
+template<in_vector InVec1,
+         in_vector InVec2,
+         inout_matrix InOutMat,
          class Triangle>
 void symmetric_matrix_rank_2_update(
-  in_vector_1_t x,
-  in_vector_2_t y,
-  inout_matrix_t A,
+  InVec1 x,
+  InVec2 y,
+  InOutMat A,
   Triangle t);
 
 template<class ExecutionPolicy,
-         class in_vector_1_t,
-         class in_vector_2_t,
-         class inout_matrix_t,
+         in_vector InVec1,
+         in_vector InVec2,
+         inout_matrix InOutMat,
          class Triangle>
 void symmetric_matrix_rank_2_update(
   ExecutionPolicy&& exec,
-  in_vector_1_t x,
-  in_vector_2_t y,
-  inout_matrix_t A,
+  InVec1 x,
+  InVec2 y,
+  InOutMat A,
   Triangle t);
 ```
 
@@ -8635,26 +8700,26 @@ the mathematical expression for the algorithm is
 #### Rank-2 update of a Hermitian matrix [linalg.algs.blas2.rank2.her2]
 
 ```c++
-template<class in_vector_1_t,
-         class in_vector_2_t,
-         class inout_matrix_t,
+template<in_vector InVec1,
+         in_vector InVec2,
+         inout_matrix InOutMat,
          class Triangle>
 void hermitian_matrix_rank_2_update(
-  in_vector_1_t x,
-  in_vector_2_t y,
-  inout_matrix_t A,
+  InVec1 x,
+  InVec2 y,
+  InOutMat A,
   Triangle t);
 
 template<class ExecutionPolicy,
-         class in_vector_1_t,
-         class in_vector_2_t,
-         class inout_matrix_t,
+         in_vector InVec1,
+         in_vector InVec2,
+         inout_matrix InOutMat,
          class Triangle>
 void hermitian_matrix_rank_2_update(
   ExecutionPolicy&& exec,
-  in_vector_1_t x,
-  in_vector_2_t y,
-  inout_matrix_t A,
+  InVec1 x,
+  InVec2 y,
+  InOutMat A,
   Triangle t);
 ```
 
@@ -9405,8 +9470,8 @@ The following requirements apply to all functions in this section.
     * `in_matrix_1_t` either has unique layout,
         or `layout_blas_packed` layout.
 
-    * `in_matrix_2_t`, `in_matrix_3_t` (if applicable), `out_matrix_t`,
-        and `inout_matrix_t` (if applicable) have unique layout.
+    * `in_matrix_2_t` and `in_matrix_3_t` (if applicable)
+        have unique layout.
 
     * If `in_matrix_1_t` has `layout_blas_packed` layout, then the
         layout's `Triangle` template argument has the same type as
@@ -9542,23 +9607,23 @@ In-place overwriting triangular matrix-matrix left product
 template<class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
-         class inout_matrix_t>
+         inout_matrix InOutMat>
 void triangular_matrix_left_product(
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
-  inout_matrix_t C);
+  InOutMat C);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
-         class inout_matrix_t>
+         inout_matrix InOutMat>
 void triangular_matrix_left_product(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
-  inout_matrix_t C);
+  InOutMat C);
 ```
 
 For `i,j` in the domain of `C`,
@@ -9620,23 +9685,23 @@ In-place overwriting triangular matrix-matrix right product
 template<class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
-         class inout_matrix_t>
+         inout_matrix InOutMat>
 void triangular_matrix_right_product(
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
-  inout_matrix_t C);
+  InOutMat C);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
-         class inout_matrix_t>
+         inout_matrix InOutMat>
 void triangular_matrix_right_product(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
-  inout_matrix_t C);
+  InOutMat C);
 ```
 
 For `i,j` in the domain of `C`,
@@ -9753,23 +9818,23 @@ to the input matrix. --*end note]*
 ```c++
 template<class T,
          class in_matrix_1_t,
-         class inout_matrix_t,
+         inout_matrix InOutMat,
          class Triangle>
 void symmetric_matrix_rank_k_update(
   T alpha,
   in_matrix_1_t A,
-  inout_matrix_t C,
+  InOutMat C,
   Triangle t);
 template<class ExecutionPolicy,
          class T,
          class in_matrix_1_t,
-         class inout_matrix_t,
+         inout_matrix InOutMat,
          class Triangle>
 void symmetric_matrix_rank_k_update(
   ExecutionPolicy&& exec,
   T alpha,
   in_matrix_1_t A,
-  inout_matrix_t C,
+  InOutMat C,
   Triangle t);
 ```
 
@@ -9832,23 +9897,23 @@ for all `k` such that `i,k` is in the domain of `A`.
 ```c++
 template<class T,
          class in_matrix_1_t,
-         class inout_matrix_t,
+         inout_matrix InOutMat,
          class Triangle>
 void hermitian_matrix_rank_k_update(
   T alpha,
   in_matrix_1_t A,
-  inout_matrix_t C,
+  InOutMat C,
   Triangle t);
 template<class ExecutionPolicy,
          class T,
          class in_matrix_1_t,
-         class inout_matrix_t,
+         inout_matrix InOutMat,
          class Triangle>
 void hermitian_matrix_rank_k_update(
   ExecutionPolicy&& exec,
   T alpha,
   in_matrix_1_t A,
-  inout_matrix_t C,
+  InOutMat C,
   Triangle t);
 ```
 
@@ -9921,23 +9986,23 @@ to the input matrices. --*end note]*
 ```c++
 template<class in_matrix_1_t,
          class in_matrix_2_t,
-         class inout_matrix_t,
+         inout_matrix InOutMat,
          class Triangle>
 void symmetric_matrix_rank_2k_update(
   in_matrix_1_t A,
   in_matrix_2_t B,
-  inout_matrix_t C,
+  InOutMat C,
   Triangle t);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class in_matrix_2_t,
-         class inout_matrix_t,
+         inout_matrix InOutMat,
          class Triangle>
 void symmetric_matrix_rank_2k_update(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   in_matrix_2_t B,
-  inout_matrix_t C,
+  InOutMat C,
   Triangle t);
 ```
 
@@ -10000,24 +10065,24 @@ for all `k2` such that `i,k2` is in the domain of `B`.
 ```c++
 template<class in_matrix_1_t,
          class in_matrix_2_t,
-         class inout_matrix_t,
+         inout_matrix InOutMat,
          class Triangle>
 void hermitian_matrix_rank_2k_update(
   in_matrix_1_t A,
   in_matrix_2_t B,
-  inout_matrix_t C,
+  InOutMat C,
   Triangle t);
 
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class in_matrix_2_t,
-         class inout_matrix_t,
+         inout_matrix InOutMat,
          class Triangle>
 void hermitian_matrix_rank_2k_update(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   in_matrix_2_t B,
-  inout_matrix_t C,
+  InOutMat C,
   Triangle t);
 ```
 
@@ -10097,10 +10162,6 @@ The following requirements apply to all functions in this section.
     * `in_matrix_1_t` either has unique layout, or `layout_blas_packed` layout;
 
     * `in_matrix_2_t` has unique layout (if applicable);
-
-    * `out_matrix_t` has unique layout;
-
-    * `inout_matrix_t` has unique layout (if applicable);
 
     * if `r,j` is in the domain of `X` and `B`, then the expression
         `X[r,j] = B[r,j]` is well formed (if applicable); and
@@ -10239,48 +10300,48 @@ In-place left solve of multiple triangular systems
 template<class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
-         class inout_matrix_t,
+         inout_matrix InOutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_left_solve(
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
-  inout_matrix_t B,
+  InOutMat B,
   BinaryDivideOp divide);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
-         class inout_matrix_t,
+         inout_matrix InOutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_left_solve(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
-  inout_matrix_t B,
+  InOutMat B,
   BinaryDivideOp divide);
 
 template<class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
-         class inout_matrix_t>
+         inout_matrix InOutMat>
 void triangular_matrix_matrix_left_solve(
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
-  inout_matrix_t B);
+  InOutMat B);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
-         class inout_matrix_t>
+         inout_matrix InOutMat>
 void triangular_matrix_matrix_left_solve(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
-  inout_matrix_t B);
+  InOutMat B);
 ```
 
 *[Note:*
@@ -10459,48 +10520,48 @@ In-place right solve of multiple triangular systems
 template<class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
-         class inout_matrix_t,
+         inout_matrix InOutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_right_solve(
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
-  inout_matrix_t B,
+  InOutMat B,
   BinaryDivideOp divide);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
-         class inout_matrix_t,
+         inout_matrix InOutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_right_solve(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
-  inout_matrix_t B,
+  InOutMat B,
   BinaryDivideOp divide);  
 
 template<class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
-         class inout_matrix_t>
+         inout_matrix InOutMat>
 void triangular_matrix_matrix_right_solve(
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
-  inout_matrix_t B);
+  InOutMat B);
 template<class ExecutionPolicy,
          class in_matrix_1_t,
          class Triangle,
          class DiagonalStorage,
-         class inout_matrix_t>
+         inout_matrix InOutMat>
 void triangular_matrix_matrix_right_solve(
   ExecutionPolicy&& exec,
   in_matrix_1_t A,
   Triangle t,
   DiagonalStorage d,
-  inout_matrix_t B);
+  InOutMat B);
 ```
 
 *[Note:*
@@ -10586,13 +10647,13 @@ upper_triangular_t opposite_triangle(lower_triangular_t) {
 // Returns nullopt if no bad pivots,
 // else the index of the first bad pivot.
 // A "bad" pivot is zero or NaN.
-template<class inout_matrix_t,
+template<inout_matrix InOutMat,
          class Triangle>
-optional<typename inout_matrix_t::size_type>
-cholesky_factor(inout_matrix_t A, Triangle t)
+optional<typename InOutMat::size_type>
+cholesky_factor(InOutMat A, Triangle t)
 {
-  using value_type = typename inout_matrix_t::value_type;
-  using size_type = typename inout_matrix_t::size_type;
+  using value_type = typename InOutMat::value_type;
+  using size_type = typename InOutMat::size_type;
   constexpr value_type ZERO {};
   constexpr value_type ONE (1.0);
   const size_type n = A.extent(0);
@@ -10672,12 +10733,12 @@ example in-place in the matrix `A`.  The example assumes that
 ```c++
 template<class in_matrix_t,
          class Triangle,
-         class in_vector_t,
+         in_vector InVec,
          class out_vector_t>
 void cholesky_solve(
   in_matrix_t A,
   Triangle t,
-  in_vector_t b,
+  InVec b,
   out_vector_t x)
 {
   using std::linalg::transposed;
@@ -10713,21 +10774,21 @@ means that the matrix has many more rows than columns.
 
 ```c++
 // Compute QR factorization A = Q R, with A storing Q.
-template<class inout_matrix_t,
-         class out_matrix_t>
-optional<typename inout_matrix_t::size_type>
+template<inout_matrix InOutMat,
+         out_matrix OutMat>
+optional<typename InOutMat::size_type>
 cholesky_tsqr_one_step(
-  inout_matrix_t A, // A on input, Q on output
-  out_matrix_t R)
+  InOutMat A, // A on input, Q on output
+  OutMat R)
 {
-  using size_type = typename inout_matrix_t::size_type;
+  using size_type = typename InOutMat::size_type;
 
   // One might use cache size, sizeof(element_type), and A.extent(1)
   // to pick the number of rows per block.  For now, we just pick
   // some constant.
   constexpr size_type max_num_rows_per_block = 500;
 
-  using R_element_type = typename out_matrix_t::element_type;
+  using R_value_type = typename OutMat::value_type;
   constexpr R_element_type ZERO {};
   for(size_type j = 0; j < R.extent(1); ++j) {
     for(size_type i = 0; i < R.extent(0); ++i) {

--- a/D1673/P1673.md
+++ b/D1673/P1673.md
@@ -3555,8 +3555,8 @@ void givens_rotation_setup(const complex<Real>& a,
                            complex<Real>& r);
 
 // [linalg.algs.blas1.givens.rot], apply computed Givens rotation
-template<inout_vector InOutVec1,
-         inout_vector InOutVec2,
+template<@_inout-vector_@ InOutVec1,
+         @_inout-vector_@ InOutVec2,
          class Real>
 void givens_rotation_apply(
   InOutVec1 x,
@@ -3564,8 +3564,8 @@ void givens_rotation_apply(
   const Real c,
   const Real s);
 template<class ExecutionPolicy,
-         inout_vector InOutVec1,
-         inout_vector InOutVec2,
+         @_inout-vector_@ InOutVec1,
+         @_inout-vector_@ InOutVec2,
          class Real>
 void givens_rotation_apply(
   ExecutionPolicy&& exec,
@@ -3573,8 +3573,8 @@ void givens_rotation_apply(
   InOutVec2 y,
   const Real c,
   const Real s);
-template<inout_vector InOutVec1,
-         inout_vector InOutVec2,
+template<@_inout-vector_@ InOutVec1,
+         @_inout-vector_@ InOutVec2,
          class Real>
 void givens_rotation_apply(
   InOutVec1 x,
@@ -3582,8 +3582,8 @@ void givens_rotation_apply(
   const Real c,
   const complex<Real> s);
 template<class ExecutionPolicy,
-         inout_vector InOutVec1,
-         inout_vector InOutVec2,
+         @_inout-vector_@ InOutVec1,
+         @_inout-vector_@ InOutVec2,
          class Real>
 void givens_rotation_apply(
   ExecutionPolicy&& exec,
@@ -3593,25 +3593,25 @@ void givens_rotation_apply(
   const complex<Real> s);
 
 // [linalg.algs.blas1.swap], swap elements
-template<inout_object InOutObj1,
-         inout_object InOutObj2>
+template<@_inout-object_@ InOutObj1,
+         @_inout-object_@ InOutObj2>
 void swap_elements(InOutObj1 x,
                    InOutObj2 y);
 template<class ExecutionPolicy,
-         inout_object InOutObj1,
-         inout_object InOutObj2>
+         @_inout-object_@ InOutObj1,
+         @_inout-object_@ InOutObj2>
 void swap_elements(ExecutionPolicy&& exec,
                    InOutObj1 x,
                    InOutObj2 y);
 
 // [linalg.algs.blas1.scal], multiply elements by scalar
 template<class Scalar,
-         inout_object InOutObj>
+         @_inout-object_@ InOutObj>
 void scale(const Scalar alpha,
            InOutObj obj);
 template<class ExecutionPolicy,
          class Scalar,
-         inout_object InOutObj>
+         @_inout-object_@ InOutObj>
 void scale(ExecutionPolicy&& exec,
            const Scalar alpha,
            InOutObj obj);
@@ -3995,7 +3995,7 @@ void triangular_matrix_vector_product(
 template<in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
-         inout_vector InOutVec>
+         @_inout-vector_@ InOutVec>
 void triangular_matrix_vector_product(
   InMat A,
   Triangle t,
@@ -4005,7 +4005,7 @@ template<class ExecutionPolicy,
          in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
-         inout_vector InOutVec>
+         @_inout-vector_@ InOutVec>
 void triangular_matrix_vector_product(
   ExecutionPolicy&& exec,
   InMat A,
@@ -4105,7 +4105,7 @@ void triangular_matrix_vector_solve(
 template<in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
-         inout_vector InOutVec,
+         @_inout-vector_@ InOutVec,
          class BinaryDivideOp>
 void triangular_matrix_vector_solve(
   InMat A,
@@ -4117,7 +4117,7 @@ template<class ExecutionPolicy,
          in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
-         inout_vector InOutVec,
+         @_inout-vector_@ InOutVec,
          class BinaryDivideOp>
 void triangular_matrix_vector_solve(
   ExecutionPolicy&& exec,
@@ -4129,7 +4129,7 @@ void triangular_matrix_vector_solve(
 template<in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
-         inout_vector InOutVec>
+         @_inout-vector_@ InOutVec>
 void triangular_matrix_vector_solve(
   InMat A,
   Triangle t,
@@ -4139,7 +4139,7 @@ template<class ExecutionPolicy,
          in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
-         inout_vector InOutVec>
+         @_inout-vector_@ InOutVec>
 void triangular_matrix_vector_solve(
   ExecutionPolicy&& exec,
   InMat A,
@@ -4151,7 +4151,7 @@ void triangular_matrix_vector_solve(
 // nonconjugated rank-1 matrix update
 template<in_vector InVec1,
          in_vector InVec2,
-         inout_matrix InOutMat>
+         @_inout-matrix_@ InOutMat>
 void matrix_rank_1_update(
   InVec1 x,
   InVec2 y,
@@ -4159,7 +4159,7 @@ void matrix_rank_1_update(
 template<class ExecutionPolicy,
          in_vector InVec1,
          in_vector InVec2,
-         inout_matrix InOutMat>
+         @_inout-matrix_@ InOutMat>
 void matrix_rank_1_update(
   ExecutionPolicy&& exec,
   InVec1 x,
@@ -4170,7 +4170,7 @@ void matrix_rank_1_update(
 // conjugated rank-1 matrix update
 template<in_vector InVec1,
          in_vector InVec2,
-         inout_matrix InOutMat>
+         @_inout-matrix_@ InOutMat>
 void matrix_rank_1_update_c(
   InVec1 x,
   InVec2 y,
@@ -4178,7 +4178,7 @@ void matrix_rank_1_update_c(
 template<class ExecutionPolicy,
          in_vector InVec1,
          in_vector InVec2,
-         inout_matrix InOutMat>
+         @_inout-matrix_@ InOutMat>
 void matrix_rank_1_update_c(
   ExecutionPolicy&& exec,
   InVec1 x,
@@ -4188,7 +4188,7 @@ void matrix_rank_1_update_c(
 // [linalg.algs.blas2.rank1.syr],
 // symmetric rank-1 matrix update
 template<in_vector InVec,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_1_update(
   InVec x,
@@ -4196,7 +4196,7 @@ void symmetric_matrix_rank_1_update(
   Triangle t);
 template<class ExecutionPolicy,
          in_vector InVec,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_1_update(
   ExecutionPolicy&& exec,
@@ -4205,7 +4205,7 @@ void symmetric_matrix_rank_1_update(
   Triangle t);
 template<class T,
          in_vector InVec,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_1_update(
   T alpha,
@@ -4215,7 +4215,7 @@ void symmetric_matrix_rank_1_update(
 template<class ExecutionPolicy,
          class T,
          in_vector InVec,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_1_update(
   ExecutionPolicy&& exec,
@@ -4227,7 +4227,7 @@ void symmetric_matrix_rank_1_update(
 // [linalg.algs.blas2.rank1.her],
 // Hermitian rank-1 matrix update
 template<in_vector InVec,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_1_update(
   InVec x,
@@ -4235,7 +4235,7 @@ void hermitian_matrix_rank_1_update(
   Triangle t);
 template<class ExecutionPolicy,
          in_vector InVec,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_1_update(
   ExecutionPolicy&& exec,
@@ -4244,7 +4244,7 @@ void hermitian_matrix_rank_1_update(
   Triangle t);
 template<class T,
          in_vector InVec,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_1_update(
   T alpha,
@@ -4254,7 +4254,7 @@ void hermitian_matrix_rank_1_update(
 template<class ExecutionPolicy,
          class T,
          in_vector InVec,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_1_update(
   ExecutionPolicy&& exec,
@@ -4267,7 +4267,7 @@ void hermitian_matrix_rank_1_update(
 // symmetric rank-2 matrix update
 template<in_vector InVec1,
          in_vector InVec2,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_2_update(
   InVec1 x,
@@ -4277,7 +4277,7 @@ void symmetric_matrix_rank_2_update(
 template<class ExecutionPolicy,
          in_vector InVec1,
          in_vector InVec2,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_2_update(
   ExecutionPolicy&& exec,
@@ -4290,7 +4290,7 @@ void symmetric_matrix_rank_2_update(
 // Hermitian rank-2 matrix update
 template<in_vector InVec1,
          in_vector InVec2,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_2_update(
   InVec1 x,
@@ -4300,7 +4300,7 @@ void hermitian_matrix_rank_2_update(
 template<class ExecutionPolicy,
          in_vector InVec1,
          in_vector InVec2,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_2_update(
   ExecutionPolicy&& exec,
@@ -4582,7 +4582,7 @@ void triangular_matrix_left_product(
 template<in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         inout_matrix InOutMat>
+         @_inout-matrix_@ InOutMat>
 void triangular_matrix_left_product(
   InMat1 A,
   Triangle t,
@@ -4592,7 +4592,7 @@ template<class ExecutionPolicy,
          in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         inout_matrix InOutMat>
+         @_inout-matrix_@ InOutMat>
 void triangular_matrix_left_product(
   ExecutionPolicy&& exec,
   InMat1 A,
@@ -4629,7 +4629,7 @@ void triangular_matrix_right_product(
 template<in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         inout_matrix InOutMat>
+         @_inout-matrix_@ InOutMat>
 void triangular_matrix_right_product(
   InMat1 A,
   Triangle t,
@@ -4639,7 +4639,7 @@ template<class ExecutionPolicy,
          in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         inout_matrix InOutMat>
+         @_inout-matrix_@ InOutMat>
 void triangular_matrix_right_product(
   ExecutionPolicy&& exec,
   InMat1 A,
@@ -4713,7 +4713,7 @@ void triangular_matrix_right_product(
 // rank-k symmetric matrix update
 template<class T,
          in_matrix InMat1,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_k_update(
   T alpha,
@@ -4723,7 +4723,7 @@ void symmetric_matrix_rank_k_update(
 template<class T,
          class ExecutionPolicy,
          in_matrix InMat1,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_k_update(
   ExecutionPolicy&& exec,
@@ -4736,7 +4736,7 @@ void symmetric_matrix_rank_k_update(
 // rank-k Hermitian matrix update
 template<class T,
          in_matrix InMat1,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_k_update(
   T alpha,
@@ -4746,7 +4746,7 @@ void hermitian_matrix_rank_k_update(
 template<class ExecutionPolicy,
          class T,
          in_matrix InMat1,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_k_update(
   ExecutionPolicy&& exec,
@@ -4759,7 +4759,7 @@ void hermitian_matrix_rank_k_update(
 // rank-2k symmetric matrix update
 template<in_matrix InMat1,
          in_matrix InMat2,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_2k_update(
   InMat1 A,
@@ -4769,7 +4769,7 @@ void symmetric_matrix_rank_2k_update(
 template<class ExecutionPolicy,
          in_matrix InMat1,
          in_matrix InMat2,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_2k_update(
   ExecutionPolicy&& exec,
@@ -4782,7 +4782,7 @@ void symmetric_matrix_rank_2k_update(
 // rank-2k Hermitian matrix update
 template<in_matrix InMat1,
          in_matrix InMat2,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_2k_update(
   InMat1 A,
@@ -4792,7 +4792,7 @@ void hermitian_matrix_rank_2k_update(
 template<class ExecutionPolicy,
          in_matrix InMat1,
          in_matrix InMat2,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_2k_update(
   ExecutionPolicy&& exec,
@@ -4838,7 +4838,7 @@ void triangular_matrix_matrix_left_solve(
 template<in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_left_solve(
   InMat1 A,
@@ -4850,7 +4850,7 @@ template<class ExecutionPolicy,
          in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_left_solve(
   ExecutionPolicy&& exec,
@@ -4887,7 +4887,7 @@ void triangular_matrix_matrix_left_solve(
 template<in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         inout_matrix InOutMat>
+         @_inout-matrix_@ InOutMat>
 void triangular_matrix_matrix_left_solve(
   InMat1 A,
   Triangle t,
@@ -4897,7 +4897,7 @@ template<class ExecutionPolicy,
          in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         inout_matrix InOutMat>
+         @_inout-matrix_@ InOutMat>
 void triangular_matrix_matrix_left_solve(
   ExecutionPolicy&& exec,
   InMat1 A,
@@ -4939,7 +4939,7 @@ void triangular_matrix_matrix_right_solve(
 template<in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_right_solve(
   InMat1 A,
@@ -4951,7 +4951,7 @@ template<class ExecutionPolicy,
          in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_right_solve(
   ExecutionPolicy&& exec,
@@ -4988,7 +4988,7 @@ void triangular_matrix_matrix_right_solve(
 template<in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         inout_matrix InOutMat>
+         @_inout-matrix_@ InOutMat>
 void triangular_matrix_matrix_right_solve(
   InMat1 A,
   Triangle t,
@@ -4998,7 +4998,7 @@ template<class ExecutionPolicy,
          in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         inout_matrix InOutMat>
+         @_inout-matrix_@ InOutMat>
 void triangular_matrix_matrix_right_solve(
   ExecutionPolicy&& exec,
   InMat1 A,
@@ -6744,7 +6744,7 @@ concept @_inout-object_@ = // exposition only
 ```
 
 If an algorithm in *[linalg.algs]* accesses the elements
-of an _`in-vector`_, `in-matrix`, or `in-object`,
+of an _`in-vector`_, _`in-matrix`_, or _`in-object`_,
 it will do so in read-only fashion.
 
 *[Note:* The `element_type` of an
@@ -6754,7 +6754,7 @@ need not necessarily be convertible to an accessor
 with a const `element_type`. --*end note]*
 
 If an algorithm in *[linalg.algs]* accesses the elements
-of an _`out-vector`_, `out-matrix`, or `out-object`,
+of an _`out-vector`_, _`out-matrix`_, or _`out-object`_,
 it will do so in write-only fashion.
 
 ## Algorithms [linalg.algs]
@@ -6857,8 +6857,8 @@ because the output argument `c` (cosine) is a signed magnitude.
 ##### Apply a computed Givens rotation to vectors [linalg.algs.blas1.givens.rot]
 
 ```c++
-template<inout_vector InOutVec1,
-         inout_vector InOutVec2,
+template<@_inout-vector_@ InOutVec1,
+         @_inout-vector_@ InOutVec2,
          class Real>
 void givens_rotation_apply(
   InOutVec1 x,
@@ -6867,8 +6867,8 @@ void givens_rotation_apply(
   const Real s);
 
 template<class ExecutionPolicy,
-         inout_vector InOutVec1,
-         inout_vector InOutVec2,
+         @_inout-vector_@ InOutVec1,
+         @_inout-vector_@ InOutVec2,
          class Real>
 void givens_rotation_apply(
   ExecutionPolicy&& exec,
@@ -6877,8 +6877,8 @@ void givens_rotation_apply(
   const Real c,
   const Real s);
 
-template<inout_vector InOutVec1,
-         inout_vector InOutVec2,
+template<@_inout-vector_@ InOutVec1,
+         @_inout-vector_@ InOutVec2,
          class Real>
 void givens_rotation_apply(
   InOutVec1 x,
@@ -6887,8 +6887,8 @@ void givens_rotation_apply(
   const complex<Real> s);
 
 template<class ExecutionPolicy,
-         inout_vector InOutVec1,
-         inout_vector InOutVec2,
+         @_inout-vector_@ InOutVec1,
+         @_inout-vector_@ InOutVec2,
          class Real>
 void givens_rotation_apply(
   ExecutionPolicy&& exec,
@@ -6924,14 +6924,14 @@ the mathematical expressions for the algorithm are
 #### Swap matrix or vector elements [linalg.algs.blas1.swap]
 
 ```c++
-template<inout_object InOutObj1,
-         inout_object InOutObj2>
+template<@_inout-object_@ InOutObj1,
+         @_inout-object_@ InOutObj2>
 void swap_elements(InOutObj1 x,
                    InOutObj2 y);
 
 template<class ExecutionPolicy,
-         inout_object InOutObj1,
-         inout_object InOutObj2>
+         @_inout-object_@ InOutObj1,
+         @_inout-object_@ InOutObj2>
 void swap_elements(ExecutionPolicy&& exec,
                    InOutObj1 x,
                    InOutObj2 y);
@@ -6964,13 +6964,13 @@ void swap_elements(ExecutionPolicy&& exec,
 
 ```c++
 template<class Scalar,
-         inout_object InOutObj>
+         @_inout-object_@ InOutObj>
 void scale(const Scalar alpha,
            InOutObj obj);
 
 template<class ExecutionPolicy,
          class Scalar,
-         inout_object InOutObj>
+         @_inout-object_@ InOutObj>
 void scale(ExecutionPolicy&& exec,
            const Scalar alpha,
            InOutObj obj);
@@ -8061,7 +8061,7 @@ void triangular_matrix_vector_product(
 template<in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
-         inout_vector InOutVec>
+         @_inout-vector_@ InOutVec>
 void triangular_matrix_vector_product(
   InMat A,
   Triangle t,
@@ -8071,7 +8071,7 @@ template<class ExecutionPolicy,
          in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
-         inout_vector InOutVec>
+         @_inout-vector_@ InOutVec>
 void triangular_matrix_vector_product(
   ExecutionPolicy&& exec,
   InMat A,
@@ -8263,7 +8263,7 @@ void triangular_matrix_vector_solve(
 template<in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
-         inout_vector InOutVec,
+         @_inout-vector_@ InOutVec,
          class BinaryDivideOp>
 void triangular_matrix_vector_solve(
   InMat A,
@@ -8275,7 +8275,7 @@ template<class ExecutionPolicy,
          in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
-         inout_vector InOutVec,
+         @_inout-vector_@ InOutVec,
          class BinaryDivideOp>
 void triangular_matrix_vector_solve(
   ExecutionPolicy&& exec,
@@ -8307,7 +8307,7 @@ This is why the `ExecutionPolicy` overload exists.
 template<in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
-         inout_vector InOutVec>
+         @_inout-vector_@ InOutVec>
 void triangular_matrix_vector_solve(
   InMat A,
   Triangle t,
@@ -8322,7 +8322,7 @@ template<class ExecutionPolicy,
          in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
-         inout_vector InOutVec>
+         @_inout-vector_@ InOutVec>
 void triangular_matrix_vector_solve(
   ExecutionPolicy&& exec,
   InMat A,
@@ -8340,7 +8340,7 @@ void triangular_matrix_vector_solve(
 ```c++
 template<in_vector InVec1,
          in_vector InVec2,
-         inout_matrix InOutMat>
+         @_inout-matrix_@ InOutMat>
 void matrix_rank_1_update(
   InVec1 x,
   InVec2 y,
@@ -8349,7 +8349,7 @@ void matrix_rank_1_update(
 template<class ExecutionPolicy,
          in_vector InVec1,
          in_vector InVec2,
-         inout_matrix InOutMat>
+         @_inout-matrix_@ InOutMat>
 void matrix_rank_1_update(
   ExecutionPolicy&& exec,
   InVec1 x,
@@ -8399,7 +8399,7 @@ as the result of `conjugated`.  Alternately, they can use the shortcut
 ```c++
 template<in_vector InVec1,
          in_vector InVec2,
-         inout_matrix InOutMat>
+         @_inout-matrix_@ InOutMat>
 void matrix_rank_1_update_c(
   InVec1 x,
   InVec2 y,
@@ -8408,7 +8408,7 @@ void matrix_rank_1_update_c(
 template<class ExecutionPolicy,
          in_vector InVec1,
          in_vector InVec2,
-         inout_matrix InOutMat>
+         @_inout-matrix_@ InOutMat>
 void matrix_rank_1_update_c(
   ExecutionPolicy&& exec,
   InVec1 x,
@@ -8426,7 +8426,7 @@ note]*
 
 ```c++
 template<in_vector InVec,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_1_update(
   InVec x,
@@ -8434,7 +8434,7 @@ void symmetric_matrix_rank_1_update(
   Triangle t);
 template<class ExecutionPolicy,
          in_vector InVec,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_1_update(
   ExecutionPolicy&& exec,
@@ -8443,7 +8443,7 @@ void symmetric_matrix_rank_1_update(
   Triangle t);
 template<class T,
          in_vector InVec,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_1_update(
   T alpha,
@@ -8453,7 +8453,7 @@ void symmetric_matrix_rank_1_update(
 template<class ExecutionPolicy,
          class T,
          in_vector InVec,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_1_update(
   ExecutionPolicy&& exec,
@@ -8526,7 +8526,7 @@ the mathematical expression for the algorithm is
 
 ```c++
 template<in_vector InVec,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_1_update(
   InVec x,
@@ -8534,7 +8534,7 @@ void hermitian_matrix_rank_1_update(
   Triangle t);
 template<class ExecutionPolicy,
          in_vector InVec,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_1_update(
   ExecutionPolicy&& exec,
@@ -8543,7 +8543,7 @@ void hermitian_matrix_rank_1_update(
   Triangle t);
 template<class T,
          in_vector InVec,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_1_update(
   T alpha,
@@ -8553,7 +8553,7 @@ void hermitian_matrix_rank_1_update(
 template<class ExecutionPolicy,
          class T,
          in_vector InVec,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_1_update(
   ExecutionPolicy&& exec,
@@ -8632,7 +8632,7 @@ the mathematical expression for the algorithm is
 ```c++
 template<in_vector InVec1,
          in_vector InVec2,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_2_update(
   InVec1 x,
@@ -8643,7 +8643,7 @@ void symmetric_matrix_rank_2_update(
 template<class ExecutionPolicy,
          in_vector InVec1,
          in_vector InVec2,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_2_update(
   ExecutionPolicy&& exec,
@@ -8709,7 +8709,7 @@ the mathematical expression for the algorithm is
 ```c++
 template<in_vector InVec1,
          in_vector InVec2,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_2_update(
   InVec1 x,
@@ -8720,7 +8720,7 @@ void hermitian_matrix_rank_2_update(
 template<class ExecutionPolicy,
          in_vector InVec1,
          in_vector InVec2,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_2_update(
   ExecutionPolicy&& exec,
@@ -9606,7 +9606,7 @@ In-place overwriting triangular matrix-matrix left product
 template<in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         inout_matrix InOutMat>
+         @_inout-matrix_@ InOutMat>
 void triangular_matrix_left_product(
   InMat1 A,
   Triangle t,
@@ -9616,7 +9616,7 @@ template<class ExecutionPolicy,
          in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         inout_matrix InOutMat>
+         @_inout-matrix_@ InOutMat>
 void triangular_matrix_left_product(
   ExecutionPolicy&& exec,
   InMat1 A,
@@ -9684,7 +9684,7 @@ In-place overwriting triangular matrix-matrix right product
 template<in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         inout_matrix InOutMat>
+         @_inout-matrix_@ InOutMat>
 void triangular_matrix_right_product(
   InMat1 A,
   Triangle t,
@@ -9694,7 +9694,7 @@ template<class ExecutionPolicy,
          in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         inout_matrix InOutMat>
+         @_inout-matrix_@ InOutMat>
 void triangular_matrix_right_product(
   ExecutionPolicy&& exec,
   InMat1 A,
@@ -9817,7 +9817,7 @@ to the input matrix. --*end note]*
 ```c++
 template<class T,
          in_matrix InMat1,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_k_update(
   T alpha,
@@ -9827,7 +9827,7 @@ void symmetric_matrix_rank_k_update(
 template<class ExecutionPolicy,
          class T,
          in_matrix InMat1,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_k_update(
   ExecutionPolicy&& exec,
@@ -9896,7 +9896,7 @@ for all `k` such that `i,k` is in the domain of `A`.
 ```c++
 template<class T,
          in_matrix InMat1,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_k_update(
   T alpha,
@@ -9906,7 +9906,7 @@ void hermitian_matrix_rank_k_update(
 template<class ExecutionPolicy,
          class T,
          in_matrix InMat1,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_k_update(
   ExecutionPolicy&& exec,
@@ -9985,7 +9985,7 @@ to the input matrices. --*end note]*
 ```c++
 template<in_matrix InMat1,
          in_matrix InMat2,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_2k_update(
   InMat1 A,
@@ -9995,7 +9995,7 @@ void symmetric_matrix_rank_2k_update(
 template<class ExecutionPolicy,
          in_matrix InMat1,
          in_matrix InMat2,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_2k_update(
   ExecutionPolicy&& exec,
@@ -10064,7 +10064,7 @@ for all `k2` such that `i,k2` is in the domain of `B`.
 ```c++
 template<in_matrix InMat1,
          in_matrix InMat2,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_2k_update(
   InMat1 A,
@@ -10075,7 +10075,7 @@ void hermitian_matrix_rank_2k_update(
 template<class ExecutionPolicy,
          in_matrix InMat1,
          in_matrix InMat2,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_2k_update(
   ExecutionPolicy&& exec,
@@ -10299,7 +10299,7 @@ In-place left solve of multiple triangular systems
 template<in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_left_solve(
   InMat1 A,
@@ -10311,7 +10311,7 @@ template<class ExecutionPolicy,
          in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_left_solve(
   ExecutionPolicy&& exec,
@@ -10324,7 +10324,7 @@ void triangular_matrix_matrix_left_solve(
 template<in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         inout_matrix InOutMat>
+         @_inout-matrix_@ InOutMat>
 void triangular_matrix_matrix_left_solve(
   InMat1 A,
   Triangle t,
@@ -10334,7 +10334,7 @@ template<class ExecutionPolicy,
          in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         inout_matrix InOutMat>
+         @_inout-matrix_@ InOutMat>
 void triangular_matrix_matrix_left_solve(
   ExecutionPolicy&& exec,
   InMat1 A,
@@ -10519,7 +10519,7 @@ In-place right solve of multiple triangular systems
 template<in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_right_solve(
   InMat1 A,
@@ -10531,7 +10531,7 @@ template<class ExecutionPolicy,
          in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         inout_matrix InOutMat,
+         @_inout-matrix_@ InOutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_right_solve(
   ExecutionPolicy&& exec,
@@ -10544,7 +10544,7 @@ void triangular_matrix_matrix_right_solve(
 template<in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         inout_matrix InOutMat>
+         @_inout-matrix_@ InOutMat>
 void triangular_matrix_matrix_right_solve(
   InMat1 A,
   Triangle t,
@@ -10554,7 +10554,7 @@ template<class ExecutionPolicy,
          in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         inout_matrix InOutMat>
+         @_inout-matrix_@ InOutMat>
 void triangular_matrix_matrix_right_solve(
   ExecutionPolicy&& exec,
   InMat1 A,
@@ -10646,7 +10646,7 @@ upper_triangular_t opposite_triangle(lower_triangular_t) {
 // Returns nullopt if no bad pivots,
 // else the index of the first bad pivot.
 // A "bad" pivot is zero or NaN.
-template<inout_matrix InOutMat,
+template<@_inout-matrix_@ InOutMat,
          class Triangle>
 optional<typename InOutMat::size_type>
 cholesky_factor(InOutMat A, Triangle t)
@@ -10773,7 +10773,7 @@ means that the matrix has many more rows than columns.
 
 ```c++
 // Compute QR factorization A = Q R, with A storing Q.
-template<inout_matrix InOutMat,
+template<@_inout-matrix_@ InOutMat,
          out_matrix OutMat>
 optional<typename InOutMat::size_type>
 cholesky_tsqr_one_step(

--- a/D1673/P1673.md
+++ b/D1673/P1673.md
@@ -3451,10 +3451,10 @@ class layout_blas_packed;
 
 // [linalg.scaled.base], exposition-only function and class templates
 
-class @_proxy-reference-base_@; // <it>exposition only</it>
+class @_proxy-reference-base_@; // @_exposition only_@
 
 template<class Reference, class Value, class Derived>
-class @_proxy-reference_@; // <it>exposition only</it>
+class @_proxy-reference_@; // @_exposition only_@
 
 // [linalg.scaled.accessor_scaled], class template accessor_scaled
 
@@ -3591,7 +3591,6 @@ void givens_rotation_apply(
   InOutVec2 y,
   const Real c,
   const complex<Real> s);
-}
 
 // [linalg.algs.blas1.swap], swap elements
 template<inout_object InOutObj1,
@@ -5332,7 +5331,7 @@ public:
     using layout_type = layout_blas_packed<Triangle, StorageOrder>;
 
   private:
-    Extents <it>extents_</it>{}; // exposition only
+    Extents @_extents__@{}; // exposition only
 
   public:
     constexpr mapping() noexcept = default;
@@ -5344,7 +5343,7 @@ public:
 
     constexpr mapping& operator=(const mapping&) noexcept = default;
 
-    constexpr extents_type extents() const noexcept { return <it>extents_</it>; }
+    constexpr extents_type extents() const noexcept { return @_extents__@; }
 
     constexpr size_type required_span_size() const noexcept;
 
@@ -5398,7 +5397,7 @@ constexpr mapping(const extents_type& e) noexcept;
 
     * `e.extent(0)` equals `e.extent(1)`.
 
-* *Effects:* Direct-non-list-initializes <it>`extents_`</it> with `e`.
+* *Effects:* Direct-non-list-initializes _`extents_`_ with `e`.
 
 ```c++
 template<class OtherExtents>
@@ -5411,7 +5410,7 @@ template<class OtherExtents>
 *Preconditions:* `other.required_span_size()` is representable as a value
     of type `index_type` (**[basic.fundamental]**).
 
-*Effects:* Direct-non-list-initializes <it>`extents_`</it> with `other.extents()`.
+*Effects:* Direct-non-list-initializes _`extents_`_ with `other.extents()`.
 
 ```c++
 constexpr index_type required_span_size() const noexcept;
@@ -5435,8 +5434,8 @@ template<class ... Indices>
 
   * `(is_nothrow_constructible_v<index_type, Indices>)` is `true`.
 
-*Preconditions:* `extents_type::`<it>`index-cast`</it>`(k)` is
-    a multidimensional index in <it>`extents_`</it> (**[mdspan.overview]**).
+*Preconditions:* `extents_type::`_`index-cast`_`(k)` is
+    a multidimensional index in _`extents_`_ (**[mdspan.overview]**).
 
 *Returns:* Let `N` equal `extent(0)`, let `i` be the zeroth element of `k`,
     and let `j` be the first element of `k`.  Then:

--- a/D1673/P1673.md
+++ b/D1673/P1673.md
@@ -446,6 +446,16 @@ toc: true
       out and inout matrix parameter(s) of
       *[linalg.algs.blas3.trmm]* and *[linalg.alg.blas3.trsm]*.
 
+  * Fix `matrix_frob_norm`, `matrix_one_norm` and `matrix_inf_norm`
+      Remarks to use `value_type` instead of `element_type`.
+
+  * Remove unnecessary constraint on *[linalg.algs.blas2.gemv]*
+      that input matrix parameter(s) have unique layout,
+      and remove all other constraints there, as they are redundant
+      with the new exposition-only concepts.
+      (Retain the unique layout constraint
+      for symmetric and Hermitian matrix-vector product.)
+
 # Purpose of this paper
 
 This paper proposes a C++ Standard Library dense linear algebra
@@ -3749,149 +3759,149 @@ typename InVec::extents_type idx_abs_max(
 
 // [linalg.algs.blas1.matfrobnorm],
 // Frobenius norm of a matrix
-template<class in_matrix_t,
+template<in_matrix InMat,
          class T>
 T matrix_frob_norm(
-  in_matrix_t A,
+  InMat A,
   T init);
 template<class ExecutionPolicy,
-         class in_matrix_t,
+         in_matrix InMat,
          class T>
 T matrix_frob_norm(
   ExecutionPolicy&& exec,
-  in_matrix_t A,
+  InMat A,
   T init);
-template<class in_matrix_t>
+template<in_matrix InMat>
 auto matrix_frob_norm(
-  in_matrix_t A) -> /* see-below */;
+  InMat A) -> /* see-below */;
 template<class ExecutionPolicy,
-         class in_matrix_t>
+         in_matrix InMat>
 auto matrix_frob_norm(
   ExecutionPolicy&& exec,
-  in_matrix_t A) -> /* see-below */;
+  InMat A) -> /* see-below */;
 
 // [linalg.algs.blas1.matonenorm],
 // One norm of a matrix
-template<class in_matrix_t,
+template<in_matrix InMat,
          class T>
 T matrix_one_norm(
-  in_matrix_t A,
+  InMat A,
   T init);
 template<class ExecutionPolicy,
-         class in_matrix_t,
+         in_matrix InMat,
          class T>
 T matrix_one_norm(
   ExecutionPolicy&& exec,
-  in_matrix_t A,
+  InMat A,
   T init);
-template<class in_matrix_t>
+template<in_matrix InMat>
 auto matrix_one_norm(
-  in_matrix_t A) -> /* see-below */;
+  InMat A) -> /* see-below */;
 template<class ExecutionPolicy,
-         class in_matrix_t>
+         in_matrix InMat>
 auto matrix_one_norm(
   ExecutionPolicy&& exec,
-  in_matrix_t A) -> /* see-below */;
+  InMat A) -> /* see-below */;
 
 // [linalg.algs.blas1.matinfnorm],
 // Infinity norm of a matrix
-template<class in_matrix_t,
+template<in_matrix InMat,
          class T>
 T matrix_inf_norm(
-  in_matrix_t A,
+  InMat A,
   T init);
 template<class ExecutionPolicy,
-         class in_matrix_t,
+         in_matrix InMat,
          class T>
 T matrix_inf_norm(
   ExecutionPolicy&& exec,
-  in_matrix_t A,
+  InMat A,
   T init);
-template<class in_matrix_t>
+template<in_matrix InMat>
 auto matrix_inf_norm(
-  in_matrix_t A) -> /* see-below */;
+  InMat A) -> /* see-below */;
 template<class ExecutionPolicy,
-         class in_matrix_t>
+         in_matrix InMat>
 auto matrix_inf_norm(
   ExecutionPolicy&& exec,
-  in_matrix_t A) -> /* see-below */;
+  InMat A) -> /* see-below */;
 
 // [linalg.algs.blas2.gemv],
 // general matrix-vector product
 template<in_vector InVec,
-         class in_matrix_t,
+         in_matrix InMat,
          class out_vector_t>
-void matrix_vector_product(in_matrix_t A,
+void matrix_vector_product(InMat A,
                            InVec x,
                            out_vector_t y);
 template<class ExecutionPolicy,
          in_vector InVec,
-         class in_matrix_t,
+         in_matrix InMat,
          class out_vector_t>
 void matrix_vector_product(ExecutionPolicy&& exec,
-                           in_matrix_t A,
+                           InMat A,
                            InVec x,
                            out_vector_t y);
 template<in_vector InVec1,
-         class in_matrix_t,
+         in_matrix InMat,
          in_vector InVec2,
          class out_vector_t>
-void matrix_vector_product(in_matrix_t A,
+void matrix_vector_product(InMat A,
                            InVec1 x,
                            InVec2 y,
                            out_vector_t z);
 template<class ExecutionPolicy,
          in_vector InVec1,
-         class in_matrix_t,
+         in_matrix InMat,
          in_vector InVec2,
          class out_vector_t>
 void matrix_vector_product(ExecutionPolicy&& exec,
-                           in_matrix_t A,
+                           InMat A,
                            InVec1 x,
                            InVec2 y,
                            out_vector_t z);
 
 // [linalg.algs.blas2.symv],
 // symmetric matrix-vector product
-template<class in_matrix_t,
+template<in_matrix InMat,
          class Triangle,
          in_vector InVec,
          class out_vector_t>
-void symmetric_matrix_vector_product(in_matrix_t A,
+void symmetric_matrix_vector_product(InMat A,
                                      Triangle t,
                                      InVec x,
                                      out_vector_t y);
 template<class ExecutionPolicy,
-         class in_matrix_t,
+         in_matrix InMat,
          class Triangle,
          in_vector InVec,
          class out_vector_t>
 void symmetric_matrix_vector_product(ExecutionPolicy&& exec,
-                                     in_matrix_t A,
+                                     InMat A,
                                      Triangle t,
                                      InVec x,
                                      out_vector_t y);
-template<class in_matrix_t,
+template<in_matrix InMat,
          class Triangle,
          in_vector InVec1,
          in_vector InVec2,
          class out_vector_t>
 void symmetric_matrix_vector_product(
-  in_matrix_t A,
+  InMat A,
   Triangle t,
   InVec1 x,
   InVec2 y,
   out_vector_t z);
 
 template<class ExecutionPolicy,
-         class in_matrix_t,
+         in_matrix InMat,
          class Triangle,
          in_vector InVec1,
          in_vector InVec2,
          class out_vector_t>
 void symmetric_matrix_vector_product(
   ExecutionPolicy&& exec,
-  in_matrix_t A,
+  InMat A,
   Triangle t,
   InVec1 x,
   InVec2 y,
@@ -3899,43 +3909,43 @@ void symmetric_matrix_vector_product(
 
 // [linalg.algs.blas2.hemv],
 // Hermitian matrix-vector product
-template<class in_matrix_t,
+template<in_matrix InMat,
          class Triangle,
          in_vector InVec,
          class out_vector_t>
-void hermitian_matrix_vector_product(in_matrix_t A,
+void hermitian_matrix_vector_product(InMat A,
                                      Triangle t,
                                      InVec x,
                                      out_vector_t y);
 template<class ExecutionPolicy,
-         class in_matrix_t,
+         in_matrix InMat,
          class Triangle,
          in_vector InVec,
          class out_vector_t>
 void hermitian_matrix_vector_product(ExecutionPolicy&& exec,
-                                     in_matrix_t A,
+                                     InMat A,
                                      Triangle t,
                                      InVec x,
                                      out_vector_t y);
-template<class in_matrix_t,
+template<in_matrix InMat,
          class Triangle,
          in_vector InVec1,
          in_vector InVec2,
          class out_vector_t>
-void hermitian_matrix_vector_product(in_matrix_t A,
+void hermitian_matrix_vector_product(InMat A,
                                      Triangle t,
                                      InVec1 x,
                                      InVec2 y,
                                      out_vector_t z);
 
 template<class ExecutionPolicy,
-         class in_matrix_t,
+         in_matrix InMat,
          class Triangle,
          in_vector InVec1,
          in_vector InVec2,
          class out_vector_t>
 void hermitian_matrix_vector_product(ExecutionPolicy&& exec,
-                                     in_matrix_t A,
+                                     InMat A,
                                      Triangle t,
                                      InVec1 x,
                                      InVec2 y,
@@ -3946,26 +3956,26 @@ void hermitian_matrix_vector_product(ExecutionPolicy&& exec,
 
 // [linalg.algs.blas2.trmv.ov],
 // Overwriting triangular matrix-vector product
-template<class in_matrix_t,
+template<in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
          in_vector InVec,
          class out_vector_t>
 void triangular_matrix_vector_product(
-  in_matrix_t A,
+  InMat A,
   Triangle t,
   DiagonalStorage d,
   InVec x,
   out_vector_t y);
 template<class ExecutionPolicy,
-         class in_matrix_t,
+         in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
          in_vector InVec,
          class out_vector_t>
 void triangular_matrix_vector_product(
   ExecutionPolicy&& exec,
-  in_matrix_t A,
+  InMat A,
   Triangle t,
   DiagonalStorage d,
   InVec x,
@@ -3973,50 +3983,50 @@ void triangular_matrix_vector_product(
 
 // [linalg.algs.blas2.trmv.in-place],
 // In-place triangular matrix-vector product
-template<class in_matrix_t,
+template<in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
          inout_vector InOutVec>
 void triangular_matrix_vector_product(
-  in_matrix_t A,
+  InMat A,
   Triangle t,
   DiagonalStorage d,
   InOutVec y);
 template<class ExecutionPolicy,
-         class in_matrix_t,
+         in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
          inout_vector InOutVec>
 void triangular_matrix_vector_product(
   ExecutionPolicy&& exec,
-  in_matrix_t A,
+  InMat A,
   Triangle t,
   DiagonalStorage d,
   InOutVec y);
 
 // [linalg.algs.blas2.trmv.up],
 // Updating triangular matrix-vector product
-template<class in_matrix_t,
+template<in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
          in_vector InVec1,
          in_vector InVec2,
          class out_vector_t>
-void triangular_matrix_vector_product(in_matrix_t A,
+void triangular_matrix_vector_product(InMat A,
                                       Triangle t,
                                       DiagonalStorage d,
                                       InVec1 x,
                                       InVec2 y,
                                       out_vector_t z);
 template<class ExecutionPolicy,
-         class in_matrix_t,
+         in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
          in_vector InVec1,
          in_vector InVec2,
          class out_vector_t>
 void triangular_matrix_vector_product(ExecutionPolicy&& exec,
-                                      in_matrix_t A,
+                                      InMat A,
                                       Triangle t,
                                       DiagonalStorage d,
                                       InVec1 x,
@@ -4028,21 +4038,21 @@ void triangular_matrix_vector_product(ExecutionPolicy&& exec,
 
 // [linalg.algs.blas2.trsv.not-in-place],
 // Solve a triangular linear system, not in place
-template<class in_matrix_t,
+template<in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
          in_vector InVec,
          class out_vector_t,
          class BinaryDivideOp>
 void triangular_matrix_vector_solve(
-  in_matrix_t A,
+  InMat A,
   Triangle t,
   DiagonalStorage d,
   InVec b,
   out_vector_t x,
   BinaryDivideOp divide);
 template<class ExecutionPolicy,
-         class in_matrix_t,
+         in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
          in_vector InVec,
@@ -4050,32 +4060,32 @@ template<class ExecutionPolicy,
          class BinaryDivideOp>
 void triangular_matrix_vector_solve(
   ExecutionPolicy&& exec,
-  in_matrix_t A,
+  InMat A,
   Triangle t,
   DiagonalStorage d,
   InVec b,
   out_vector_t x,
   BinaryDivideOp divide);
-template<class in_matrix_t,
+template<in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
          in_vector InVec,
          class out_vector_t>
 void triangular_matrix_vector_solve(
-  in_matrix_t A,
+  InMat A,
   Triangle t,
   DiagonalStorage d,
   InVec b,
   out_vector_t x);
 template<class ExecutionPolicy,
-         class in_matrix_t,
+         in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
          in_vector InVec,
          class out_vector_t>
 void triangular_matrix_vector_solve(
   ExecutionPolicy&& exec,
-  in_matrix_t A,
+  InMat A,
   Triangle t,
   DiagonalStorage d,
   InVec b,
@@ -4083,47 +4093,47 @@ void triangular_matrix_vector_solve(
 
 // [linalg.algs.blas2.trsv.in-place],
 // Solve a triangular linear system, in place
-template<class in_matrix_t,
+template<in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
          inout_vector InOutVec,
          class BinaryDivideOp>
 void triangular_matrix_vector_solve(
-  in_matrix_t A,
+  InMat A,
   Triangle t,
   DiagonalStorage d,
   InOutVec b,
   BinaryDivideOp divide);
 template<class ExecutionPolicy,
-         class in_matrix_t,
+         in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
          inout_vector InOutVec,
          class BinaryDivideOp>
 void triangular_matrix_vector_solve(
   ExecutionPolicy&& exec,
-  in_matrix_t A,
+  InMat A,
   Triangle t,
   DiagonalStorage d,
   InOutVec b,
   BinaryDivideOp divide);
-template<class in_matrix_t,
+template<in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
          inout_vector InOutVec>
 void triangular_matrix_vector_solve(
-  in_matrix_t A,
+  InMat A,
   Triangle t,
   DiagonalStorage d,
   InOutVec b);
 template<class ExecutionPolicy,
-         class in_matrix_t,
+         in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
          inout_vector InOutVec>
 void triangular_matrix_vector_solve(
   ExecutionPolicy&& exec,
-  in_matrix_t A,
+  InMat A,
   Triangle t,
   DiagonalStorage d,
   InOutVec b);
@@ -4911,10 +4921,10 @@ template<class ExecutionPolicy,
          class BinaryDivideOp>
 void triangular_matrix_matrix_right_solve(
   ExecutionPolicy&& exec,
-  in_matrix_t A,
+  InMat A,
   Triangle t,
   DiagonalStorage d,
-  in_matrix_t B,
+  InMat B,
   out_matrix_t X,
   BinaryDivideOp divide);
 template<class in_matrix_1_t,
@@ -4961,10 +4971,10 @@ template<class ExecutionPolicy,
          class out_matrix_t>
 void triangular_matrix_matrix_right_solve(
   ExecutionPolicy&& exec,
-  in_matrix_t A,
+  InMat A,
   Triangle t,
   DiagonalStorage d,
-  in_matrix_t B,
+  InMat B,
   out_matrix_t X);
 template<class in_matrix_1_t,
          class Triangle,
@@ -7427,21 +7437,21 @@ The `abs` function is invoked via unqualified lookup.
 ##### Frobenius norm with specified result type
 
 ```c++
-template<class in_matrix_t,
+template<in_matrix InMat,
          class T>
 T matrix_frob_norm(
-  in_matrix_t A,
+  InMat A,
   T init);
 template<class ExecutionPolicy,
-         class in_matrix_t,
+         in_matrix InMat,
          class T>
 T matrix_frob_norm(
   ExecutionPolicy&& exec,
-  in_matrix_t A,
+  InMat A,
   T init);
 ```
 
-* *Preconditions:* `init + abs(declval<in_matrix_t::value_type>())*abs(declval<in_matrix_t::value_type>())`
+* *Preconditions:* `init + abs(declval<InMat::value_type>())*abs(declval<InMat::value_type>())`
     shall be convertible to `T`.
 
 * *Effects:* Returns the square root of the sum of squares
@@ -7454,11 +7464,11 @@ T matrix_frob_norm(
     See *Remarks* below.
     --*end note]*
 
-* *Remarks:* If `in_matrix_t::element_type` is a floating-point type
+* *Remarks:* If `InMat::value_type` is a floating-point type
     or `complex<R>` for some floating-point type `R`,
     and if `T` is a floating-point type, then
 
-    * if `T` has higher precision than `in_matrix_type::element_type`, then
+    * if `T` has higher precision than `InMatype::value_type`, then
         intermediate terms in the sum use `T`'s precision or greater; and
 
     * any guarantees regarding overflow and underflow of `matrix_frob_norm`
@@ -7471,17 +7481,17 @@ The `abs` function is invoked via unqualified lookup.
 ##### Frobenius norm with default result type
 
 ```c++
-template<class in_matrix_t>
+template<in_matrix InMat>
 auto matrix_frob_norm(
-  in_matrix_t A) -> /* see-below */;
+  InMat A) -> /* see-below */;
 template<class ExecutionPolicy,
-         class in_matrix_t>
+         in_matrix InMat>
 auto matrix_frob_norm(
   ExecutionPolicy&& exec,
-  in_matrix_t A) -> /* see-below */;
+  InMat A) -> /* see-below */;
 ```
 
-* *Effects:* Let `T` be `abs(declval<in_matrix_t::value_type>())*abs(declval<in_matrix_t::value_type>())`.
+* *Effects:* Let `T` be `abs(declval<InMat::value_type>())*abs(declval<InMat::value_type>())`.
     Then, the one-parameter overload is equivalent to
     `matrix_frob_norm(A, T{});`,
     and the two-parameter overload is equivalent to
@@ -7492,17 +7502,17 @@ auto matrix_frob_norm(
 ##### One norm with specified result type
 
 ```c++
-template<class in_matrix_t,
+template<in_matrix InMat,
          class T>
 T matrix_one_norm(
-  in_matrix_t A,
+  InMat A,
   T init);
 template<class ExecutionPolicy,
-         class in_matrix_t,
+         in_matrix InMat,
          class T>
 T matrix_one_norm(
   ExecutionPolicy&& exec,
-  in_matrix_t A,
+  InMat A,
   T init);
 ```
 
@@ -7516,23 +7526,23 @@ T matrix_one_norm(
         The one norm of the matrix `A` is the maximum over all columns of `A`,
         of the sum of the absolute values of the elements of the column.
 
-* *Remarks:* If `in_matrix_t::element_type` is a floating-point type
+* *Remarks:* If `InMat::value_type` is a floating-point type
     or `complex<R>` for some floating-point type `R`,
     if `T` is a floating-point type,
-    and if `T` has higher precision than `in_matrix_type::element_type`,
+    and if `T` has higher precision than `InMat::value_type`,
     then intermediate terms in each sum use `T`'s precision or greater.
 
 ##### One norm with default result type
 
 ```c++
-template<class in_matrix_t>
+template<in_matrix InMat>
 auto matrix_one_norm(
-  in_matrix_t A) -> /* see-below */;
+  InMat A) -> /* see-below */;
 template<class ExecutionPolicy,
-         class in_matrix_t>
+         in_matrix InMat>
 auto matrix_one_norm(
   ExecutionPolicy&& exec,
-  in_matrix_t A) -> /* see-below */;
+  InMat A) -> /* see-below */;
 ```
 
 * *Effects:* Let `T` be `decltype(abs(A[0,0])`.
@@ -7550,17 +7560,17 @@ The `abs` function is invoked via unqualified lookup.
 ##### Infinity norm with specified result type
 
 ```c++
-template<class in_matrix_t,
+template<in_matrix InMat,
          class T>
 T matrix_inf_norm(
-  in_matrix_t A,
+  InMat A,
   T init);
 template<class ExecutionPolicy,
-         class in_matrix_t,
+         in_matrix InMat,
          class T>
 T matrix_inf_norm(
   ExecutionPolicy&& exec,
-  in_matrix_t A,
+  InMat A,
   T init);
 ```
 
@@ -7574,10 +7584,10 @@ T matrix_inf_norm(
         The infinity norm of the matrix `A` is the maximum over all rows of `A`,
         of the sum of the absolute values of the elements of the row.
 
-* *Remarks:* If `in_matrix_t::element_type` is a floating-point type
+* *Remarks:* If `InMat::value_type` is a floating-point type
     or `complex<R>` for some floating-point type `R`,
     if `T` is a floating-point type,
-    and if `T` has higher precision than `in_matrix_type::element_type`,
+    and if `T` has higher precision than `InMat::value_type`,
     then intermediate terms in each sum use `T`'s precision or greater.
 
 *[Note:*
@@ -7587,14 +7597,14 @@ The `abs` function is invoked via unqualified lookup.
 ##### Infinity norm with default result type
 
 ```c++
-template<class in_matrix_t>
+template<in_matrix InMat>
 auto matrix_inf_norm(
-  in_matrix_t A) -> /* see-below */;
+  InMat A) -> /* see-below */;
 template<class ExecutionPolicy,
-         class in_matrix_t>
+         in_matrix InMat>
 auto matrix_inf_norm(
   ExecutionPolicy&& exec,
-  in_matrix_t A) -> /* see-below */;
+  InMat A) -> /* see-below */;
 ```
 
 * *Effects:* Let `T` be `decltype(abs(A[0,0])`.
@@ -7620,13 +7630,6 @@ The following requirements apply to all functions in this section.
 
     * `y.extent(0)` equals `z.extent(0)` (if applicable).
 
-* *Constraints:* For all functions in this section:
-
-    * `in_matrix_t` has unique layout; and
-
-    * `A.rank()` equals 2, `x.rank()` equals 1, `y.rank()` equals 1, and
-        `z.rank()` equals 1 (if applicable).
-
 * *Mandates:*
 
     * If neither `A.static_extent(1)` nor `x.static_extent(0)` equals
@@ -7649,18 +7652,18 @@ The following requirements apply to all functions in this section.
 
 ```c++
 template<in_vector InVec,
-         class in_matrix_t,
+         in_matrix InMat,
          class out_vector_t>
-void matrix_vector_product(in_matrix_t A,
+void matrix_vector_product(InMat A,
                            InVec x,
                            out_vector_t y);
 
 template<class ExecutionPolicy,
          in_vector InVec,
-         class in_matrix_t,
+         in_matrix InMat,
          class out_vector_t>
 void matrix_vector_product(ExecutionPolicy&& exec,
-                           in_matrix_t A,
+                           InMat A,
                            InVec x,
                            out_vector_t y);
 ```
@@ -7705,21 +7708,21 @@ void scaled_matvec_2(mdspan<double, extents<size_t, num_rows, num_cols>> A,
 
 ```c++
 template<in_vector InVec1,
-         class in_matrix_t,
+         in_matrix InMat,
          in_vector InVec2,
          class out_vector_t>
-void matrix_vector_product(in_matrix_t A,
+void matrix_vector_product(InMat A,
                            InVec1 x,
                            InVec2 y,
                            out_vector_t z);
 
 template<class ExecutionPolicy,
          in_vector InVec1,
-         class in_matrix_t,
+         in_matrix InMat,
          in_vector InVec2,
          class out_vector_t>
 void matrix_vector_product(ExecutionPolicy&& exec,
-                           in_matrix_t A,
+                           InMat A,
                            InVec1 x,
                            InVec2 y,
                            out_vector_t z);
@@ -7746,9 +7749,9 @@ The following requirements apply to all functions in this section.
 
 * *Constraints:*
 
-    * `in_matrix_t` either has unique layout, or `layout_blas_packed` layout.
+    * `InMat` either has unique layout, or `layout_blas_packed` layout.
 
-    * If `in_matrix_t` has `layout_blas_packed` layout, then the
+    * If `InMat` has `layout_blas_packed` layout, then the
         layout's `Triangle` template argument has the same type as
         the function's `Triangle` template argument.
 
@@ -7785,22 +7788,22 @@ The following requirements apply to all functions in this section.
 ##### Overwriting symmetric matrix-vector product
 
 ```c++
-template<class in_matrix_t,
+template<in_matrix InMat,
          class Triangle,
          in_vector InVec,
          class out_vector_t>
-void symmetric_matrix_vector_product(in_matrix_t A,
+void symmetric_matrix_vector_product(InMat A,
                                      Triangle t,
                                      InVec x,
                                      out_vector_t y);
 
 template<class ExecutionPolicy,
-         class in_matrix_t,
+         in_matrix InMat,
          class Triangle,
          in_vector InVec,
          class out_vector_t>
 void symmetric_matrix_vector_product(ExecutionPolicy&& exec,
-                                     in_matrix_t A,
+                                     InMat A,
                                      Triangle t,
                                      InVec x,
                                      out_vector_t y);
@@ -7811,27 +7814,27 @@ void symmetric_matrix_vector_product(ExecutionPolicy&& exec,
 ##### Updating symmetric matrix-vector product
 
 ```c++
-template<class in_matrix_t,
+template<in_matrix InMat,
          class Triangle,
          in_vector InVec1,
          in_vector InVec2,
          class out_vector_t>
 void symmetric_matrix_vector_product(
-  in_matrix_t A,
+  InMat A,
   Triangle t,
   InVec1 x,
   InVec2 y,
   out_vector_t z);
 
 template<class ExecutionPolicy,
-         class in_matrix_t,
+         in_matrix InMat,
          class Triangle,
          in_vector InVec1,
          in_vector InVec2,
          class out_vector_t>
 void symmetric_matrix_vector_product(
   ExecutionPolicy&& exec,
-  in_matrix_t A,
+  InMat A,
   Triangle t,
   InVec1 x,
   InVec2 y,
@@ -7859,9 +7862,9 @@ The following requirements apply to all functions in this section.
 
 * *Constraints:*
 
-    * `in_matrix_t` either has unique layout, or `layout_blas_packed` layout.
+    * `InMat` either has unique layout, or `layout_blas_packed` layout.
 
-    * If `in_matrix_t` has `layout_blas_packed` layout, then the
+    * If `InMat` has `layout_blas_packed` layout, then the
         layout's `Triangle` template argument has the same type as
         the function's `Triangle` template argument.
 
@@ -7898,22 +7901,22 @@ The following requirements apply to all functions in this section.
 ##### Overwriting Hermitian matrix-vector product
 
 ```c++
-template<class in_matrix_t,
+template<in_matrix InMat,
          class Triangle,
          in_vector InVec,
          class out_vector_t>
-void hermitian_matrix_vector_product(in_matrix_t A,
+void hermitian_matrix_vector_product(InMat A,
                                      Triangle t,
                                      InVec x,
                                      out_vector_t y);
 
 template<class ExecutionPolicy,
-         class in_matrix_t,
+         in_matrix InMat,
          class Triangle,
          in_vector InVec,
          class out_vector_t>
 void hermitian_matrix_vector_product(ExecutionPolicy&& exec,
-                                     in_matrix_t A,
+                                     InMat A,
                                      Triangle t,
                                      InVec x,
                                      out_vector_t y);
@@ -7924,25 +7927,25 @@ void hermitian_matrix_vector_product(ExecutionPolicy&& exec,
 ##### Updating Hermitian matrix-vector product
 
 ```c++
-template<class in_matrix_t,
+template<in_matrix InMat,
          class Triangle,
          in_vector InVec1,
          in_vector InVec2,
          class out_vector_t>
-void hermitian_matrix_vector_product(in_matrix_t A,
+void hermitian_matrix_vector_product(InMat A,
                                      Triangle t,
                                      InVec1 x,
                                      InVec2 y,
                                      out_vector_t z);
 
 template<class ExecutionPolicy,
-         class in_matrix_t,
+         in_matrix InMat,
          class Triangle,
          in_vector InVec1,
          in_vector InVec2,
          class out_vector_t>
 void hermitian_matrix_vector_product(ExecutionPolicy&& exec,
-                                     in_matrix_t A,
+                                     InMat A,
                                      Triangle t,
                                      InVec1 x,
                                      InVec2 y,
@@ -7970,9 +7973,9 @@ The following requirements apply to all functions in this section.
 
 * *Constraints:*
 
-    * `in_matrix_t` either has unique layout, or `layout_blas_packed` layout;
+    * `InMat` either has unique layout, or `layout_blas_packed` layout;
 
-    * if `in_matrix_t` has `layout_blas_packed` layout, then the
+    * if `InMat` has `layout_blas_packed` layout, then the
         layout's `Triangle` template argument has the same type as
         the function's `Triangle` template argument;
 
@@ -8020,26 +8023,26 @@ The following requirements apply to all functions in this section.
 ##### Overwriting triangular matrix-vector product [linalg.algs.blas2.trmv.ov]
 
 ```c++
-template<class in_matrix_t,
+template<in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
          in_vector InVec,
          class out_vector_t>
 void triangular_matrix_vector_product(
-  in_matrix_t A,
+  InMat A,
   Triangle t,
   DiagonalStorage d,
   InVec x,
   out_vector_t y);
 template<class ExecutionPolicy,
-         class in_matrix_t,
+         in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
          in_vector InVec,
          class out_vector_t>
 void triangular_matrix_vector_product(
   ExecutionPolicy&& exec,
-  in_matrix_t A,
+  InMat A,
   Triangle t,
   DiagonalStorage d,
   InVec x,
@@ -8051,23 +8054,23 @@ void triangular_matrix_vector_product(
 ##### In-place triangular matrix-vector product [linalg.algs.blas2.trmv.in-place]
 
 ```c++
-template<class in_matrix_t,
+template<in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
          inout_vector InOutVec>
 void triangular_matrix_vector_product(
-  in_matrix_t A,
+  InMat A,
   Triangle t,
   DiagonalStorage d,
   InOutVec y);
 template<class ExecutionPolicy,
-         class in_matrix_t,
+         in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
          inout_vector InOutVec>
 void triangular_matrix_vector_product(
   ExecutionPolicy&& exec,
-  in_matrix_t A,
+  InMat A,
   Triangle t,
   DiagonalStorage d,
   InOutVec y);
@@ -8093,13 +8096,13 @@ This is why the `ExecutionPolicy` overload exists.
 ##### Updating triangular matrix-vector product [linalg.algs.blas2.trmv.up]
 
 ```c++
-template<class in_matrix_t,
+template<in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
          in_vector InVec1,
          in_vector InVec2,
          class out_vector_t>
-void triangular_matrix_vector_product(in_matrix_t A,
+void triangular_matrix_vector_product(InMat A,
                                       Triangle t,
                                       DiagonalStorage d,
                                       InVec1 x,
@@ -8107,14 +8110,14 @@ void triangular_matrix_vector_product(in_matrix_t A,
                                       out_vector_t z);
 
 template<class ExecutionPolicy,
-         class in_matrix_t,
+         in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
          in_vector InVec1,
          in_vector InVec2,
          class out_vector_t>
 void triangular_matrix_vector_product(ExecutionPolicy&& exec,
-                                      in_matrix_t A,
+                                      InMat A,
                                       Triangle t,
                                       DiagonalStorage d,
                                       InVec1 x,
@@ -8143,9 +8146,9 @@ The following requirements apply to all functions in this section.
 
     * `b.rank()` equals 1;
 
-    * `in_matrix_t` either has unique layout, or `layout_blas_packed` layout; and
+    * `InMat` either has unique layout, or `layout_blas_packed` layout; and
 
-    * if `in_matrix_t` has `layout_blas_packed` layout, then the
+    * if `InMat` has `layout_blas_packed` layout, then the
         layout's `Triangle` template argument has the same type as
         the function's `Triangle` template argument.
 
@@ -8177,21 +8180,21 @@ The following requirements apply to all functions in this section.
 ##### Not-in-place triangular solve [linalg.algs.blas2.trsv.not-in-place]
 
 ```c++
-template<class in_matrix_t,
+template<in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
          in_vector InVec,
          class out_vector_t,
          class BinaryDivideOp>
 void triangular_matrix_vector_solve(
-  in_matrix_t A,
+  InMat A,
   Triangle t,
   DiagonalStorage d,
   InVec b,
   out_vector_t x,
   BinaryDivideOp divide);
 template<class ExecutionPolicy,
-         class in_matrix_t,
+         in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
          in_vector InVec,
@@ -8199,7 +8202,7 @@ template<class ExecutionPolicy,
          class BinaryDivideOp>
 void triangular_matrix_vector_solve(
   ExecutionPolicy&& exec,
-  in_matrix_t A,
+  InMat A,
   Triangle t,
   DiagonalStorage d,
   InVec b,
@@ -8217,13 +8220,13 @@ void triangular_matrix_vector_solve(
 * *Effects:* Computes $x$ such that $b = A x$.  If no such $x$ exists, then the elements of $x$ are valid but unspecified.
 
 ```c++
-template<class in_matrix_t,
+template<in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
          in_vector InVec,
          class out_vector_t>
 void triangular_matrix_vector_solve(
-  in_matrix_t A,
+  InMat A,
   Triangle t,
   DiagonalStorage d,
   InVec b,
@@ -8234,14 +8237,14 @@ void triangular_matrix_vector_solve(
 
 ```c++
 template<class ExecutionPolicy,
-         class in_matrix_t,
+         in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
          in_vector InVec,
          class out_vector_t>
 void triangular_matrix_vector_solve(
   ExecutionPolicy&& exec,
-  in_matrix_t A,
+  InMat A,
   Triangle t,
   DiagonalStorage d,
   InVec b,
@@ -8253,26 +8256,26 @@ void triangular_matrix_vector_solve(
 ##### In-place triangular solve [linalg.algs.blas2.trsv.in-place]
 
 ```c++
-template<class in_matrix_t,
+template<in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
          inout_vector InOutVec,
          class BinaryDivideOp>
 void triangular_matrix_vector_solve(
-  in_matrix_t A,
+  InMat A,
   Triangle t,
   DiagonalStorage d,
   InOutVec b,
   BinaryDivideOp divide);
 template<class ExecutionPolicy,
-         class in_matrix_t,
+         in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
          inout_vector InOutVec,
          class BinaryDivideOp>
 void triangular_matrix_vector_solve(
   ExecutionPolicy&& exec,
-  in_matrix_t A,
+  InMat A,
   Triangle t,
   DiagonalStorage d,
   InOutVec b,
@@ -8297,12 +8300,12 @@ This is why the `ExecutionPolicy` overload exists.
 * *Effects:* Overwrites $b$ with $x$ such that $b = A x$.  If no such $x$ exists, then the elements of $b$ are valid but unspecified.
 
 ```c++
-template<class in_matrix_t,
+template<in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
          inout_vector InOutVec>
 void triangular_matrix_vector_solve(
-  in_matrix_t A,
+  InMat A,
   Triangle t,
   DiagonalStorage d,
   InOutVec b);
@@ -8312,13 +8315,13 @@ void triangular_matrix_vector_solve(
 
 ```c++
 template<class ExecutionPolicy,
-         class in_matrix_t,
+         in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
          inout_vector InOutVec>
 void triangular_matrix_vector_solve(
   ExecutionPolicy&& exec,
-  in_matrix_t A,
+  InMat A,
   Triangle t,
   DiagonalStorage d,
   InOutVec b);
@@ -10731,12 +10734,12 @@ example in-place in the matrix `A`.  The example assumes that
 `cholesky_factor(A, t)` returned `nullopt`, indicating no zero or NaN pivots.
 
 ```c++
-template<class in_matrix_t,
+template<in_matrix InMat,
          class Triangle,
          in_vector InVec,
          class out_vector_t>
 void cholesky_solve(
-  in_matrix_t A,
+  InMat A,
   Triangle t,
   InVec b,
   out_vector_t x)
@@ -10826,13 +10829,13 @@ cholesky_tsqr_one_step(
 
 // Compute QR factorization A = Q R.  Use R_tmp as temporary R factor
 // storage for iterative refinement.
-template<class in_matrix_t,
+template<in_matrix InMat,
          class out_matrix_1_t,
          class out_matrix_2_t,
          class out_matrix_3_t>
 optional<typename out_matrix_1_t::size_type>
 cholesky_tsqr(
-  in_matrix_t A,
+  InMat A,
   out_matrix_1_t Q,
   out_matrix_2_t R_tmp,
   out_matrix_3_t R)

--- a/D1673/P1673.md
+++ b/D1673/P1673.md
@@ -366,7 +366,7 @@ toc: true
 
     * Changes suggested by SG6 small group review on 2022/06/09
 
-        * Make existing exposition-only function `conj-if-needed`
+        * Make existing exposition-only function _`conj-if-needed`_
 	          use `conj` if it can find it via unqualified (ADL-only) lookup,
 	          otherwise be the identity.
 	          Make it a function object instead of a function,
@@ -3404,16 +3404,16 @@ template<class Triangle,
          class StorageOrder>
 class layout_blas_packed;
 
-// [linalg.scaled.conj], exposition-only function object <it>conj-if-needed</it>
+// [linalg.scaled.conj], exposition-only function object @_conj-if-needed_@
 
-/* see-below */ <it>conj-if-needed</it>;
+/* see-below */ @_conj-if-needed_@;
 
 // [linalg.scaled.base], exposition-only function and class templates
 
-class proxy_reference_base; // <it>exposition only</it>
+class @_proxy-reference-base_@; // <it>exposition only</it>
 
 template<class Reference, class Value, class Derived>
-class proxy_reference; // <it>exposition only</it>
+class @_proxy-reference_@; // <it>exposition only</it>
 
 // [linalg.scaled.accessor_scaled], class template accessor_scaled
 
@@ -5457,7 +5457,7 @@ run-time value(s) of the relevant BLAS function arguments (e.g.,
 
 ### Exposition-only function object _`conj-if-needed`_ [linalg.scaled.conj]
 
-The name `_conj-if-needed_` denotes an exposition-only function object.
+The name _`conj-if-needed`_ denotes an exposition-only function object.
 The expression _`conj-if-needed`_`(E)` for subexpression `E`
 is expression-equivalent to:
 
@@ -5480,25 +5480,25 @@ The `E` case presumes that a type without a `conj` function is noncomplex,
 so that the conjugate is the identity.
 --*end note]*
 
-### Exposition-only class templates `proxy_reference_base` and `proxy_reference` [linalg.scaled.base]
+### Exposition-only class templates _`proxy-reference-base`_ and _`proxy-reference`_ [linalg.scaled.base]
 
-The exposition-only class `proxy_reference_base` is a tag
+The exposition-only class _`proxy-reference-base`_ is a tag
 to identify whether a class is a specialization of either
-`scaled_scalar` **[linalg.scaled.accessor_scaled]** or
-`conjugated_scalar` **[linalg.scaled.accessor_conjugated]**.
+_`scaled-scalar`_ **[linalg.scaled.accessor_scaled]** or
+_`conjugated-scalar`_ **[linalg.scaled.accessor_conjugated]**.
 
-The exposition-only class template `proxy_reference`
+The exposition-only class template _`proxy-reference`_
 is part of the implementation of 
-`scaled_scalar` **[linalg.scaled.accessor_scaled]** and
-`conjugated_scalar` **[linalg.scaled.accessor_conjugated]**.
+_`scaled-scalar`_ **[linalg.scaled.accessor_scaled]** and
+_`conjugated-scalar`_ **[linalg.scaled.accessor_conjugated]**.
 
 ```c++
-class proxy_reference_base {}; // exposition only
+class @_proxy-reference-base_@ {}; // exposition only
 
 template<class Reference, class Value, class Derived>
-class proxy_reference : public proxy_reference_base { // exposition only
+class @_proxy-reference_@ : public @_proxy-reference-base_@ { // exposition only
 private:
-  using this_type = proxy_reference<Reference, Value, Derived>;
+  using this_type = @_proxy-reference_@<Reference, Value, Derived>;
   
   Reference reference_;
 
@@ -5507,7 +5507,7 @@ public:
   using value_type = Value;
   using derived_type = Derived;
 
-  constexpr explicit proxy_reference(Reference reference) : reference_(reference) {}
+  constexpr explicit @_proxy-reference_@(Reference reference) : reference_(reference) {}
 
   constexpr operator value_type() const {
     return static_cast<const Derived&>(*this).to_value(reference_);
@@ -5518,69 +5518,69 @@ public:
     return -value_type(cs);
   }
 
-  template<class Rhs, enable_if_t<is_base_of_v<proxy_reference_base, Rhs>, bool> = true>
+  template<class Rhs, enable_if_t<is_base_of_v<@_proxy-reference-base_@, Rhs>, bool> = true>
   constexpr friend auto operator+ (derived_type lhs, Rhs rhs)
   {
     using rhs_value_type = typename Rhs::value_type; // exposition only
     return value_type(lhs) + rhs_value_type(rhs);
   }
-  template<class Rhs, enable_if_t<! is_base_of_v<proxy_reference_base, Rhs>, bool> = true>
+  template<class Rhs, enable_if_t<! is_base_of_v<@_proxy-reference-base_@, Rhs>, bool> = true>
   constexpr friend auto operator+ (derived_type lhs, Rhs rhs)
   {
     return value_type(lhs) + rhs;
   }
-  template<class Lhs, enable_if_t<! is_base_of_v<proxy_reference_base, Lhs>, bool> = true>
+  template<class Lhs, enable_if_t<! is_base_of_v<@_proxy-reference-base_@, Lhs>, bool> = true>
   constexpr friend auto operator+ (Lhs lhs, derived_type rhs)
   {
     return lhs + value_type(rhs);
   }
 
-  template<class Rhs, enable_if_t<is_base_of_v<proxy_reference_base, Rhs>, bool> = true>
+  template<class Rhs, enable_if_t<is_base_of_v<@_proxy-reference-base_@, Rhs>, bool> = true>
   constexpr friend auto operator- (derived_type lhs, Rhs rhs)
   {
     using rhs_value_type = typename Rhs::value_type; // exposition only
     return value_type(lhs) - rhs_value_type(rhs);
   }
-  template<class Rhs, enable_if_t<! is_base_of_v<proxy_reference_base, Rhs>, bool> = true>
+  template<class Rhs, enable_if_t<! is_base_of_v<@_proxy-reference-base_@, Rhs>, bool> = true>
   constexpr friend auto operator- (derived_type lhs, Rhs rhs)
   {
     return value_type(lhs) - rhs;
   }
-  template<class Lhs, enable_if_t<! is_base_of_v<proxy_reference_base, Lhs>, bool> = true>
+  template<class Lhs, enable_if_t<! is_base_of_v<@_proxy-reference-base_@, Lhs>, bool> = true>
   constexpr friend auto operator- (Lhs lhs, derived_type rhs)
   {
     return lhs - value_type(rhs);
   }
 
-  template<class Rhs, enable_if_t<is_base_of_v<proxy_reference_base, Rhs>, bool> = true>
+  template<class Rhs, enable_if_t<is_base_of_v<@_proxy-reference-base_@, Rhs>, bool> = true>
   constexpr friend auto operator* (derived_type lhs, Rhs rhs)
   {
     using rhs_value_type = typename Rhs::value_type; // exposition only
     return value_type(lhs) * rhs_value_type(rhs);
   }
-  template<class Rhs, enable_if_t<! is_base_of_v<proxy_reference_base, Rhs>, bool> = true>
+  template<class Rhs, enable_if_t<! is_base_of_v<@_proxy-reference-base_@, Rhs>, bool> = true>
   constexpr friend auto operator* (derived_type lhs, Rhs rhs)
   {
     return value_type(lhs) * rhs;
   }
-  template<class Lhs, enable_if_t<! is_base_of_v<proxy_reference_base, Lhs>, bool> = true>
+  template<class Lhs, enable_if_t<! is_base_of_v<@_proxy-reference-base_@, Lhs>, bool> = true>
   constexpr friend auto operator* (Lhs lhs, derived_type rhs)
   {
     return lhs * value_type(rhs);
   }
 
-  template<class Rhs, enable_if_t<is_base_of_v<proxy_reference_base, Rhs>, bool> = true>
+  template<class Rhs, enable_if_t<is_base_of_v<@_proxy-reference-base_@, Rhs>, bool> = true>
   constexpr friend auto operator/ (derived_type lhs, Rhs rhs)
   {
     using rhs_value_type = typename Rhs::value_type; // exposition only
     return value_type(lhs) / rhs_value_type(rhs);
   }
-  template<class Rhs, enable_if_t<! is_base_of_v<proxy_reference_base, Rhs>, bool> = true>
+  template<class Rhs, enable_if_t<! is_base_of_v<@_proxy-reference-base_@, Rhs>, bool> = true>
   constexpr friend auto operator/ (derived_type lhs, Rhs rhs)
   {
     return value_type(lhs) / rhs;
   }
-  template<class Lhs, enable_if_t<! is_base_of_v<proxy_reference_base, Lhs>, bool> = true>
+  template<class Lhs, enable_if_t<! is_base_of_v<@_proxy-reference-base_@, Lhs>, bool> = true>
   constexpr friend auto operator/ (Lhs lhs, derived_type rhs)
   {
     return lhs / value_type(rhs);
@@ -5697,39 +5697,39 @@ for which the number's imaginary part is zero
 constexpr friend auto conj(const derived_type& x);
 ```
 
-* *Effects:* Equivalent to `return `_`conj-if-needed`_`(x);`.
+* *Effects:* Equivalent to `return` _`conj-if-needed`_`(x);`.
 
-### Exposition-only class template `scaled_scalar`
+### Exposition-only class template _`scaled-scalar`_
 
-The exposition-only class template `scaled_scalar` represents a
+The exposition-only class template _`scaled-scalar`_ represents a
 read-only value, which is the product of a fixed value (the "scaling
 factor") and the value of a reference to an element of a
 `mdspan`.  *[Note:* The value is read only to avoid confusion
 with the definition of "assigning to a scaled scalar."  --*end note]*
-`scaled_scalar` is part of the implementation of `accessor_scaled`
+_`scaled-scalar`_ is part of the implementation of `accessor_scaled`
 **[linalg.scaled.accessor_scaled]**.
 
 ```c++
 template<class ScalingFactor, class ReferenceValue>
-concept <it>scalable</it> = // exposition only
+concept @_scalable_@ = // exposition only
 requires {
   { declval<ScalingFactor>() * declval<ReferenceValue>() };
 };
 
 template<class ScalingFactor, class Reference, class ReferenceValue>
-class scaled_scalar : // exposition only
-  public proxy_reference<Reference, ReferenceValue,
-    scaled_scalar<ScalingFactor, Reference, ReferenceValue>>
+class @_scaled-scalar_@ : // exposition only
+  public @_proxy-reference_@<Reference, ReferenceValue,
+    @_scaled-scalar_@<ScalingFactor, Reference, ReferenceValue>>
 {
 private:
-  ScalingFactor scaling_factor_;
+  ScalingFactor @_scaling-factor_@; // exposition only
 
-  using my_type = scaled_scalar<ScalingFactor, Reference, ReferenceValue>; // exposition only
-  using base_type = proxy_reference<Reference, ReferenceValue, my_type>; // exposition only
+  using @_my-type_@ = @_scaled-scalar_@<ScalingFactor, Reference, ReferenceValue>; // exposition only
+  using base_type = @_proxy-reference_@<Reference, ReferenceValue, @_my-type_@>; // exposition only
 public:
-  explicit scaled_scalar(const ScalingFactor& scaling_factor, const Reference& reference);
+  explicit @_scaled-scalar_@(const ScalingFactor& scaling_factor, const Reference& reference);
 
-  using value_type = decltype(scaling_factor_ * ReferenceValue(declval<Reference>()));
+  using value_type = decltype(@_scaling-factor_@ * ReferenceValue(declval<Reference>()));
   value_type to_value(Reference reference) const;
 };
 ```
@@ -5763,17 +5763,13 @@ explicit scaled_scalar(const ScalingFactor& scaling_factor, const Reference& ref
 
     * Direct non-list-initializes `static_cast<base_type&>(*this)` with `reference`, and
 
-    * direct non-list-initializes `scaling_factor_` with `scaling_factor`.
+    * direct non-list-initializes _`scaling-factor`_ with `scaling_factor`.
 
 ```c++
 value_type to_value(Reference reference) const;
 ```
 
-*Effects:* Equivalent to `return scaling_factor_ * ReferenceValue(reference);`.
-
-The class template `accessor_scaled` is an `mdspan` accessor
-policy whose reference type represents the product of a scaling factor
-and its nested `mdspan` accessor's reference.
+*Effects:* Equivalent to `return` _`scaling-factor`_ ` * ReferenceValue(reference);`.
 
 ### Class template `accessor_scaled` [linalg.scaled.accessor_scaled]
 
@@ -5806,8 +5802,8 @@ public:
   constexpr Accessor nested_accessor() const;
 
 private:
-  ScalingFactor scaling_factor_; // exposition only
-  Accessor accessor_; // exposition only
+  ScalingFactor @_scaling-factor_@; // exposition only
+  Accessor @_nested-accessor_@; // exposition only
 };
 ```
 
@@ -5823,34 +5819,34 @@ constexpr accessor_scaled(const ScalingFactor& s, const Accessor& a);
 
 *Effects:*
 
-    * Direct non-list-initializes `scaling_factor_` with `s`, and
+    * Direct non-list-initializes _`scaling-factor`_ with `s`, and
 
-    * direct non-list-initializes `accessor_` with `a`.
+    * direct non-list-initializes _`nested-accessor`_ with `a`.
 
 ```c++
 constexpr reference access(data_handle_type p, size_t i) const noexcept;
 ```
 
-*Effects:* Equivalent to `return reference(scaling_factor_, accessor_.access(p, i));`.
+*Effects:* Equivalent to `return reference(`_`scaling-factor`_`,` _`nested-accessor`_`.access(p, i));`.
 
 ```c++
 constexpr offset_policy::data_handle_type
 offset(data_handle_type p, size_t i) const noexcept;
 ```
 
-*Effects:* Equivalent to `return accessor_.offset(p, i);`.
+*Effects:* Equivalent to `return` _`nested-accessor`_`.offset(p, i);`.
 
 ```c++
 constexpr ScalingFactor scaling_factor() const;
 ```
 
-*Effects:* Equivalent to `return scaling_factor_;`.
+*Effects:* Equivalent to `return` _`scaling-factor`_`;`.
 
 ```c++
 constexpr Accessor nested_accessor() const;
 ```
 
-*Effects:* Equivalent to `return accessor_;`.
+*Effects:* Equivalent to `return` _`nested-accessor`_`;`.
 
 ### `scaled` [linalg.scaled.scaled]
 
@@ -5920,33 +5916,33 @@ BLAS function.
 
 --*end note]*
 
-### Exposition-only class template `conjugated_scalar`
+### Exposition-only class template _`conjugated-scalar`_
 
-The exposition-only class template `conjugated_scalar` represents a
+The exposition-only class template _`conjugated-scalar`_ represents a
 read-only value, which is the complex conjugate of the value of a
 reference to an element of an `mdspan`.  *[Note:* The value is
 read only to avoid confusion with the definition of "assigning to the
-conjugate of a scalar."  --*end note]* `conjugated_scalar` is part of
+conjugate of a scalar."  --*end note]* _`conjugated-scalar`_ is part of
 the implementation of `accessor_conjugate`
 **[linalg.conj.accessor_conjugate]**.
 
 ```c++
 template<class ReferenceValue>
-concept <it>conjugatable</it> = // exposition only
+concept @_conjugatable_@ = // exposition only
 requires {
-  { <it>conj-if-needed</it>(declval<ReferenceValue>()) } -> same_as<ReferenceValue>;
+  { @_conj-if-needed_@(declval<ReferenceValue>()) } -> same_as<ReferenceValue>;
 };
 
 template<class Reference, class ReferenceValue>
-class conjugated_scalar : // exposition only
-  public proxy_reference<Reference, ReferenceValue, conjugated_scalar<Reference, ReferenceValue>>
+class @_conjugated-scalar_@ : // exposition only
+  public @_proxy-reference_@<Reference, ReferenceValue, @_conjugated-scalar_@<Reference, ReferenceValue>>
 {
 private:
-  using my_type = conjugated_scalar<Reference, ReferenceValue>; // exposition only
-  using base_type = proxy_reference<Reference, ReferenceValue, my_type>; // exposition only
+  using @_my-type_@ = @_conjugated-scalar_@<Reference, ReferenceValue>; // exposition only
+  using base_type = @_proxy-reference_@<Reference, ReferenceValue, @_my-type_@>; // exposition only
 
 public:
-  constexpr explicit conjugated_scalar(Reference reference);
+  constexpr explicit @_conjugated-scalar_@(Reference reference);
 
   using value_type = /* see below */;
   constexpr static auto to_value(Reference reference);
@@ -5964,7 +5960,7 @@ using value_type = /* see below */;
 `value_type` names the type `decltype(`_`conj-if-needed`_`(ReferenceValue(declval<Reference>())))`.
 
 ```c++
-constexpr explicit conjugated_scalar(Reference reference);
+constexpr explicit @_conjugated-scalar_@(Reference reference);
 ```
 
 * *Effects:* Initializes `base_type` with `reference`.
@@ -5989,7 +5985,7 @@ It is part of the implementation of `conjugated`
 template<class Accessor>
 class accessor_conjugate {
 private:
-  Accessor acc_; // exposition only
+  Accessor @_nested-accessor_@; // exposition only
 
 public:
   using reference     = /* see below */;
@@ -6000,11 +5996,11 @@ public:
   constexpr accessor_conjugate(Accessor a);
 
   constexpr reference access(data_handle_type p, size_t i) const
-    noexcept(noexcept(reference(acc_.access(p, i))));
+    noexcept(noexcept(reference(@_nested-accessor_@.access(p, i))));
 
   constexpr typename offset_policy::data_handle_type
     offset(data_handle_type p, size_t i) const
-      noexcept(noexcept(acc_.offset(p, i)));
+      noexcept(noexcept(@_nested-accessor_@.offset(p, i)));
 
   constexpr Accessor nested_accessor() const;
 };
@@ -6021,7 +6017,7 @@ This names
 * `typename Accessor::reference`,
     if `remove_cv_t<typename Accessor::element_type>` is an arithmetic type;
 
-* otherwise, `conjugated_scalar<typename Accessor::reference, remove_cv_t<typename Accessor::element_type>>`.
+* otherwise, _`conjugated-scalar`_`<typename Accessor::reference, remove_cv_t<typename Accessor::element_type>>`.
 
 ```c++
 using element_type = /* see below */
@@ -6053,28 +6049,28 @@ This names
 constexpr accessor_conjugate(Accessor a);
 ```
 
-* *Effects:* Direct non-list-initializes `acc_` with `a`.
+* *Effects:* Direct non-list-initializes _`nested-accessor`_ with `a`.
 
 ```c++
 constexpr reference access(data_handle_type p, size_t i) const
-  noexcept(noexcept(reference(acc_.access(p, i))));
+  noexcept(noexcept(reference(@_nested-accessor_@.access(p, i))));
 ```
 
-* *Effects:* Equivalent to `return reference(acc_.access(p, i));`.
+* *Effects:* Equivalent to `return reference(`_`nested-accessor`_`.access(p, i));`.
 
 ```c++
 constexpr typename offset_policy::data_handle_type
   offset(data_handle_type p, size_t i) const
-    noexcept(noexcept(acc_.offset(p, i)));
+    noexcept(noexcept(@_nested-accessor_@.offset(p, i)));
 ```
 
-* *Effects:* Equivalent to `return acc_.offset(p, i);`.
+* *Effects:* Equivalent to `return` _`nested-accessor`_`.offset(p, i);`.
 
 ```c++
 constexpr Accessor nested_accessor() const;
 ```
 
-* *Effects:* Equivalent to `return acc_;`.
+* *Effects:* Equivalent to `return` _`nested-accessor`_`;`.
 
 ### `conjugated` [linalg.conj.conjugated]
 
@@ -6181,11 +6177,11 @@ of any unique `mdspan` layout mapping policy.
 
 ```c++
 template<class InputExtents>
-using transpose_extents_t = /* see below */; // exposition only
+using @_transpose-extents-t_@ = /* see below */; // exposition only
 ```
 
 For `InputExtents` a specialization of `extents`,
-`transpose_extents_t<InputExtents>` names the `extents` type
+_`transpose-extents-t`_`<InputExtents>` names the `extents` type
 `OutputExtents` such that
 
 * `InputExtents::static_extent(InputExtents::rank()-1)` equals
@@ -6204,8 +6200,8 @@ For `InputExtents` a specialization of `extents`,
 
 ```c++
 template<class InputExtents>
-constexpr transpose_extents_t<InputExtents>
-transpose_extents(const InputExtents& in); // exposition only
+constexpr @_transpose-extents-t_@<InputExtents>
+@_transpose-extents_@(const InputExtents& in); // exposition only
 ```
 
 * *Constraints:* `InputExtents::rank()` equals 2.
@@ -6227,7 +6223,7 @@ public:
   private:
     using nested_mapping_type =
       typename Layout::template mapping<
-        transpose_extents_t<Extents>>; // exposition only
+        @_transpose-extents-t_@<Extents>>; // exposition only
     nested_mapping_type nested_mapping_; // exposition only
 
   public:
@@ -6286,7 +6282,7 @@ constexpr extents_type extents() const
 ```
 
 * *Effects:* Equivalent to
-    `return transpose_extents(nested_mapping_.extents());`.
+    `return` _`transpose-extents`_`(nested_mapping_.extents());`.
 
 ```c++
 constexpr size_type required_span_size() const
@@ -6399,7 +6395,7 @@ constexpr auto transposed(
   mdspan<ElementType, Extents, Layout, Accessor> a);
 ```
 
-Let `ReturnExtents` name the type `transpose_extents_t<Extents>`.
+Let `ReturnExtents` name the type _`transpose-extents-t`_`<Extents>`.
 Let `R` name the type
 `mdspan<ReturnElementType, ReturnExtents, ReturnLayout, ReturnAccessor>`,
 where
@@ -6464,7 +6460,7 @@ where
         then equivalent to
 ```c++
 return R(a.data(),
-  ReturnMapping(transpose_extents(a.mapping().extents())),
+  ReturnMapping(@_transpose-extents_@(a.mapping().extents())),
   a.accessor());
 ```
 
@@ -6473,7 +6469,7 @@ return R(a.data(),
 ```c++
 return R(a.data(),
   ReturnMapping(
-    transpose_extents(a.mapping().extents()),
+    @_transpose-extents_@(a.mapping().extents()),
     a.mapping().stride(1)),
   a.accessor());
 ```
@@ -6483,7 +6479,7 @@ return R(a.data(),
 ```c++
 return R(a.data(),
   ReturnMapping(
-    transpose_extents(a.mapping().extents()),
+    @_transpose-extents_@(a.mapping().extents()),
     a.mapping().stride(0)),
   a.accessor());
 ```
@@ -6493,7 +6489,7 @@ return R(a.data(),
 ```c++
 return R(a.data(),
   ReturnMapping(
-    transpose_extents(a.mapping().extents()),
+    @_transpose-extents_@(a.mapping().extents()),
     array<decltype(), a.mapping().rank()>{
       a.mapping().stride(1),
       a.mapping().stride(0)}),

--- a/D1673/P1673.md
+++ b/D1673/P1673.md
@@ -432,6 +432,10 @@ toc: true
 
   * Change from name-based requirements (`in_{vector,matrix,object}*_t`)
       to exposition-only concepts (following LEWG feedback).
+      Remove the requirement that
+      vector / matrix / object template parameters
+      may deduce a `const` lvalue reference
+      or a (non-`const`) rvalue reference to an `mdspan`.
 
   * Fix `dot` Remarks to include both vector types
       and to use `value_type` instead of `element_type`.
@@ -3836,126 +3840,126 @@ auto matrix_inf_norm(
 // general matrix-vector product
 template<in_vector InVec,
          in_matrix InMat,
-         class out_vector_t>
+         out_vector OutVec>
 void matrix_vector_product(InMat A,
                            InVec x,
-                           out_vector_t y);
+                           OutVec y);
 template<class ExecutionPolicy,
          in_vector InVec,
          in_matrix InMat,
-         class out_vector_t>
+         out_vector OutVec>
 void matrix_vector_product(ExecutionPolicy&& exec,
                            InMat A,
                            InVec x,
-                           out_vector_t y);
+                           OutVec y);
 template<in_vector InVec1,
          in_matrix InMat,
          in_vector InVec2,
-         class out_vector_t>
+         out_vector OutVec>
 void matrix_vector_product(InMat A,
                            InVec1 x,
                            InVec2 y,
-                           out_vector_t z);
+                           OutVec z);
 template<class ExecutionPolicy,
          in_vector InVec1,
          in_matrix InMat,
          in_vector InVec2,
-         class out_vector_t>
+         out_vector OutVec>
 void matrix_vector_product(ExecutionPolicy&& exec,
                            InMat A,
                            InVec1 x,
                            InVec2 y,
-                           out_vector_t z);
+                           OutVec z);
 
 // [linalg.algs.blas2.symv],
 // symmetric matrix-vector product
 template<in_matrix InMat,
          class Triangle,
          in_vector InVec,
-         class out_vector_t>
+         out_vector OutVec>
 void symmetric_matrix_vector_product(InMat A,
                                      Triangle t,
                                      InVec x,
-                                     out_vector_t y);
+                                     OutVec y);
 template<class ExecutionPolicy,
          in_matrix InMat,
          class Triangle,
          in_vector InVec,
-         class out_vector_t>
+         out_vector OutVec>
 void symmetric_matrix_vector_product(ExecutionPolicy&& exec,
                                      InMat A,
                                      Triangle t,
                                      InVec x,
-                                     out_vector_t y);
+                                     OutVec y);
 template<in_matrix InMat,
          class Triangle,
          in_vector InVec1,
          in_vector InVec2,
-         class out_vector_t>
+         out_vector OutVec>
 void symmetric_matrix_vector_product(
   InMat A,
   Triangle t,
   InVec1 x,
   InVec2 y,
-  out_vector_t z);
+  OutVec z);
 
 template<class ExecutionPolicy,
          in_matrix InMat,
          class Triangle,
          in_vector InVec1,
          in_vector InVec2,
-         class out_vector_t>
+         out_vector OutVec>
 void symmetric_matrix_vector_product(
   ExecutionPolicy&& exec,
   InMat A,
   Triangle t,
   InVec1 x,
   InVec2 y,
-  out_vector_t z);
+  OutVec z);
 
 // [linalg.algs.blas2.hemv],
 // Hermitian matrix-vector product
 template<in_matrix InMat,
          class Triangle,
          in_vector InVec,
-         class out_vector_t>
+         out_vector OutVec>
 void hermitian_matrix_vector_product(InMat A,
                                      Triangle t,
                                      InVec x,
-                                     out_vector_t y);
+                                     OutVec y);
 template<class ExecutionPolicy,
          in_matrix InMat,
          class Triangle,
          in_vector InVec,
-         class out_vector_t>
+         out_vector OutVec>
 void hermitian_matrix_vector_product(ExecutionPolicy&& exec,
                                      InMat A,
                                      Triangle t,
                                      InVec x,
-                                     out_vector_t y);
+                                     OutVec y);
 template<in_matrix InMat,
          class Triangle,
          in_vector InVec1,
          in_vector InVec2,
-         class out_vector_t>
+         out_vector OutVec>
 void hermitian_matrix_vector_product(InMat A,
                                      Triangle t,
                                      InVec1 x,
                                      InVec2 y,
-                                     out_vector_t z);
+                                     OutVec z);
 
 template<class ExecutionPolicy,
          in_matrix InMat,
          class Triangle,
          in_vector InVec1,
          in_vector InVec2,
-         class out_vector_t>
+         out_vector OutVec>
 void hermitian_matrix_vector_product(ExecutionPolicy&& exec,
                                      InMat A,
                                      Triangle t,
                                      InVec1 x,
                                      InVec2 y,
-                                     out_vector_t z);
+                                     OutVec z);
 
 // [linalg.algs.blas2.trmv],
 // Triangular matrix-vector product
@@ -3966,26 +3970,26 @@ template<in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
          in_vector InVec,
-         class out_vector_t>
+         out_vector OutVec>
 void triangular_matrix_vector_product(
   InMat A,
   Triangle t,
   DiagonalStorage d,
   InVec x,
-  out_vector_t y);
+  OutVec y);
 template<class ExecutionPolicy,
          in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
          in_vector InVec,
-         class out_vector_t>
+         out_vector OutVec>
 void triangular_matrix_vector_product(
   ExecutionPolicy&& exec,
   InMat A,
   Triangle t,
   DiagonalStorage d,
   InVec x,
-  out_vector_t y);
+  OutVec y);
 
 // [linalg.algs.blas2.trmv.in-place],
 // In-place triangular matrix-vector product
@@ -4017,27 +4021,27 @@ template<in_matrix InMat,
          class DiagonalStorage,
          in_vector InVec1,
          in_vector InVec2,
-         class out_vector_t>
+         out_vector OutVec>
 void triangular_matrix_vector_product(InMat A,
                                       Triangle t,
                                       DiagonalStorage d,
                                       InVec1 x,
                                       InVec2 y,
-                                      out_vector_t z);
+                                      OutVec z);
 template<class ExecutionPolicy,
          in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
          in_vector InVec1,
          in_vector InVec2,
-         class out_vector_t>
+         out_vector OutVec>
 void triangular_matrix_vector_product(ExecutionPolicy&& exec,
                                       InMat A,
                                       Triangle t,
                                       DiagonalStorage d,
                                       InVec1 x,
                                       InVec2 y,
-                                      out_vector_t z);
+                                      OutVec z);
 
 // [linalg.algs.blas2.trsv],
 // Solve a triangular linear system
@@ -4048,21 +4052,21 @@ template<in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
          in_vector InVec,
-         class out_vector_t,
+         out_vector OutVec,
          class BinaryDivideOp>
 void triangular_matrix_vector_solve(
   InMat A,
   Triangle t,
   DiagonalStorage d,
   InVec b,
-  out_vector_t x,
+  OutVec x,
   BinaryDivideOp divide);
 template<class ExecutionPolicy,
          in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
          in_vector InVec,
-         class out_vector_t,
+         out_vector OutVec,
          class BinaryDivideOp>
 void triangular_matrix_vector_solve(
   ExecutionPolicy&& exec,
@@ -4070,32 +4074,32 @@ void triangular_matrix_vector_solve(
   Triangle t,
   DiagonalStorage d,
   InVec b,
-  out_vector_t x,
+  OutVec x,
   BinaryDivideOp divide);
 template<in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
          in_vector InVec,
-         class out_vector_t>
+         out_vector OutVec>
 void triangular_matrix_vector_solve(
   InMat A,
   Triangle t,
   DiagonalStorage d,
   InVec b,
-  out_vector_t x);
+  OutVec x);
 template<class ExecutionPolicy,
          in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
          in_vector InVec,
-         class out_vector_t>
+         out_vector OutVec>
 void triangular_matrix_vector_solve(
   ExecutionPolicy&& exec,
   InMat A,
   Triangle t,
   DiagonalStorage d,
   InVec b,
-  out_vector_t x);
+  OutVec x);
 
 // [linalg.algs.blas2.trsv.in-place],
 // Solve a triangular linear system, in place
@@ -4308,37 +4312,37 @@ void hermitian_matrix_rank_2_update(
 
 // [linalg.algs.blas3.gemm],
 // general matrix-matrix product
-template<class in_matrix_1_t,
-         class in_matrix_2_t,
+template<in_matrix InMat1,
+         in_matrix InMat2,
          out_matrix OutMat>
-void matrix_product(in_matrix_1_t A,
-                    in_matrix_2_t B,
+void matrix_product(InMat1 A,
+                    InMat2 B,
                     OutMat C);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
-         class in_matrix_2_t,
+         in_matrix InMat1,
+         in_matrix InMat2,
          out_matrix OutMat>
 void matrix_product(ExecutionPolicy&& exec,
-                    in_matrix_1_t A,
-                    in_matrix_2_t B,
+                    InMat1 A,
+                    InMat2 B,
                     OutMat C);
-template<class in_matrix_1_t,
-         class in_matrix_2_t,
-         class in_matrix_3_t,
+template<in_matrix InMat1,
+         in_matrix InMat2,
+         in_matrix InMat3,
          out_matrix OutMat>
-void matrix_product(in_matrix_1_t A,
-                    in_matrix_2_t B,
-                    in_matrix_3_t E,
+void matrix_product(InMat1 A,
+                    InMat2 B,
+                    InMat3 E,
                     OutMat C);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
-         class in_matrix_2_t,
-         class in_matrix_3_t,
+         in_matrix InMat1,
+         in_matrix InMat2,
+         in_matrix InMat3,
          out_matrix OutMat>
 void matrix_product(ExecutionPolicy&& exec,
-                    in_matrix_1_t A,
-                    in_matrix_2_t B,
-                    in_matrix_3_t E,
+                    InMat1 A,
+                    InMat2 B,
+                    InMat3 E,
                     OutMat C);
 
 // [linalg.algs.blas3.symm],
@@ -4346,102 +4350,102 @@ void matrix_product(ExecutionPolicy&& exec,
 
 // [linalg.algs.blas3.symm.ov.left],
 // overwriting symmetric matrix-matrix left product
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
-         class in_matrix_2_t,
+         in_matrix InMat2,
          out_matrix OutMat>
 void symmetric_matrix_left_product(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
-  in_matrix_2_t B,
+  InMat2 B,
   OutMat C);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
-         class in_matrix_2_t,
+         in_matrix InMat2,
          out_matrix OutMat>
 void symmetric_matrix_left_product(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
-  in_matrix_2_t B,
+  InMat2 B,
   OutMat C);
 
 // [linalg.algs.blas3.symm.ov.right],
 // overwriting symmetric matrix-matrix right product
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
-         class in_matrix_2_t,
+         in_matrix InMat2,
          out_matrix OutMat>
 void symmetric_matrix_right_product(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
-  in_matrix_2_t B,
+  InMat2 B,
   OutMat C);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
-         class in_matrix_2_t,
+         in_matrix InMat2,
          out_matrix OutMat>
 void symmetric_matrix_right_product(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
-  in_matrix_2_t B,
+  InMat2 B,
   OutMat C);
 
 // [linalg.algs.blas3.symm.up.left],
 // updating symmetric matrix-matrix left product
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
-         class in_matrix_2_t,
-         class in_matrix_3_t,
+         in_matrix InMat2,
+         in_matrix InMat3,
          out_matrix OutMat>
 void symmetric_matrix_left_product(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
-  in_matrix_2_t B,
-  in_matrix_3_t E,
+  InMat2 B,
+  InMat3 E,
   OutMat C);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
-         class in_matrix_2_t,
-         class in_matrix_3_t,
+         in_matrix InMat2,
+         in_matrix InMat3,
          out_matrix OutMat>
 void symmetric_matrix_left_product(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
-  in_matrix_2_t B,
-  in_matrix_3_t E,
+  InMat2 B,
+  InMat3 E,
   OutMat C);
 
 // [linalg.algs.blas3.symm.up.right],
 // updating symmetric matrix-matrix right product
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
-         class in_matrix_2_t,
-         class in_matrix_3_t,
+         in_matrix InMat2,
+         in_matrix InMat3,
          out_matrix OutMat>
 void symmetric_matrix_right_product(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
-  in_matrix_2_t B,
-  in_matrix_3_t E,
+  InMat2 B,
+  InMat3 E,
   OutMat C);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
-         class in_matrix_2_t,
-         class in_matrix_3_t,
+         in_matrix InMat2,
+         in_matrix InMat3,
          out_matrix OutMat>
 void symmetric_matrix_right_product(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
-  in_matrix_2_t B,
-  in_matrix_3_t E,
+  InMat2 B,
+  InMat3 E,
   OutMat C);
 
 // [linalg.algs.blas3.hemm],
@@ -4449,102 +4453,102 @@ void symmetric_matrix_right_product(
 
 // [linalg.algs.blas3.hemm.ov.left],
 // overwriting Hermitian matrix-matrix left product
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
-         class in_matrix_2_t,
+         in_matrix InMat2,
          out_matrix OutMat>
 void hermitian_matrix_left_product(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
-  in_matrix_2_t B,
+  InMat2 B,
   OutMat C);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
-         class in_matrix_2_t,
+         in_matrix InMat2,
          out_matrix OutMat>
 void hermitian_matrix_left_product(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
-  in_matrix_2_t B,
+  InMat2 B,
   OutMat C);
 
 // [linalg.algs.blas3.hemm.ov.right],
 // overwriting Hermitian matrix-matrix right product
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
-         class in_matrix_2_t,
+         in_matrix InMat2,
          out_matrix OutMat>
 void hermitian_matrix_right_product(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
-  in_matrix_2_t B,
+  InMat2 B,
   OutMat C);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
-         class in_matrix_2_t,
+         in_matrix InMat2,
          out_matrix OutMat>
 void hermitian_matrix_right_product(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
-  in_matrix_2_t B,
+  InMat2 B,
   OutMat C);
 
 // [linalg.algs.blas3.hemm.up.left],
 // updating Hermitian matrix-matrix left product
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
-         class in_matrix_2_t,
-         class in_matrix_3_t,
+         in_matrix InMat2,
+         in_matrix InMat3,
          out_matrix OutMat>
 void hermitian_matrix_left_product(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
-  in_matrix_2_t B,
-  in_matrix_3_t E,
+  InMat2 B,
+  InMat3 E,
   OutMat C);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
-         class in_matrix_2_t,
-         class in_matrix_3_t,
+         in_matrix InMat2,
+         in_matrix InMat3,
          out_matrix OutMat>
 void hermitian_matrix_left_product(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
-  in_matrix_2_t B,
-  in_matrix_3_t E,
+  InMat2 B,
+  InMat3 E,
   OutMat C);
 
 // [linalg.algs.blas3.hemm.up.right],
 // updating Hermitian matrix-matrix right product
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
-         class in_matrix_2_t,
-         class in_matrix_3_t,
+         in_matrix InMat2,
+         in_matrix InMat3,
          out_matrix OutMat>
 void hermitian_matrix_right_product(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
-  in_matrix_2_t B,
-  in_matrix_3_t E,
+  InMat2 B,
+  InMat3 E,
   OutMat C);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
-         class in_matrix_2_t,
-         class in_matrix_3_t,
+         in_matrix InMat2,
+         in_matrix InMat3,
          out_matrix OutMat>
 void hermitian_matrix_right_product(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
-  in_matrix_2_t B,
-  in_matrix_3_t E,
+  InMat2 B,
+  InMat3 E,
   OutMat C);
 
 // [linalg.algs.blas3.trmm],
@@ -4552,249 +4556,249 @@ void hermitian_matrix_right_product(
 
 // [linalg.algs.blas3.trmm.ov.left],
 // overwriting triangular matrix-matrix left product
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         class in_matrix_2_t,
+         in_matrix InMat2,
          out_matrix OutMat>
 void triangular_matrix_left_product(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
-  in_matrix_2_t B,
+  InMat2 B,
   OutMat C);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         class in_matrix_2_t,
+         in_matrix InMat2,
          out_matrix OutMat>
 void triangular_matrix_left_product(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
-  in_matrix_2_t B,
+  InMat2 B,
   OutMat C);
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
          inout_matrix InOutMat>
 void triangular_matrix_left_product(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
   InOutMat C);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
          inout_matrix InOutMat>
 void triangular_matrix_left_product(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
   InOutMat C);
 
 // [linalg.algs.blas3.trmm.ov.right],
 // overwriting triangular matrix-matrix right product
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         class in_matrix_2_t,
+         in_matrix InMat2,
          out_matrix OutMat>
 void triangular_matrix_right_product(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
-  in_matrix_2_t B,
+  InMat2 B,
   OutMat C);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         class in_matrix_2_t,
+         in_matrix InMat2,
          out_matrix OutMat>
 void triangular_matrix_right_product(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
-  in_matrix_2_t B,
+  InMat2 B,
   OutMat C);
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
          inout_matrix InOutMat>
 void triangular_matrix_right_product(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
   InOutMat C);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
          inout_matrix InOutMat>
 void triangular_matrix_right_product(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
   InOutMat C);
 
 // [linalg.algs.blas3.trmm.up.left],
 // updating triangular matrix-matrix left product
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         class in_matrix_2_t,
-         class in_matrix_3_t,
+         in_matrix InMat2,
+         in_matrix InMat3,
          out_matrix OutMat>
 void triangular_matrix_left_product(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
-  in_matrix_2_t B,
-  in_matrix_3_t E,
+  InMat2 B,
+  InMat3 E,
   OutMat C);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         class in_matrix_2_t,
-         class in_matrix_3_t,
+         in_matrix InMat2,
+         in_matrix InMat3,
          out_matrix OutMat>
 void triangular_matrix_left_product(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
-  in_matrix_2_t B,
-  in_matrix_3_t E,
+  InMat2 B,
+  InMat3 E,
   OutMat C);
 
 // [linalg.algs.blas3.trmm.up.right],
 // updating triangular matrix-matrix right product
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         class in_matrix_2_t,
-         class in_matrix_3_t,
+         in_matrix InMat2,
+         in_matrix InMat3,
          out_matrix OutMat>
 void triangular_matrix_right_product(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
-  in_matrix_2_t B,
-  in_matrix_3_t E,
+  InMat2 B,
+  InMat3 E,
   OutMat C);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         class in_matrix_2_t,
-         class in_matrix_3_t,
+         in_matrix InMat2,
+         in_matrix InMat3,
          out_matrix OutMat>
 void triangular_matrix_right_product(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
-  in_matrix_2_t B,
-  in_matrix_3_t E,
+  InMat2 B,
+  InMat3 E,
   OutMat C);
 
 // [linalg.alg.blas3.rank-k.syrk],
 // rank-k symmetric matrix update
 template<class T,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          inout_matrix InOutMat,
          class Triangle>
 void symmetric_matrix_rank_k_update(
   T alpha,
-  in_matrix_1_t A,
+  InMat1 A,
   InOutMat C,
   Triangle t);
 template<class T,
          class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          inout_matrix InOutMat,
          class Triangle>
 void symmetric_matrix_rank_k_update(
   ExecutionPolicy&& exec,
   T alpha,
-  in_matrix_1_t A,
+  InMat1 A,
   InOutMat C,
   Triangle t);
 
 // [linalg.alg.blas3.rank-k.herk],
 // rank-k Hermitian matrix update
 template<class T,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          inout_matrix InOutMat,
          class Triangle>
 void hermitian_matrix_rank_k_update(
   T alpha,
-  in_matrix_1_t A,
+  InMat1 A,
   InOutMat C,
   Triangle t);
 template<class ExecutionPolicy,
          class T,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          inout_matrix InOutMat,
          class Triangle>
 void hermitian_matrix_rank_k_update(
   ExecutionPolicy&& exec,
   T alpha,
-  in_matrix_1_t A,
+  InMat1 A,
   InOutMat C,
   Triangle t);
 
 // [linalg.alg.blas3.rank2k.syr2k],
 // rank-2k symmetric matrix update
-template<class in_matrix_1_t,
-         class in_matrix_2_t,
+template<in_matrix InMat1,
+         in_matrix InMat2,
          inout_matrix InOutMat,
          class Triangle>
 void symmetric_matrix_rank_2k_update(
-  in_matrix_1_t A,
-  in_matrix_2_t B,
+  InMat1 A,
+  InMat2 B,
   InOutMat C,
   Triangle t);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
-         class in_matrix_2_t,
+         in_matrix InMat1,
+         in_matrix InMat2,
          inout_matrix InOutMat,
          class Triangle>
 void symmetric_matrix_rank_2k_update(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
-  in_matrix_2_t B,
+  InMat1 A,
+  InMat2 B,
   InOutMat C,
   Triangle t);
 
 // [linalg.alg.blas3.rank2k.her2k],
 // rank-2k Hermitian matrix update
-template<class in_matrix_1_t,
-         class in_matrix_2_t,
+template<in_matrix InMat1,
+         in_matrix InMat2,
          inout_matrix InOutMat,
          class Triangle>
 void hermitian_matrix_rank_2k_update(
-  in_matrix_1_t A,
-  in_matrix_2_t B,
+  InMat1 A,
+  InMat2 B,
   InOutMat C,
   Triangle t);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
-         class in_matrix_2_t,
+         in_matrix InMat1,
+         in_matrix InMat2,
          inout_matrix InOutMat,
          class Triangle>
 void hermitian_matrix_rank_2k_update(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
-  in_matrix_2_t B,
+  InMat1 A,
+  InMat2 B,
   InOutMat C,
   Triangle t);
 
@@ -4804,100 +4808,100 @@ void hermitian_matrix_rank_2k_update(
 // [linalg.alg.blas3.trsm.left],
 // solve multiple triangular linear systems
 // with triangular matrix on the left
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         class in_matrix_2_t,
+         in_matrix InMat2,
          out_matrix OutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_left_solve(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
-  in_matrix_2_t B,
+  InMat2 B,
   OutMat X,
   BinaryDivideOp divide);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         class in_matrix_2_t,
+         in_matrix InMat2,
          out_matrix OutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_left_solve(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
-  in_matrix_2_t B,
+  InMat2 B,
   OutMat X,
   BinaryDivideOp divide);
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
          inout_matrix InOutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_left_solve(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
   InOutMat B,
   BinaryDivideOp divide);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
          inout_matrix InOutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_left_solve(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
   InOutMat B,
   BinaryDivideOp divide);
 
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         class in_matrix_2_t,
+         in_matrix InMat2,
          out_matrix OutMat>
 void triangular_matrix_matrix_left_solve(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
-  in_matrix_2_t B,
+  InMat2 B,
   OutMat X);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         class in_matrix_2_t,
+         in_matrix InMat2,
          out_matrix OutMat>
 void triangular_matrix_matrix_left_solve(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
-  in_matrix_2_t B,
+  InMat2 B,
   OutMat X);
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
          inout_matrix InOutMat>
 void triangular_matrix_matrix_left_solve(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
   InOutMat B);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
          inout_matrix InOutMat>
 void triangular_matrix_matrix_left_solve(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
   InOutMat B);
@@ -4905,24 +4909,24 @@ void triangular_matrix_matrix_left_solve(
 // [linalg.alg.blas3.trsm.right],
 // solve multiple triangular linear systems
 // with triangular matrix on the right
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         class in_matrix_2_t,
+         in_matrix InMat2,
          out_matrix OutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_right_solve(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
-  in_matrix_2_t B,
+  InMat2 B,
   OutMat X,
   BinaryDivideOp divide);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         class in_matrix_2_t,
+         in_matrix InMat2,
          out_matrix OutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_right_solve(
@@ -4933,47 +4937,47 @@ void triangular_matrix_matrix_right_solve(
   InMat B,
   OutMat X,
   BinaryDivideOp divide);
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
          inout_matrix InOutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_right_solve(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
   InOutMat B,
   BinaryDivideOp divide);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
          inout_matrix InOutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_right_solve(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
   InOutMat B,
   BinaryDivideOp divide);
 
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         class in_matrix_2_t,
+         in_matrix InMat2,
          out_matrix OutMat>
 void triangular_matrix_matrix_right_solve(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
-  in_matrix_2_t B,
+  InMat2 B,
   OutMat X);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         class in_matrix_2_t,
+         in_matrix InMat2,
          out_matrix OutMat>
 void triangular_matrix_matrix_right_solve(
   ExecutionPolicy&& exec,
@@ -4982,23 +4986,23 @@ void triangular_matrix_matrix_right_solve(
   DiagonalStorage d,
   InMat B,
   OutMat X);
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
          inout_matrix InOutMat>
 void triangular_matrix_matrix_right_solve(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
   InOutMat B);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
          inout_matrix InOutMat>
 void triangular_matrix_matrix_right_solve(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
   InOutMat B);
@@ -6772,13 +6776,6 @@ or other things as appropriate.
 
 * `DiagonalStorage` is either `implicit_unit_diagonal_t` or `explicit_diagonal_t`.
 
-* `in_*_t` template parameters may deduce a `const` lvalue reference
-    or a (non-`const`) rvalue reference to an `mdspan`.
-
-* `inout_*_t` and `out_*_t` template parameters may deduce
-    a `const` lvalue reference to an `mdspan`, or
-    a (non-`const`) rvalue reference to an `mdspan`.
-
 * `BinaryDivideOp` template parameters
     are a binary function object (**[function.objects]**).
 
@@ -7659,19 +7656,19 @@ The following requirements apply to all functions in this section.
 ```c++
 template<in_vector InVec,
          in_matrix InMat,
-         class out_vector_t>
+         out_vector OutVec>
 void matrix_vector_product(InMat A,
                            InVec x,
-                           out_vector_t y);
+                           OutVec y);
 
 template<class ExecutionPolicy,
          in_vector InVec,
          in_matrix InMat,
-         class out_vector_t>
+         out_vector OutVec>
 void matrix_vector_product(ExecutionPolicy&& exec,
                            InMat A,
                            InVec x,
-                           out_vector_t y);
+                           OutVec y);
 ```
 
 * *Effects:* Computes $y$ such that $y = A x$.
@@ -7716,22 +7713,22 @@ void scaled_matvec_2(mdspan<double, extents<size_t, num_rows, num_cols>> A,
 template<in_vector InVec1,
          in_matrix InMat,
          in_vector InVec2,
-         class out_vector_t>
+         out_vector OutVec>
 void matrix_vector_product(InMat A,
                            InVec1 x,
                            InVec2 y,
-                           out_vector_t z);
+                           OutVec z);
 
 template<class ExecutionPolicy,
          in_vector InVec1,
          in_matrix InMat,
          in_vector InVec2,
-         class out_vector_t>
+         out_vector OutVec>
 void matrix_vector_product(ExecutionPolicy&& exec,
                            InMat A,
                            InVec1 x,
                            InVec2 y,
-                           out_vector_t z);
+                           OutVec z);
 ```
 
 * *Effects:* Computes $z$ such that $z = y + A x$.
@@ -7797,22 +7794,22 @@ The following requirements apply to all functions in this section.
 template<in_matrix InMat,
          class Triangle,
          in_vector InVec,
-         class out_vector_t>
+         out_vector OutVec>
 void symmetric_matrix_vector_product(InMat A,
                                      Triangle t,
                                      InVec x,
-                                     out_vector_t y);
+                                     OutVec y);
 
 template<class ExecutionPolicy,
          in_matrix InMat,
          class Triangle,
          in_vector InVec,
-         class out_vector_t>
+         out_vector OutVec>
 void symmetric_matrix_vector_product(ExecutionPolicy&& exec,
                                      InMat A,
                                      Triangle t,
                                      InVec x,
-                                     out_vector_t y);
+                                     OutVec y);
 ```
 
 * *Effects:* Computes $y$ such that $y = A x$.
@@ -7824,27 +7821,27 @@ template<in_matrix InMat,
          class Triangle,
          in_vector InVec1,
          in_vector InVec2,
-         class out_vector_t>
+         out_vector OutVec>
 void symmetric_matrix_vector_product(
   InMat A,
   Triangle t,
   InVec1 x,
   InVec2 y,
-  out_vector_t z);
+  OutVec z);
 
 template<class ExecutionPolicy,
          in_matrix InMat,
          class Triangle,
          in_vector InVec1,
          in_vector InVec2,
-         class out_vector_t>
+         out_vector OutVec>
 void symmetric_matrix_vector_product(
   ExecutionPolicy&& exec,
   InMat A,
   Triangle t,
   InVec1 x,
   InVec2 y,
-  out_vector_t z);
+  OutVec z);
 ```
 
 * *Effects:* Computes $z$ such that $z = y + A x$.
@@ -7910,22 +7907,22 @@ The following requirements apply to all functions in this section.
 template<in_matrix InMat,
          class Triangle,
          in_vector InVec,
-         class out_vector_t>
+         out_vector OutVec>
 void hermitian_matrix_vector_product(InMat A,
                                      Triangle t,
                                      InVec x,
-                                     out_vector_t y);
+                                     OutVec y);
 
 template<class ExecutionPolicy,
          in_matrix InMat,
          class Triangle,
          in_vector InVec,
-         class out_vector_t>
+         out_vector OutVec>
 void hermitian_matrix_vector_product(ExecutionPolicy&& exec,
                                      InMat A,
                                      Triangle t,
                                      InVec x,
-                                     out_vector_t y);
+                                     OutVec y);
 ```
 
 * *Effects:* Computes $y$ such that $y = A x$.
@@ -7937,25 +7934,25 @@ template<in_matrix InMat,
          class Triangle,
          in_vector InVec1,
          in_vector InVec2,
-         class out_vector_t>
+         out_vector OutVec>
 void hermitian_matrix_vector_product(InMat A,
                                      Triangle t,
                                      InVec1 x,
                                      InVec2 y,
-                                     out_vector_t z);
+                                     OutVec z);
 
 template<class ExecutionPolicy,
          in_matrix InMat,
          class Triangle,
          in_vector InVec1,
          in_vector InVec2,
-         class out_vector_t>
+         out_vector OutVec>
 void hermitian_matrix_vector_product(ExecutionPolicy&& exec,
                                      InMat A,
                                      Triangle t,
                                      InVec1 x,
                                      InVec2 y,
-                                     out_vector_t z);
+                                     OutVec z);
 ```
 
 * *Effects:* Computes $z$ such that $z = y + A x$.
@@ -8033,26 +8030,26 @@ template<in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
          in_vector InVec,
-         class out_vector_t>
+         out_vector OutVec>
 void triangular_matrix_vector_product(
   InMat A,
   Triangle t,
   DiagonalStorage d,
   InVec x,
-  out_vector_t y);
+  OutVec y);
 template<class ExecutionPolicy,
          in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
          in_vector InVec,
-         class out_vector_t>
+         out_vector OutVec>
 void triangular_matrix_vector_product(
   ExecutionPolicy&& exec,
   InMat A,
   Triangle t,
   DiagonalStorage d,
   InVec x,
-  out_vector_t y);
+  OutVec y);
 ```
 
 * *Effects:* Computes $y$ such that $y = A x$.
@@ -8107,13 +8104,13 @@ template<in_matrix InMat,
          class DiagonalStorage,
          in_vector InVec1,
          in_vector InVec2,
-         class out_vector_t>
+         out_vector OutVec>
 void triangular_matrix_vector_product(InMat A,
                                       Triangle t,
                                       DiagonalStorage d,
                                       InVec1 x,
                                       InVec2 y,
-                                      out_vector_t z);
+                                      OutVec z);
 
 template<class ExecutionPolicy,
          in_matrix InMat,
@@ -8121,14 +8118,14 @@ template<class ExecutionPolicy,
          class DiagonalStorage,
          in_vector InVec1,
          in_vector InVec2,
-         class out_vector_t>
+         out_vector OutVec>
 void triangular_matrix_vector_product(ExecutionPolicy&& exec,
                                       InMat A,
                                       Triangle t,
                                       DiagonalStorage d,
                                       InVec1 x,
                                       InVec2 y,
-                                      out_vector_t z);
+                                      OutVec z);
 ```
 
 * *Effects:* Computes $z$ such that $z = y + A x$.
@@ -8190,21 +8187,21 @@ template<in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
          in_vector InVec,
-         class out_vector_t,
+         out_vector OutVec,
          class BinaryDivideOp>
 void triangular_matrix_vector_solve(
   InMat A,
   Triangle t,
   DiagonalStorage d,
   InVec b,
-  out_vector_t x,
+  OutVec x,
   BinaryDivideOp divide);
 template<class ExecutionPolicy,
          in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
          in_vector InVec,
-         class out_vector_t,
+         out_vector OutVec,
          class BinaryDivideOp>
 void triangular_matrix_vector_solve(
   ExecutionPolicy&& exec,
@@ -8212,7 +8209,7 @@ void triangular_matrix_vector_solve(
   Triangle t,
   DiagonalStorage d,
   InVec b,
-  out_vector_t x,
+  OutVec x,
   BinaryDivideOp divide);
 ```
 
@@ -8230,13 +8227,13 @@ template<in_matrix InMat,
          class Triangle,
          class DiagonalStorage,
          in_vector InVec,
-         class out_vector_t>
+         out_vector OutVec>
 void triangular_matrix_vector_solve(
   InMat A,
   Triangle t,
   DiagonalStorage d,
   InVec b,
-  out_vector_t x);
+  OutVec x);
 ```
 
 * *Effects:* Equivalent to `triangular_matrix_vector_solve(A, t, d, b, x, [](const auto& A_ii, const auto& b_i) { return A_ii / b_i; });`.
@@ -8247,14 +8244,14 @@ template<class ExecutionPolicy,
          class Triangle,
          class DiagonalStorage,
          in_vector InVec,
-         class out_vector_t>
+         out_vector OutVec>
 void triangular_matrix_vector_solve(
   ExecutionPolicy&& exec,
   InMat A,
   Triangle t,
   DiagonalStorage d,
   InVec b,
-  out_vector_t x);
+  OutVec x);
 ```
 
 * *Effects:* Equivalent to `triangular_matrix_vector_solve(forward<ExecutionPolicy>(exec), A, t, d, b, x, [](const auto& A_ii, const auto& b_i) { return A_ii / b_i; });`.
@@ -8831,20 +8828,20 @@ The following requirements apply to all functions in this section.
 ##### Overwriting general matrix-matrix product
 
 ```c++
-template<class in_matrix_1_t,
-         class in_matrix_2_t,
+template<in_matrix InMat1,
+         in_matrix InMat2,
          out_matrix OutMat>
-void matrix_product(in_matrix_1_t A,
-                    in_matrix_2_t B,
+void matrix_product(InMat1 A,
+                    InMat2 B,
                     OutMat C);
 
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
-         class in_matrix_2_t,
+         in_matrix InMat1,
+         in_matrix InMat2,
          out_matrix OutMat>
 void matrix_product(ExecutionPolicy&& exec,
-                    in_matrix_1_t A,
-                    in_matrix_2_t B,
+                    InMat1 A,
+                    InMat2 B,
                     OutMat C);
 ```
 
@@ -8859,24 +8856,24 @@ for all `k` such that `i,k` is in the domain of `A`.
 ##### Updating general matrix-matrix product
 
 ```c++
-template<class in_matrix_1_t,
-         class in_matrix_2_t,
-         class in_matrix_3_t,
+template<in_matrix InMat1,
+         in_matrix InMat2,
+         in_matrix InMat3,
          out_matrix OutMat>
-void matrix_product(in_matrix_1_t A,
-                    in_matrix_2_t B,
-                    in_matrix_3_t E,
+void matrix_product(InMat1 A,
+                    InMat2 B,
+                    InMat3 E,
                     OutMat C);
 
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
-         class in_matrix_2_t,
-         class in_matrix_3_t,
+         in_matrix InMat1,
+         in_matrix InMat2,
+         in_matrix InMat3,
          out_matrix OutMat>
 void matrix_product(ExecutionPolicy&& exec,
-                    in_matrix_1_t A,
-                    in_matrix_2_t B,
-                    in_matrix_3_t E,
+                    InMat1 A,
+                    InMat2 B,
+                    InMat3 E,
                     OutMat C);
 ```
 
@@ -8914,13 +8911,13 @@ The following requirements apply to all functions in this section.
 
 * *Constraints:*
 
-    * `in_matrix_1_t` either has unique layout,
+    * `InMat1` either has unique layout,
         or `layout_blas_packed` layout.
 
-    * `in_matrix_2_t`, `in_matrix_3_t` (if applicable),
+    * `InMat2`, `InMat3` (if applicable),
         and `OutMat` have unique layout.
 
-    * If `in_matrix_1_t` has `layout_blas_packed` layout, then the
+    * If `InMat1` has `layout_blas_packed` layout, then the
         layout's `Triangle` template argument has the same type as
         the function's `Triangle` template argument.
 
@@ -9007,25 +9004,25 @@ The following requirements apply to all overloads of
 ##### Overwriting symmetric matrix-matrix left product [linalg.algs.blas3.symm.ov.left]
 
 ```c++
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
-         class in_matrix_2_t,
+         in_matrix InMat2,
          out_matrix OutMat>
 void symmetric_matrix_left_product(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
-  in_matrix_2_t B,
+  InMat2 B,
   OutMat C);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
-         class in_matrix_2_t,
+         in_matrix InMat2,
          out_matrix OutMat>
 void symmetric_matrix_left_product(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
-  in_matrix_2_t B,
+  InMat2 B,
   OutMat C);
 ```
 
@@ -9046,25 +9043,25 @@ and in the triangle of `A` specified by `t`.
 ##### Overwriting symmetric matrix-matrix right product [linalg.algs.blas3.symm.ov.right]
 
 ```c++
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
-         class in_matrix_2_t,
+         in_matrix InMat2,
          out_matrix OutMat>
 void symmetric_matrix_right_product(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
-  in_matrix_2_t B,
+  InMat2 B,
   OutMat C);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
-         class in_matrix_2_t,
+         in_matrix InMat2,
          out_matrix OutMat>
 void symmetric_matrix_right_product(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
-  in_matrix_2_t B,
+  InMat2 B,
   OutMat C);
 ```
 
@@ -9086,29 +9083,29 @@ and in the triangle of `A` specified by `t`.
 ##### Updating symmetric matrix-matrix left product [linalg.algs.blas3.symm.up.left]
 
 ```c++
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
-         class in_matrix_2_t,
-         class in_matrix_3_t,
+         in_matrix InMat2,
+         in_matrix InMat3,
          out_matrix OutMat>
 void symmetric_matrix_left_product(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
-  in_matrix_2_t B,
-  in_matrix_3_t E,
+  InMat2 B,
+  InMat3 E,
   OutMat C);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
-         class in_matrix_2_t,
-         class in_matrix_3_t,
+         in_matrix InMat2,
+         in_matrix InMat3,
          out_matrix OutMat>
 void symmetric_matrix_left_product(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
-  in_matrix_2_t B,
-  in_matrix_3_t E,
+  InMat2 B,
+  InMat3 E,
   OutMat C);
 ```
 
@@ -9129,29 +9126,29 @@ and in the triangle of `A` specified by `t`.
 ##### Updating symmetric matrix-matrix right product [linalg.algs.blas3.symm.up.right]
 
 ```c++
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
-         class in_matrix_2_t,
-         class in_matrix_3_t,
+         in_matrix InMat2,
+         in_matrix InMat3,
          out_matrix OutMat>
 void symmetric_matrix_right_product(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
-  in_matrix_2_t B,
-  in_matrix_3_t E,
+  InMat2 B,
+  InMat3 E,
   OutMat C);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
-         class in_matrix_2_t,
-         class in_matrix_3_t,
+         in_matrix InMat2,
+         in_matrix InMat3,
          out_matrix OutMat>
 void symmetric_matrix_right_product(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
-  in_matrix_2_t B,
-  in_matrix_3_t E,
+  InMat2 B,
+  InMat3 E,
   OutMat C);
 ```
 
@@ -9193,13 +9190,13 @@ The following requirements apply to all functions in this section.
 
 * *Constraints:*
 
-    * `in_matrix_1_t` either has unique layout,
+    * `InMat1` either has unique layout,
         or `layout_blas_packed` layout.
 
-    * `in_matrix_2_t`, `in_matrix_3_t` (if applicable), and
+    * `InMat2`, `InMat3` (if applicable), and
         `OutMat` have unique layout.
 
-    * If `in_matrix_1_t` has `layout_blas_packed` layout, then the
+    * If `InMat1` has `layout_blas_packed` layout, then the
         layout's `Triangle` template argument has the same type as
         the function's `Triangle` template argument.
 
@@ -9286,25 +9283,25 @@ The following requirements apply to all overloads of
 ##### Overwriting Hermitian matrix-matrix left product [linalg.algs.blas3.hemm.ov.left]
 
 ```c++
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
-         class in_matrix_2_t,
+         in_matrix InMat2,
          out_matrix OutMat>
 void hermitian_matrix_left_product(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
-  in_matrix_2_t B,
+  InMat2 B,
   OutMat C);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
-         class in_matrix_2_t,
+         in_matrix InMat2,
          out_matrix OutMat>
 void hermitian_matrix_left_product(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
-  in_matrix_2_t B,
+  InMat2 B,
   OutMat C);
 ```
 
@@ -9326,25 +9323,25 @@ and in the triangle of `A` specified by `t`.
 ##### Overwriting Hermitian matrix-matrix right product [linalg.algs.blas3.hemm.ov.right]
 
 ```c++
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
-         class in_matrix_2_t,
+         in_matrix InMat2,
          out_matrix OutMat>
 void hermitian_matrix_right_product(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
-  in_matrix_2_t B,
+  InMat2 B,
   OutMat C);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
-         class in_matrix_2_t,
+         in_matrix InMat2,
          out_matrix OutMat>
 void hermitian_matrix_right_product(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
-  in_matrix_2_t B,
+  InMat2 B,
   OutMat C);
 ```
 
@@ -9366,29 +9363,29 @@ and in the triangle of `A` specified by `t`.
 ##### Updating Hermitian matrix-matrix left product [linalg.algs.blas3.hemm.up.left]
 
 ```c++
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
-         class in_matrix_2_t,
-         class in_matrix_3_t,
+         in_matrix InMat2,
+         in_matrix InMat3,
          out_matrix OutMat>
 void hermitian_matrix_left_product(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
-  in_matrix_2_t B,
-  in_matrix_3_t E,
+  InMat2 B,
+  InMat3 E,
   OutMat C);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
-         class in_matrix_2_t,
-         class in_matrix_3_t,
+         in_matrix InMat2,
+         in_matrix InMat3,
          out_matrix OutMat>
 void hermitian_matrix_left_product(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
-  in_matrix_2_t B,
-  in_matrix_3_t E,
+  InMat2 B,
+  InMat3 E,
   OutMat C);
 ```
 
@@ -9410,29 +9407,29 @@ and in the triangle of `A` specified by `t`.
 ##### Updating Hermitian matrix-matrix right product [linalg.algs.blas3.hemm.up.right]
 
 ```c++
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
-         class in_matrix_2_t,
-         class in_matrix_3_t,
+         in_matrix InMat2,
+         in_matrix InMat3,
          out_matrix OutMat>
 void hermitian_matrix_right_product(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
-  in_matrix_2_t B,
-  in_matrix_3_t E,
+  InMat2 B,
+  InMat3 E,
   OutMat C);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
-         class in_matrix_2_t,
-         class in_matrix_3_t,
+         in_matrix InMat2,
+         in_matrix InMat3,
          out_matrix OutMat>
 void hermitian_matrix_right_product(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
-  in_matrix_2_t B,
-  in_matrix_3_t E,
+  InMat2 B,
+  InMat3 E,
   OutMat C);
 ```
 
@@ -9468,13 +9465,13 @@ The following requirements apply to all functions in this section.
 
 * *Constraints:*
 
-    * `in_matrix_1_t` either has unique layout,
+    * `InMat1` either has unique layout,
         or `layout_blas_packed` layout.
 
-    * `in_matrix_2_t` and `in_matrix_3_t` (if applicable)
+    * `InMat2` and `InMat3` (if applicable)
         have unique layout.
 
-    * If `in_matrix_1_t` has `layout_blas_packed` layout, then the
+    * If `InMat1` has `layout_blas_packed` layout, then the
         layout's `Triangle` template argument has the same type as
         the function's `Triangle` template argument.
 
@@ -9567,29 +9564,29 @@ The following requirements apply to all overloads of
 Not-in-place overwriting triangular matrix-matrix left product
 
 ```c++
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         class in_matrix_2_t,
+         in_matrix InMat2,
          out_matrix OutMat>
 void triangular_matrix_left_product(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
-  in_matrix_2_t B,
+  InMat2 B,
   OutMat C);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         class in_matrix_2_t,
+         in_matrix InMat2,
          out_matrix OutMat>
 void triangular_matrix_left_product(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
-  in_matrix_2_t B,
+  InMat2 B,
   OutMat C);
 ```
 
@@ -9605,23 +9602,23 @@ and in the triangle of `A` specified by `t` and `d`.
 In-place overwriting triangular matrix-matrix left product
 
 ```c++
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
          inout_matrix InOutMat>
 void triangular_matrix_left_product(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
   InOutMat C);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
          inout_matrix InOutMat>
 void triangular_matrix_left_product(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
   InOutMat C);
@@ -9646,29 +9643,29 @@ and in the triangle of `A` specified by `t` and `d`.
 
 Not-in-place overwriting triangular matrix-matrix right product
 ```c++
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         class in_matrix_2_t,
+         in_matrix InMat2,
          out_matrix OutMat>
 void triangular_matrix_right_product(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
-  in_matrix_2_t B,
+  InMat2 B,
   OutMat C);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         class in_matrix_2_t,
+         in_matrix InMat2,
          out_matrix OutMat>
 void triangular_matrix_right_product(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
-  in_matrix_2_t B,
+  InMat2 B,
   OutMat C);
 ```
 
@@ -9683,23 +9680,23 @@ and in the triangle of `A` specified by `t` and `d`.
 
 In-place overwriting triangular matrix-matrix right product
 ```c++
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
          inout_matrix InOutMat>
 void triangular_matrix_right_product(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
   InOutMat C);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
          inout_matrix InOutMat>
 void triangular_matrix_right_product(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
   InOutMat C);
@@ -9723,33 +9720,33 @@ and in the triangle of `A` specified by `t` and `d`.
 ##### Updating triangular matrix-matrix left product [linalg.algs.blas3.trmm.up.left]
 
 ```c++
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         class in_matrix_2_t,
-         class in_matrix_3_t,
+         in_matrix InMat2,
+         in_matrix InMat3,
          out_matrix OutMat>
 void triangular_matrix_left_product(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
-  in_matrix_2_t B,
-  in_matrix_3_t E,
+  InMat2 B,
+  InMat3 E,
   OutMat C);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         class in_matrix_2_t,
-         class in_matrix_3_t,
+         in_matrix InMat2,
+         in_matrix InMat3,
          out_matrix OutMat>
 void triangular_matrix_left_product(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
-  in_matrix_2_t B,
-  in_matrix_3_t E,
+  InMat2 B,
+  InMat3 E,
   OutMat C);
 ```
 
@@ -9765,33 +9762,33 @@ and in the triangle of `A` specified by `t` and `d`.
 ##### Updating triangular matrix-matrix right product [linalg.algs.blas3.trmm.up.right]
 
 ```c++
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         class in_matrix_2_t,
-         class in_matrix_3_t,
+         in_matrix InMat2,
+         in_matrix InMat3,
          out_matrix OutMat>
 void triangular_matrix_right_product(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
-  in_matrix_2_t B,
-  in_matrix_3_t E,
+  InMat2 B,
+  InMat3 E,
   OutMat C);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         class in_matrix_2_t,
-         class in_matrix_3_t,
+         in_matrix InMat2,
+         in_matrix InMat3,
          out_matrix OutMat>
 void triangular_matrix_right_product(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
-  in_matrix_2_t B,
-  in_matrix_3_t E,
+  InMat2 B,
+  InMat3 E,
   OutMat C);
 ```
 
@@ -9818,23 +9815,23 @@ to the input matrix. --*end note]*
 
 ```c++
 template<class T,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          inout_matrix InOutMat,
          class Triangle>
 void symmetric_matrix_rank_k_update(
   T alpha,
-  in_matrix_1_t A,
+  InMat1 A,
   InOutMat C,
   Triangle t);
 template<class ExecutionPolicy,
          class T,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          inout_matrix InOutMat,
          class Triangle>
 void symmetric_matrix_rank_k_update(
   ExecutionPolicy&& exec,
   T alpha,
-  in_matrix_1_t A,
+  InMat1 A,
   InOutMat C,
   Triangle t);
 ```
@@ -9897,23 +9894,23 @@ for all `k` such that `i,k` is in the domain of `A`.
 
 ```c++
 template<class T,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          inout_matrix InOutMat,
          class Triangle>
 void hermitian_matrix_rank_k_update(
   T alpha,
-  in_matrix_1_t A,
+  InMat1 A,
   InOutMat C,
   Triangle t);
 template<class ExecutionPolicy,
          class T,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          inout_matrix InOutMat,
          class Triangle>
 void hermitian_matrix_rank_k_update(
   ExecutionPolicy&& exec,
   T alpha,
-  in_matrix_1_t A,
+  InMat1 A,
   InOutMat C,
   Triangle t);
 ```
@@ -9985,24 +9982,24 @@ to the input matrices. --*end note]*
 ##### Rank-2k symmetric matrix update [linalg.alg.blas3.rank2k.syr2k]
 
 ```c++
-template<class in_matrix_1_t,
-         class in_matrix_2_t,
+template<in_matrix InMat1,
+         in_matrix InMat2,
          inout_matrix InOutMat,
          class Triangle>
 void symmetric_matrix_rank_2k_update(
-  in_matrix_1_t A,
-  in_matrix_2_t B,
+  InMat1 A,
+  InMat2 B,
   InOutMat C,
   Triangle t);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
-         class in_matrix_2_t,
+         in_matrix InMat1,
+         in_matrix InMat2,
          inout_matrix InOutMat,
          class Triangle>
 void symmetric_matrix_rank_2k_update(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
-  in_matrix_2_t B,
+  InMat1 A,
+  InMat2 B,
   InOutMat C,
   Triangle t);
 ```
@@ -10064,25 +10061,25 @@ for all `k2` such that `i,k2` is in the domain of `B`.
 ##### Rank-2k Hermitian matrix update [linalg.alg.blas3.rank2k.her2k]
 
 ```c++
-template<class in_matrix_1_t,
-         class in_matrix_2_t,
+template<in_matrix InMat1,
+         in_matrix InMat2,
          inout_matrix InOutMat,
          class Triangle>
 void hermitian_matrix_rank_2k_update(
-  in_matrix_1_t A,
-  in_matrix_2_t B,
+  InMat1 A,
+  InMat2 B,
   InOutMat C,
   Triangle t);
 
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
-         class in_matrix_2_t,
+         in_matrix InMat1,
+         in_matrix InMat2,
          inout_matrix InOutMat,
          class Triangle>
 void hermitian_matrix_rank_2k_update(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
-  in_matrix_2_t B,
+  InMat1 A,
+  InMat2 B,
   InOutMat C,
   Triangle t);
 ```
@@ -10160,9 +10157,9 @@ The following requirements apply to all functions in this section.
 
     * `X.rank()` equals 2 (if applicable);
 
-    * `in_matrix_1_t` either has unique layout, or `layout_blas_packed` layout;
+    * `InMat1` either has unique layout, or `layout_blas_packed` layout;
 
-    * `in_matrix_2_t` has unique layout (if applicable);
+    * `InMat2` has unique layout (if applicable);
 
     * if `r,j` is in the domain of `X` and `B`, then the expression
         `X[r,j] = B[r,j]` is well formed (if applicable); and
@@ -10201,58 +10198,58 @@ The following requirements apply to all functions in this section.
 Not-in-place left solve of multiple triangular systems
 
 ```c++
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         class in_matrix_2_t,
+         in_matrix InMat2,
          out_matrix OutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_left_solve(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
-  in_matrix_2_t B,
+  InMat2 B,
   OutMat X,
   BinaryDivideOp divide);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         class in_matrix_2_t,
+         in_matrix InMat2,
          out_matrix OutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_left_solve(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
-  in_matrix_2_t B,
+  InMat2 B,
   OutMat X,
   BinaryDivideOp divide);
 
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         class in_matrix_2_t,
+         in_matrix InMat2,
          out_matrix OutMat>
 void triangular_matrix_matrix_left_solve(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
-  in_matrix_2_t B,
+  InMat2 B,
   OutMat X);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         class in_matrix_2_t,
+         in_matrix InMat2,
          out_matrix OutMat>
 void triangular_matrix_matrix_left_solve(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
-  in_matrix_2_t B,
+  InMat2 B,
   OutMat X);
 ```
 
@@ -10298,48 +10295,48 @@ in the subset of the domain of `A` specified by `t`.
 In-place left solve of multiple triangular systems
 
 ```c++
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
          inout_matrix InOutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_left_solve(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
   InOutMat B,
   BinaryDivideOp divide);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
          inout_matrix InOutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_left_solve(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
   InOutMat B,
   BinaryDivideOp divide);
 
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
          inout_matrix InOutMat>
 void triangular_matrix_matrix_left_solve(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
   InOutMat B);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
          inout_matrix InOutMat>
 void triangular_matrix_matrix_left_solve(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
   InOutMat B);
@@ -10404,58 +10401,58 @@ in the subset of the domain of `A` specified by `t`.
 Not-in-place right solve of multiple triangular systems
 
 ```c++
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         class in_matrix_2_t,
+         in_matrix InMat2,
          out_matrix OutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_right_solve(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
-  in_matrix_2_t B,
+  InMat2 B,
   OutMat X,
   BinaryDivideOp divide);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         class in_matrix_2_t,
+         in_matrix InMat2,
          out_matrix OutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_right_solve(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
-  in_matrix_2_t B,
+  InMat2 B,
   OutMat X,
   BinaryDivideOp divide);
 
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         class in_matrix_2_t,
+         in_matrix InMat2,
          out_matrix OutMat>
 void triangular_matrix_matrix_right_solve(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
-  in_matrix_2_t B,
+  InMat2 B,
   OutMat X);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
-         class in_matrix_2_t,
+         in_matrix InMat2,
          out_matrix OutMat>
 void triangular_matrix_matrix_right_solve(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
-  in_matrix_2_t B,
+  InMat2 B,
   OutMat X);
 ```
 
@@ -10518,48 +10515,48 @@ is the product of the reversed matrices in transposed order.
 In-place right solve of multiple triangular systems
 
 ```c++
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
          inout_matrix InOutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_right_solve(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
   InOutMat B,
   BinaryDivideOp divide);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
          inout_matrix InOutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_right_solve(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
   InOutMat B,
   BinaryDivideOp divide);  
 
-template<class in_matrix_1_t,
+template<in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
          inout_matrix InOutMat>
 void triangular_matrix_matrix_right_solve(
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
   InOutMat B);
 template<class ExecutionPolicy,
-         class in_matrix_1_t,
+         in_matrix InMat1,
          class Triangle,
          class DiagonalStorage,
          inout_matrix InOutMat>
 void triangular_matrix_matrix_right_solve(
   ExecutionPolicy&& exec,
-  in_matrix_1_t A,
+  InMat1 A,
   Triangle t,
   DiagonalStorage d,
   InOutMat B);
@@ -10735,12 +10732,12 @@ example in-place in the matrix `A`.  The example assumes that
 template<in_matrix InMat,
          class Triangle,
          in_vector InVec,
-         class out_vector_t>
+         out_vector OutVec>
 void cholesky_solve(
   InMat A,
   Triangle t,
   InVec b,
-  out_vector_t x)
+  OutVec x)
 {
   using std::linalg::transposed;
   using std::linalg::triangular_matrix_vector_solve;

--- a/D1673/P1673.md
+++ b/D1673/P1673.md
@@ -5354,11 +5354,11 @@ template<class ... Indices>
 
 *Constraints*:
 
-    * `sizeof...(Indices)` equals `extents_type::rank()`,
+  * `sizeof...(Indices)` equals `extents_type::rank()`,
 
-    * `(is_convertible_v<Indices, index_Type> && ...)` is `true`, and
+  * `(is_convertible_v<Indices, index_Type> && ...)` is `true`, and
 
-    * `(is_nothrow_constructible_v<index_type, Indices>)` is `true`.
+  * `(is_nothrow_constructible_v<index_type, Indices>)` is `true`.
 
 *Preconditions:* `extents_type::`<it>`index-cast`</it>`(k)` is
     a multidimensional index in <it>`extents_`</it> (**[mdspan.overview]**).
@@ -5366,25 +5366,25 @@ template<class ... Indices>
 *Returns:* Let `N` equal `extent(0)`, let `i` be the zeroth element of `k`,
     and let `j` be the first element of `k`.  Then:
 
-    * If `StorageOrder` is `column_major_t` and
+  * If `StorageOrder` is `column_major_t` and
 
-        * if `Triangle` is `upper_triangle_t`,
-            then `i` + `j` * (`j` + 1)/2 if `i` ≤ `j`,
-            else `j` + `i` * (`i` + 1)/2;
+    * if `Triangle` is `upper_triangle_t`,
+        then `i` + `j` * (`j` + 1)/2 if `i` ≤ `j`,
+        else `j` + `i` * (`i` + 1)/2;
 
-        * else, if `Triangle` is `lower_triangle_t`,
-            then `i` + `N` * `j` - `j` * (`j` + 1)/2 if `i` ≥ `j`,
-            else `j` + `N` * `i` - `i` * (`i` + 1)/2;
+    * else, if `Triangle` is `lower_triangle_t`,
+        then `i` + `N` * `j` - `j` * (`j` + 1)/2 if `i` ≥ `j`,
+        else `j` + `N` * `i` - `i` * (`i` + 1)/2;
 
-    * else, if `StorageOrder` is `row_major_t` and
+  * else, if `StorageOrder` is `row_major_t` and
 
-        * if `Triangle` is `upper_triangle_t`,
-            then `j` + `N` * `i` - `i` * (`i` + 1)/2 if `i` ≤ `j`,
-            else `i` + `N` * `j` - `j` * (`j` + 1)/2;
+    * if `Triangle` is `upper_triangle_t`,
+        then `j` + `N` * `i` - `i` * (`i` + 1)/2 if `i` ≤ `j`,
+        else `i` + `N` * `j` - `j` * (`j` + 1)/2;
 
-        * else, if `Triangle` is `lower_triangle_t`,
-            then `j` + `i` * (`i` + 1)/2 if `i` ≥ `j`,
-            else `i` + `j` * (`j` + 1)/2.
+    * else, if `Triangle` is `lower_triangle_t`,
+        then `j` + `i` * (`i` + 1)/2 if `i` ≥ `j`,
+        else `i` + `j` * (`j` + 1)/2.
 
 *[Note:*
 
@@ -5461,16 +5461,16 @@ The name `_conj-if-needed_` denotes an exposition-only function object.
 The expression _`conj-if-needed`_`(E)` for subexpression `E`
 is expression-equivalent to:
 
-    * `E`, if `T` is an arithmetic type;
+  * `E`, if `T` is an arithmetic type;
 
-    * else, `conj(E)`, if that expression is valid
-        with overload resolution performed in a context
-	that includes the declaration
-	`template<class T> T conj(const T&) = delete;`
-	and does not include a declaration of
-	`linalg::impl::`_`conj_if_needed`_;
+  * else, `conj(E)`, if that expression is valid
+      with overload resolution performed in a context
+	    that includes the declaration
+	    `template<class T> T conj(const T&) = delete;`
+	    and does not include a declaration of
+	    `linalg::impl::`_`conj_if_needed`_;
 
-    * else, `E`.
+  * else, `E`.
 
 *[Note:*
 The special case for arithmetic types

--- a/D1673/P1673.md
+++ b/D1673/P1673.md
@@ -425,6 +425,10 @@ toc: true
     * Update non-wording to reflect current status of `mdspan`
         (voted into C++ Standard draft) and `submdspan` (P2630).
 
+* Revision 11, to be submitted soon
+
+  * Remove requirement that `in_vector*_t` has unique layout.
+
 # Purpose of this paper
 
 This paper proposes a C++ Standard Library dense linear algebra
@@ -6613,14 +6617,41 @@ or other things as appropriate.
 * `Real` is any type such that `complex<Real>` is specified.
     *[Note:* See **[complex.numbers.general]**. --*end note]*
 
+
+```c++
+template<class T>
+struct @_is-mdspan_@ : false_type {};
+
+template<class ElementType, class Extents, class Layout, class Accessor>
+struct @_is-mdspan_@<mdspan<ElementType, Extents, Layout, Accessor>> : true_type {};
+
+template<class T>
+concept @_in-vector_@ = // exposition only
+  @_is-mdspan_@<T>::value &&
+  T::rank() == 1;
+```
+
 * `in_vector*_t` is a rank-1 `mdspan` with a
     potentially `const` element type and a unique layout.
-    If the algorithm accesses the object, it will do so in read-only fashion.
+    If the algorithm accesses the object, it will do so in read-only fashion.  (TODO MOVE THIS LAST SENTENCE TO A COMMON PLACE)
 
-* `inout_vector*_t` is a rank-1 `mdspan`
-    with a non-`const` element type,
-    and whose layout is always unique
-    (`layout_type::is_always_unique()` equals `true`).
+```c++
+template<class T>
+concept @_inout-vector_@ = // exposition only
+  @_is-mdspan_@<T>::value &&
+  T::rank() == 1 &&
+  is_same_v<remove_const_t<typename T::element_type>, typename T::element_type> &&
+  T::is_always_unique();
+```
+
+```c++
+template<class T>
+concept @_inout-vector_@ = // exposition only
+  @_is-mdspan_@<T>::value &&
+  T::rank() == 1 &&
+  is_same_v<remove_const_t<typename T::element_type>, typename T::element_type> &&
+  T::is_always_unique();
+```
 
 * `out_vector*_t` is a rank-1 `mdspan`
     with a non-`const` element type,

--- a/D1673/P1673.md
+++ b/D1673/P1673.md
@@ -467,6 +467,9 @@ toc: true
       All other constraints were redundant
       with the new exposition-only concepts.
 
+  * Make `matrix_vector_product` template parameter order
+      consistent with parameter order.
+
 # Purpose of this paper
 
 This paper proposes a C++ Standard Library dense linear algebra
@@ -3618,28 +3621,28 @@ void scale(ExecutionPolicy&& exec,
            InOutObj obj);
 
 // [linalg.algs.blas1.copy], copy elements
-template<in_object InObj,
-         out_object OutObj>
+template<@_in-object_@ InObj,
+         @_out-object_@ OutObj>
 void copy(InObj x,
           OutObj y);
 template<class ExecutionPolicy,
-         in_object InObj,
-         out_object OutObj>
+         @_in-object_@ InObj,
+         @_out-object_@ OutObj>
 void copy(ExecutionPolicy&& exec,
           InObj x,
           OutObj y);
 
 // [linalg.algs.blas1.add], add elementwise
-template<in_object InObj1,
-         in_object InObj2,
-         out_object OutObj>
+template<@_in-object_@ InObj1,
+         @_in-object_@ InObj2,
+         @_out-object_@ OutObj>
 void add(InObj1 x,
          InObj2 y,
          OutObj z);
 template<class ExecutionPolicy,
-         in_object InObj1,
-         in_object InObj2,
-         out_object OutObj>
+         @_in-object_@ InObj1,
+         @_in-object_@ InObj2,
+         @_out-object_@ OutObj>
 void add(ExecutionPolicy&& exec,
          InObj1 x,
          InObj2 y,
@@ -3650,54 +3653,54 @@ void add(ExecutionPolicy&& exec,
 
 // [linalg.algs.blas1.dot.dotu],
 // nonconjugated dot product of two vectors
-template<in_vector InVec1,
-         in_vector InVec2,
+template<@_in-vector_@ InVec1,
+         @_in-vector_@ InVec2,
          class T>
 T dot(InVec1 v1,
       InVec2 v2,
       T init);
 template<class ExecutionPolicy,
-         in_vector InVec1,
-         in_vector InVec2,
+         @_in-vector_@ InVec1,
+         @_in-vector_@ InVec2,
          class T>
 T dot(ExecutionPolicy&& exec,
       InVec1 v1,
       InVec2 v2,
       T init);
-template<in_vector InVec1,
-         in_vector InVec2>
+template<@_in-vector_@ InVec1,
+         @_in-vector_@ InVec2>
 auto dot(InVec1 v1,
          InVec2 v2) -> /* see-below */;
 template<class ExecutionPolicy,
-         in_vector InVec1,
-         in_vector InVec2>
+         @_in-vector_@ InVec1,
+         @_in-vector_@ InVec2>
 auto dot(ExecutionPolicy&& exec,
          InVec1 v1,
          InVec2 v2) -> /* see-below */;
 
 // [linalg.algs.blas1.dot.dotc],
 // conjugated dot product of two vectors
-template<in_vector InVec1,
-         in_vector InVec2,
+template<@_in-vector_@ InVec1,
+         @_in-vector_@ InVec2,
          class T>
 T dotc(InVec1 v1,
        InVec2 v2,
        T init);
 template<class ExecutionPolicy,
-         in_vector InVec1,
-         in_vector InVec2,
+         @_in-vector_@ InVec1,
+         @_in-vector_@ InVec2,
          class T>
 T dotc(ExecutionPolicy&& exec,
        InVec1 v1,
        InVec2 v2,
        T init);
-template<in_vector InVec1,
-         in_vector InVec2>
+template<@_in-vector_@ InVec1,
+         @_in-vector_@ InVec2>
 auto dotc(InVec1 v1,
           InVec2 v2) -> /* see-below */;
 template<class ExecutionPolicy,
-         in_vector InVec1,
-         in_vector InVec2>
+         @_in-vector_@ InVec1,
+         @_in-vector_@ InVec2>
 auto dotc(ExecutionPolicy&& exec,
           InVec1 v1,
           InVec2 v2) -> /* see-below */;
@@ -3709,7 +3712,7 @@ struct sum_of_squares_result {
   T scaling_factor;
   T scaled_sum_of_squares;
 };
-template<in_vector InVec,
+template<@_in-vector_@ InVec,
          class T>
 sum_of_squares_result<T> vector_sum_of_squares(
   InVec v,
@@ -3721,150 +3724,150 @@ sum_of_squares_result<T> vector_sum_of_squares(
 
 // [linalg.algs.blas1.nrm2],
 // Euclidean norm of a vector
-template<in_vector InVec,
+template<@_in-vector_@ InVec,
          class T>
 T vector_norm2(InVec v,
                T init);
 template<class ExecutionPolicy,
-         in_vector InVec,
+         @_in-vector_@ InVec,
          class T>
 T vector_norm2(ExecutionPolicy&& exec,
                InVec v,
                T init);
-template<in_vector InVec>
+template<@_in-vector_@ InVec>
 auto vector_norm2(InVec v) -> /* see-below */;
 template<class ExecutionPolicy,
-         in_vector InVec>
+         @_in-vector_@ InVec>
 auto vector_norm2(ExecutionPolicy&& exec,
                   InVec v) -> /* see-below */;
 
 // [linalg.algs.blas1.asum],
 // sum of absolute values of vector elements
-template<in_vector InVec,
+template<@_in-vector_@ InVec,
          class T>
 T vector_abs_sum(InVec v,
                  T init);
 template<class ExecutionPolicy,
-         in_vector InVec,
+         @_in-vector_@ InVec,
          class T>
 T vector_abs_sum(ExecutionPolicy&& exec,
                  InVec v,
                  T init);
-template<in_vector InVec>
+template<@_in-vector_@ InVec>
 auto vector_abs_sum(InVec v) -> /* see-below */;
 template<class ExecutionPolicy,
-         in_vector InVec>
+         @_in-vector_@ InVec>
 auto vector_abs_sum(ExecutionPolicy&& exec,
                     InVec v) -> /* see-below */;
 
 // [linalg.algs.blas1.iamax],
 // index of maximum absolute value of vector elements
-template<in_vector InVec>
+template<@_in-vector_@ InVec>
 typename InVec::extents_type idx_abs_max(InVec v);
 template<class ExecutionPolicy,
-         in_vector InVec>
+         @_in-vector_@ InVec>
 typename InVec::extents_type idx_abs_max(
   ExecutionPolicy&& exec,
   InVec v);
 
 // [linalg.algs.blas1.matfrobnorm],
 // Frobenius norm of a matrix
-template<in_matrix InMat,
+template<@_in-matrix_@ InMat,
          class T>
 T matrix_frob_norm(
   InMat A,
   T init);
 template<class ExecutionPolicy,
-         in_matrix InMat,
+         @_in-matrix_@ InMat,
          class T>
 T matrix_frob_norm(
   ExecutionPolicy&& exec,
   InMat A,
   T init);
-template<in_matrix InMat>
+template<@_in-matrix_@ InMat>
 auto matrix_frob_norm(
   InMat A) -> /* see-below */;
 template<class ExecutionPolicy,
-         in_matrix InMat>
+         @_in-matrix_@ InMat>
 auto matrix_frob_norm(
   ExecutionPolicy&& exec,
   InMat A) -> /* see-below */;
 
 // [linalg.algs.blas1.matonenorm],
 // One norm of a matrix
-template<in_matrix InMat,
+template<@_in-matrix_@ InMat,
          class T>
 T matrix_one_norm(
   InMat A,
   T init);
 template<class ExecutionPolicy,
-         in_matrix InMat,
+         @_in-matrix_@ InMat,
          class T>
 T matrix_one_norm(
   ExecutionPolicy&& exec,
   InMat A,
   T init);
-template<in_matrix InMat>
+template<@_in-matrix_@ InMat>
 auto matrix_one_norm(
   InMat A) -> /* see-below */;
 template<class ExecutionPolicy,
-         in_matrix InMat>
+         @_in-matrix_@ InMat>
 auto matrix_one_norm(
   ExecutionPolicy&& exec,
   InMat A) -> /* see-below */;
 
 // [linalg.algs.blas1.matinfnorm],
 // Infinity norm of a matrix
-template<in_matrix InMat,
+template<@_in-matrix_@ InMat,
          class T>
 T matrix_inf_norm(
   InMat A,
   T init);
 template<class ExecutionPolicy,
-         in_matrix InMat,
+         @_in-matrix_@ InMat,
          class T>
 T matrix_inf_norm(
   ExecutionPolicy&& exec,
   InMat A,
   T init);
-template<in_matrix InMat>
+template<@_in-matrix_@ InMat>
 auto matrix_inf_norm(
   InMat A) -> /* see-below */;
 template<class ExecutionPolicy,
-         in_matrix InMat>
+         @_in-matrix_@ InMat>
 auto matrix_inf_norm(
   ExecutionPolicy&& exec,
   InMat A) -> /* see-below */;
 
 // [linalg.algs.blas2.gemv],
 // general matrix-vector product
-template<in_vector InVec,
-         in_matrix InMat,
-         out_vector OutVec>
+template<@_in-matrix_@ InMat,
+         @_in-vector_@ InVec,
+         @_out-vector_@ OutVec>
 void matrix_vector_product(InMat A,
                            InVec x,
                            OutVec y);
 template<class ExecutionPolicy,
-         in_vector InVec,
-         in_matrix InMat,
-         out_vector OutVec>
+         @_in-matrix_@ InMat,
+         @_in-vector_@ InVec,
+         @_out-vector_@ OutVec>
 void matrix_vector_product(ExecutionPolicy&& exec,
                            InMat A,
                            InVec x,
                            OutVec y);
-template<in_vector InVec1,
-         in_matrix InMat,
-         in_vector InVec2,
-         out_vector OutVec>
+template<@_in-matrix_@ InMat,
+         @_in-vector_@ InVec1,
+         @_in-vector_@ InVec2,
+         @_out-vector_@ OutVec>
 void matrix_vector_product(InMat A,
                            InVec1 x,
                            InVec2 y,
                            OutVec z);
 template<class ExecutionPolicy,
-         in_vector InVec1,
-         in_matrix InMat,
-         in_vector InVec2,
-         out_vector OutVec>
+         @_in-matrix_@ InMat,
+         @_in-vector_@ InVec1,
+         @_in-vector_@ InVec2,
+         @_out-vector_@ OutVec>
 void matrix_vector_product(ExecutionPolicy&& exec,
                            InMat A,
                            InVec1 x,
@@ -3873,29 +3876,29 @@ void matrix_vector_product(ExecutionPolicy&& exec,
 
 // [linalg.algs.blas2.symv],
 // symmetric matrix-vector product
-template<in_matrix InMat,
+template<@_in-matrix_@ InMat,
          class Triangle,
-         in_vector InVec,
-         out_vector OutVec>
+         @_in-vector_@ InVec,
+         @_out-vector_@ OutVec>
 void symmetric_matrix_vector_product(InMat A,
                                      Triangle t,
                                      InVec x,
                                      OutVec y);
 template<class ExecutionPolicy,
-         in_matrix InMat,
+         @_in-matrix_@ InMat,
          class Triangle,
-         in_vector InVec,
-         out_vector OutVec>
+         @_in-vector_@ InVec,
+         @_out-vector_@ OutVec>
 void symmetric_matrix_vector_product(ExecutionPolicy&& exec,
                                      InMat A,
                                      Triangle t,
                                      InVec x,
                                      OutVec y);
-template<in_matrix InMat,
+template<@_in-matrix_@ InMat,
          class Triangle,
-         in_vector InVec1,
-         in_vector InVec2,
-         out_vector OutVec>
+         @_in-vector_@ InVec1,
+         @_in-vector_@ InVec2,
+         @_out-vector_@ OutVec>
 void symmetric_matrix_vector_product(
   InMat A,
   Triangle t,
@@ -3904,11 +3907,11 @@ void symmetric_matrix_vector_product(
   OutVec z);
 
 template<class ExecutionPolicy,
-         in_matrix InMat,
+         @_in-matrix_@ InMat,
          class Triangle,
-         in_vector InVec1,
-         in_vector InVec2,
-         out_vector OutVec>
+         @_in-vector_@ InVec1,
+         @_in-vector_@ InVec2,
+         @_out-vector_@ OutVec>
 void symmetric_matrix_vector_product(
   ExecutionPolicy&& exec,
   InMat A,
@@ -3919,29 +3922,29 @@ void symmetric_matrix_vector_product(
 
 // [linalg.algs.blas2.hemv],
 // Hermitian matrix-vector product
-template<in_matrix InMat,
+template<@_in-matrix_@ InMat,
          class Triangle,
-         in_vector InVec,
-         out_vector OutVec>
+         @_in-vector_@ InVec,
+         @_out-vector_@ OutVec>
 void hermitian_matrix_vector_product(InMat A,
                                      Triangle t,
                                      InVec x,
                                      OutVec y);
 template<class ExecutionPolicy,
-         in_matrix InMat,
+         @_in-matrix_@ InMat,
          class Triangle,
-         in_vector InVec,
-         out_vector OutVec>
+         @_in-vector_@ InVec,
+         @_out-vector_@ OutVec>
 void hermitian_matrix_vector_product(ExecutionPolicy&& exec,
                                      InMat A,
                                      Triangle t,
                                      InVec x,
                                      OutVec y);
-template<in_matrix InMat,
+template<@_in-matrix_@ InMat,
          class Triangle,
-         in_vector InVec1,
-         in_vector InVec2,
-         out_vector OutVec>
+         @_in-vector_@ InVec1,
+         @_in-vector_@ InVec2,
+         @_out-vector_@ OutVec>
 void hermitian_matrix_vector_product(InMat A,
                                      Triangle t,
                                      InVec1 x,
@@ -3949,11 +3952,11 @@ void hermitian_matrix_vector_product(InMat A,
                                      OutVec z);
 
 template<class ExecutionPolicy,
-         in_matrix InMat,
+         @_in-matrix_@ InMat,
          class Triangle,
-         in_vector InVec1,
-         in_vector InVec2,
-         out_vector OutVec>
+         @_in-vector_@ InVec1,
+         @_in-vector_@ InVec2,
+         @_out-vector_@ OutVec>
 void hermitian_matrix_vector_product(ExecutionPolicy&& exec,
                                      InMat A,
                                      Triangle t,
@@ -3966,11 +3969,11 @@ void hermitian_matrix_vector_product(ExecutionPolicy&& exec,
 
 // [linalg.algs.blas2.trmv.ov],
 // Overwriting triangular matrix-vector product
-template<in_matrix InMat,
+template<@_in-matrix_@ InMat,
          class Triangle,
          class DiagonalStorage,
-         in_vector InVec,
-         out_vector OutVec>
+         @_in-vector_@ InVec,
+         @_out-vector_@ OutVec>
 void triangular_matrix_vector_product(
   InMat A,
   Triangle t,
@@ -3978,11 +3981,11 @@ void triangular_matrix_vector_product(
   InVec x,
   OutVec y);
 template<class ExecutionPolicy,
-         in_matrix InMat,
+         @_in-matrix_@ InMat,
          class Triangle,
          class DiagonalStorage,
-         in_vector InVec,
-         out_vector OutVec>
+         @_in-vector_@ InVec,
+         @_out-vector_@ OutVec>
 void triangular_matrix_vector_product(
   ExecutionPolicy&& exec,
   InMat A,
@@ -3993,7 +3996,7 @@ void triangular_matrix_vector_product(
 
 // [linalg.algs.blas2.trmv.in-place],
 // In-place triangular matrix-vector product
-template<in_matrix InMat,
+template<@_in-matrix_@ InMat,
          class Triangle,
          class DiagonalStorage,
          @_inout-vector_@ InOutVec>
@@ -4003,7 +4006,7 @@ void triangular_matrix_vector_product(
   DiagonalStorage d,
   InOutVec y);
 template<class ExecutionPolicy,
-         in_matrix InMat,
+         @_in-matrix_@ InMat,
          class Triangle,
          class DiagonalStorage,
          @_inout-vector_@ InOutVec>
@@ -4016,12 +4019,12 @@ void triangular_matrix_vector_product(
 
 // [linalg.algs.blas2.trmv.up],
 // Updating triangular matrix-vector product
-template<in_matrix InMat,
+template<@_in-matrix_@ InMat,
          class Triangle,
          class DiagonalStorage,
-         in_vector InVec1,
-         in_vector InVec2,
-         out_vector OutVec>
+         @_in-vector_@ InVec1,
+         @_in-vector_@ InVec2,
+         @_out-vector_@ OutVec>
 void triangular_matrix_vector_product(InMat A,
                                       Triangle t,
                                       DiagonalStorage d,
@@ -4029,12 +4032,12 @@ void triangular_matrix_vector_product(InMat A,
                                       InVec2 y,
                                       OutVec z);
 template<class ExecutionPolicy,
-         in_matrix InMat,
+         @_in-matrix_@ InMat,
          class Triangle,
          class DiagonalStorage,
-         in_vector InVec1,
-         in_vector InVec2,
-         out_vector OutVec>
+         @_in-vector_@ InVec1,
+         @_in-vector_@ InVec2,
+         @_out-vector_@ OutVec>
 void triangular_matrix_vector_product(ExecutionPolicy&& exec,
                                       InMat A,
                                       Triangle t,
@@ -4048,11 +4051,11 @@ void triangular_matrix_vector_product(ExecutionPolicy&& exec,
 
 // [linalg.algs.blas2.trsv.not-in-place],
 // Solve a triangular linear system, not in place
-template<in_matrix InMat,
+template<@_in-matrix_@ InMat,
          class Triangle,
          class DiagonalStorage,
-         in_vector InVec,
-         out_vector OutVec,
+         @_in-vector_@ InVec,
+         @_out-vector_@ OutVec,
          class BinaryDivideOp>
 void triangular_matrix_vector_solve(
   InMat A,
@@ -4062,11 +4065,11 @@ void triangular_matrix_vector_solve(
   OutVec x,
   BinaryDivideOp divide);
 template<class ExecutionPolicy,
-         in_matrix InMat,
+         @_in-matrix_@ InMat,
          class Triangle,
          class DiagonalStorage,
-         in_vector InVec,
-         out_vector OutVec,
+         @_in-vector_@ InVec,
+         @_out-vector_@ OutVec,
          class BinaryDivideOp>
 void triangular_matrix_vector_solve(
   ExecutionPolicy&& exec,
@@ -4076,11 +4079,11 @@ void triangular_matrix_vector_solve(
   InVec b,
   OutVec x,
   BinaryDivideOp divide);
-template<in_matrix InMat,
+template<@_in-matrix_@ InMat,
          class Triangle,
          class DiagonalStorage,
-         in_vector InVec,
-         out_vector OutVec>
+         @_in-vector_@ InVec,
+         @_out-vector_@ OutVec>
 void triangular_matrix_vector_solve(
   InMat A,
   Triangle t,
@@ -4088,11 +4091,11 @@ void triangular_matrix_vector_solve(
   InVec b,
   OutVec x);
 template<class ExecutionPolicy,
-         in_matrix InMat,
+         @_in-matrix_@ InMat,
          class Triangle,
          class DiagonalStorage,
-         in_vector InVec,
-         out_vector OutVec>
+         @_in-vector_@ InVec,
+         @_out-vector_@ OutVec>
 void triangular_matrix_vector_solve(
   ExecutionPolicy&& exec,
   InMat A,
@@ -4103,7 +4106,7 @@ void triangular_matrix_vector_solve(
 
 // [linalg.algs.blas2.trsv.in-place],
 // Solve a triangular linear system, in place
-template<in_matrix InMat,
+template<@_in-matrix_@ InMat,
          class Triangle,
          class DiagonalStorage,
          @_inout-vector_@ InOutVec,
@@ -4115,7 +4118,7 @@ void triangular_matrix_vector_solve(
   InOutVec b,
   BinaryDivideOp divide);
 template<class ExecutionPolicy,
-         in_matrix InMat,
+         @_in-matrix_@ InMat,
          class Triangle,
          class DiagonalStorage,
          @_inout-vector_@ InOutVec,
@@ -4127,7 +4130,7 @@ void triangular_matrix_vector_solve(
   DiagonalStorage d,
   InOutVec b,
   BinaryDivideOp divide);
-template<in_matrix InMat,
+template<@_in-matrix_@ InMat,
          class Triangle,
          class DiagonalStorage,
          @_inout-vector_@ InOutVec>
@@ -4137,7 +4140,7 @@ void triangular_matrix_vector_solve(
   DiagonalStorage d,
   InOutVec b);
 template<class ExecutionPolicy,
-         in_matrix InMat,
+         @_in-matrix_@ InMat,
          class Triangle,
          class DiagonalStorage,
          @_inout-vector_@ InOutVec>
@@ -4150,16 +4153,16 @@ void triangular_matrix_vector_solve(
 
 // [linalg.algs.blas2.rank1.geru],
 // nonconjugated rank-1 matrix update
-template<in_vector InVec1,
-         in_vector InVec2,
+template<@_in-vector_@ InVec1,
+         @_in-vector_@ InVec2,
          @_inout-matrix_@ InOutMat>
 void matrix_rank_1_update(
   InVec1 x,
   InVec2 y,
   InOutMat A);
 template<class ExecutionPolicy,
-         in_vector InVec1,
-         in_vector InVec2,
+         @_in-vector_@ InVec1,
+         @_in-vector_@ InVec2,
          @_inout-matrix_@ InOutMat>
 void matrix_rank_1_update(
   ExecutionPolicy&& exec,
@@ -4169,16 +4172,16 @@ void matrix_rank_1_update(
 
 // [linalg.algs.blas2.rank1.gerc],
 // conjugated rank-1 matrix update
-template<in_vector InVec1,
-         in_vector InVec2,
+template<@_in-vector_@ InVec1,
+         @_in-vector_@ InVec2,
          @_inout-matrix_@ InOutMat>
 void matrix_rank_1_update_c(
   InVec1 x,
   InVec2 y,
   InOutMat A);
 template<class ExecutionPolicy,
-         in_vector InVec1,
-         in_vector InVec2,
+         @_in-vector_@ InVec1,
+         @_in-vector_@ InVec2,
          @_inout-matrix_@ InOutMat>
 void matrix_rank_1_update_c(
   ExecutionPolicy&& exec,
@@ -4188,7 +4191,7 @@ void matrix_rank_1_update_c(
 
 // [linalg.algs.blas2.rank1.syr],
 // symmetric rank-1 matrix update
-template<in_vector InVec,
+template<@_in-vector_@ InVec,
          @_inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_1_update(
@@ -4196,7 +4199,7 @@ void symmetric_matrix_rank_1_update(
   InOutMat A,
   Triangle t);
 template<class ExecutionPolicy,
-         in_vector InVec,
+         @_in-vector_@ InVec,
          @_inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_1_update(
@@ -4205,7 +4208,7 @@ void symmetric_matrix_rank_1_update(
   InOutMat A,
   Triangle t);
 template<class T,
-         in_vector InVec,
+         @_in-vector_@ InVec,
          @_inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_1_update(
@@ -4215,7 +4218,7 @@ void symmetric_matrix_rank_1_update(
   Triangle t);
 template<class ExecutionPolicy,
          class T,
-         in_vector InVec,
+         @_in-vector_@ InVec,
          @_inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_1_update(
@@ -4227,7 +4230,7 @@ void symmetric_matrix_rank_1_update(
 
 // [linalg.algs.blas2.rank1.her],
 // Hermitian rank-1 matrix update
-template<in_vector InVec,
+template<@_in-vector_@ InVec,
          @_inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_1_update(
@@ -4235,7 +4238,7 @@ void hermitian_matrix_rank_1_update(
   InOutMat A,
   Triangle t);
 template<class ExecutionPolicy,
-         in_vector InVec,
+         @_in-vector_@ InVec,
          @_inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_1_update(
@@ -4244,7 +4247,7 @@ void hermitian_matrix_rank_1_update(
   InOutMat A,
   Triangle t);
 template<class T,
-         in_vector InVec,
+         @_in-vector_@ InVec,
          @_inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_1_update(
@@ -4254,7 +4257,7 @@ void hermitian_matrix_rank_1_update(
   Triangle t);
 template<class ExecutionPolicy,
          class T,
-         in_vector InVec,
+         @_in-vector_@ InVec,
          @_inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_1_update(
@@ -4266,8 +4269,8 @@ void hermitian_matrix_rank_1_update(
 
 // [linalg.algs.blas2.rank2.syr2],
 // symmetric rank-2 matrix update
-template<in_vector InVec1,
-         in_vector InVec2,
+template<@_in-vector_@ InVec1,
+         @_in-vector_@ InVec2,
          @_inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_2_update(
@@ -4276,8 +4279,8 @@ void symmetric_matrix_rank_2_update(
   InOutMat A,
   Triangle t);
 template<class ExecutionPolicy,
-         in_vector InVec1,
-         in_vector InVec2,
+         @_in-vector_@ InVec1,
+         @_in-vector_@ InVec2,
          @_inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_2_update(
@@ -4289,8 +4292,8 @@ void symmetric_matrix_rank_2_update(
 
 // [linalg.algs.blas2.rank2.her2],
 // Hermitian rank-2 matrix update
-template<in_vector InVec1,
-         in_vector InVec2,
+template<@_in-vector_@ InVec1,
+         @_in-vector_@ InVec2,
          @_inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_2_update(
@@ -4299,8 +4302,8 @@ void hermitian_matrix_rank_2_update(
   InOutMat A,
   Triangle t);
 template<class ExecutionPolicy,
-         in_vector InVec1,
-         in_vector InVec2,
+         @_in-vector_@ InVec1,
+         @_in-vector_@ InVec2,
          @_inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_2_update(
@@ -4312,33 +4315,33 @@ void hermitian_matrix_rank_2_update(
 
 // [linalg.algs.blas3.gemm],
 // general matrix-matrix product
-template<in_matrix InMat1,
-         in_matrix InMat2,
-         out_matrix OutMat>
+template<@_in-matrix_@ InMat1,
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat>
 void matrix_product(InMat1 A,
                     InMat2 B,
                     OutMat C);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
-         in_matrix InMat2,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat1,
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat>
 void matrix_product(ExecutionPolicy&& exec,
                     InMat1 A,
                     InMat2 B,
                     OutMat C);
-template<in_matrix InMat1,
-         in_matrix InMat2,
-         in_matrix InMat3,
-         out_matrix OutMat>
+template<@_in-matrix_@ InMat1,
+         @_in-matrix_@ InMat2,
+         @_in-matrix_@ InMat3,
+         @_out-matrix_@ OutMat>
 void matrix_product(InMat1 A,
                     InMat2 B,
                     InMat3 E,
                     OutMat C);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
-         in_matrix InMat2,
-         in_matrix InMat3,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat1,
+         @_in-matrix_@ InMat2,
+         @_in-matrix_@ InMat3,
+         @_out-matrix_@ OutMat>
 void matrix_product(ExecutionPolicy&& exec,
                     InMat1 A,
                     InMat2 B,
@@ -4350,20 +4353,20 @@ void matrix_product(ExecutionPolicy&& exec,
 
 // [linalg.algs.blas3.symm.ov.left],
 // overwriting symmetric matrix-matrix left product
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
-         in_matrix InMat2,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat>
 void symmetric_matrix_left_product(
   InMat1 A,
   Triangle t,
   InMat2 B,
   OutMat C);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
-         in_matrix InMat2,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat>
 void symmetric_matrix_left_product(
   ExecutionPolicy&& exec,
   InMat1 A,
@@ -4373,20 +4376,20 @@ void symmetric_matrix_left_product(
 
 // [linalg.algs.blas3.symm.ov.right],
 // overwriting symmetric matrix-matrix right product
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
-         in_matrix InMat2,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat>
 void symmetric_matrix_right_product(
   InMat1 A,
   Triangle t,
   InMat2 B,
   OutMat C);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
-         in_matrix InMat2,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat>
 void symmetric_matrix_right_product(
   ExecutionPolicy&& exec,
   InMat1 A,
@@ -4396,11 +4399,11 @@ void symmetric_matrix_right_product(
 
 // [linalg.algs.blas3.symm.up.left],
 // updating symmetric matrix-matrix left product
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
-         in_matrix InMat2,
-         in_matrix InMat3,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_in-matrix_@ InMat3,
+         @_out-matrix_@ OutMat>
 void symmetric_matrix_left_product(
   InMat1 A,
   Triangle t,
@@ -4408,11 +4411,11 @@ void symmetric_matrix_left_product(
   InMat3 E,
   OutMat C);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
-         in_matrix InMat2,
-         in_matrix InMat3,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_in-matrix_@ InMat3,
+         @_out-matrix_@ OutMat>
 void symmetric_matrix_left_product(
   ExecutionPolicy&& exec,
   InMat1 A,
@@ -4423,11 +4426,11 @@ void symmetric_matrix_left_product(
 
 // [linalg.algs.blas3.symm.up.right],
 // updating symmetric matrix-matrix right product
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
-         in_matrix InMat2,
-         in_matrix InMat3,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_in-matrix_@ InMat3,
+         @_out-matrix_@ OutMat>
 void symmetric_matrix_right_product(
   InMat1 A,
   Triangle t,
@@ -4435,11 +4438,11 @@ void symmetric_matrix_right_product(
   InMat3 E,
   OutMat C);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
-         in_matrix InMat2,
-         in_matrix InMat3,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_in-matrix_@ InMat3,
+         @_out-matrix_@ OutMat>
 void symmetric_matrix_right_product(
   ExecutionPolicy&& exec,
   InMat1 A,
@@ -4453,20 +4456,20 @@ void symmetric_matrix_right_product(
 
 // [linalg.algs.blas3.hemm.ov.left],
 // overwriting Hermitian matrix-matrix left product
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
-         in_matrix InMat2,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat>
 void hermitian_matrix_left_product(
   InMat1 A,
   Triangle t,
   InMat2 B,
   OutMat C);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
-         in_matrix InMat2,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat>
 void hermitian_matrix_left_product(
   ExecutionPolicy&& exec,
   InMat1 A,
@@ -4476,20 +4479,20 @@ void hermitian_matrix_left_product(
 
 // [linalg.algs.blas3.hemm.ov.right],
 // overwriting Hermitian matrix-matrix right product
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
-         in_matrix InMat2,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat>
 void hermitian_matrix_right_product(
   InMat1 A,
   Triangle t,
   InMat2 B,
   OutMat C);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
-         in_matrix InMat2,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat>
 void hermitian_matrix_right_product(
   ExecutionPolicy&& exec,
   InMat1 A,
@@ -4499,11 +4502,11 @@ void hermitian_matrix_right_product(
 
 // [linalg.algs.blas3.hemm.up.left],
 // updating Hermitian matrix-matrix left product
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
-         in_matrix InMat2,
-         in_matrix InMat3,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_in-matrix_@ InMat3,
+         @_out-matrix_@ OutMat>
 void hermitian_matrix_left_product(
   InMat1 A,
   Triangle t,
@@ -4511,11 +4514,11 @@ void hermitian_matrix_left_product(
   InMat3 E,
   OutMat C);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
-         in_matrix InMat2,
-         in_matrix InMat3,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_in-matrix_@ InMat3,
+         @_out-matrix_@ OutMat>
 void hermitian_matrix_left_product(
   ExecutionPolicy&& exec,
   InMat1 A,
@@ -4526,11 +4529,11 @@ void hermitian_matrix_left_product(
 
 // [linalg.algs.blas3.hemm.up.right],
 // updating Hermitian matrix-matrix right product
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
-         in_matrix InMat2,
-         in_matrix InMat3,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_in-matrix_@ InMat3,
+         @_out-matrix_@ OutMat>
 void hermitian_matrix_right_product(
   InMat1 A,
   Triangle t,
@@ -4538,11 +4541,11 @@ void hermitian_matrix_right_product(
   InMat3 E,
   OutMat C);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
-         in_matrix InMat2,
-         in_matrix InMat3,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_in-matrix_@ InMat3,
+         @_out-matrix_@ OutMat>
 void hermitian_matrix_right_product(
   ExecutionPolicy&& exec,
   InMat1 A,
@@ -4556,11 +4559,11 @@ void hermitian_matrix_right_product(
 
 // [linalg.algs.blas3.trmm.ov.left],
 // overwriting triangular matrix-matrix left product
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
-         in_matrix InMat2,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat>
 void triangular_matrix_left_product(
   InMat1 A,
   Triangle t,
@@ -4568,11 +4571,11 @@ void triangular_matrix_left_product(
   InMat2 B,
   OutMat C);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
-         in_matrix InMat2,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat>
 void triangular_matrix_left_product(
   ExecutionPolicy&& exec,
   InMat1 A,
@@ -4580,7 +4583,7 @@ void triangular_matrix_left_product(
   DiagonalStorage d,
   InMat2 B,
   OutMat C);
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
          @_inout-matrix_@ InOutMat>
@@ -4590,7 +4593,7 @@ void triangular_matrix_left_product(
   DiagonalStorage d,
   InOutMat C);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
          @_inout-matrix_@ InOutMat>
@@ -4603,11 +4606,11 @@ void triangular_matrix_left_product(
 
 // [linalg.algs.blas3.trmm.ov.right],
 // overwriting triangular matrix-matrix right product
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
-         in_matrix InMat2,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat>
 void triangular_matrix_right_product(
   InMat1 A,
   Triangle t,
@@ -4615,11 +4618,11 @@ void triangular_matrix_right_product(
   InMat2 B,
   OutMat C);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
-         in_matrix InMat2,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat>
 void triangular_matrix_right_product(
   ExecutionPolicy&& exec,
   InMat1 A,
@@ -4627,7 +4630,7 @@ void triangular_matrix_right_product(
   DiagonalStorage d,
   InMat2 B,
   OutMat C);
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
          @_inout-matrix_@ InOutMat>
@@ -4637,7 +4640,7 @@ void triangular_matrix_right_product(
   DiagonalStorage d,
   InOutMat C);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
          @_inout-matrix_@ InOutMat>
@@ -4650,12 +4653,12 @@ void triangular_matrix_right_product(
 
 // [linalg.algs.blas3.trmm.up.left],
 // updating triangular matrix-matrix left product
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
-         in_matrix InMat2,
-         in_matrix InMat3,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_in-matrix_@ InMat3,
+         @_out-matrix_@ OutMat>
 void triangular_matrix_left_product(
   InMat1 A,
   Triangle t,
@@ -4664,12 +4667,12 @@ void triangular_matrix_left_product(
   InMat3 E,
   OutMat C);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
-         in_matrix InMat2,
-         in_matrix InMat3,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_in-matrix_@ InMat3,
+         @_out-matrix_@ OutMat>
 void triangular_matrix_left_product(
   ExecutionPolicy&& exec,
   InMat1 A,
@@ -4681,12 +4684,12 @@ void triangular_matrix_left_product(
 
 // [linalg.algs.blas3.trmm.up.right],
 // updating triangular matrix-matrix right product
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
-         in_matrix InMat2,
-         in_matrix InMat3,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_in-matrix_@ InMat3,
+         @_out-matrix_@ OutMat>
 void triangular_matrix_right_product(
   InMat1 A,
   Triangle t,
@@ -4695,12 +4698,12 @@ void triangular_matrix_right_product(
   InMat3 E,
   OutMat C);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
-         in_matrix InMat2,
-         in_matrix InMat3,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_in-matrix_@ InMat3,
+         @_out-matrix_@ OutMat>
 void triangular_matrix_right_product(
   ExecutionPolicy&& exec,
   InMat1 A,
@@ -4713,7 +4716,7 @@ void triangular_matrix_right_product(
 // [linalg.alg.blas3.rank-k.syrk],
 // rank-k symmetric matrix update
 template<class T,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          @_inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_k_update(
@@ -4723,7 +4726,7 @@ void symmetric_matrix_rank_k_update(
   Triangle t);
 template<class T,
          class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          @_inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_k_update(
@@ -4736,7 +4739,7 @@ void symmetric_matrix_rank_k_update(
 // [linalg.alg.blas3.rank-k.herk],
 // rank-k Hermitian matrix update
 template<class T,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          @_inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_k_update(
@@ -4746,7 +4749,7 @@ void hermitian_matrix_rank_k_update(
   Triangle t);
 template<class ExecutionPolicy,
          class T,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          @_inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_k_update(
@@ -4758,8 +4761,8 @@ void hermitian_matrix_rank_k_update(
 
 // [linalg.alg.blas3.rank2k.syr2k],
 // rank-2k symmetric matrix update
-template<in_matrix InMat1,
-         in_matrix InMat2,
+template<@_in-matrix_@ InMat1,
+         @_in-matrix_@ InMat2,
          @_inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_2k_update(
@@ -4768,8 +4771,8 @@ void symmetric_matrix_rank_2k_update(
   InOutMat C,
   Triangle t);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
-         in_matrix InMat2,
+         @_in-matrix_@ InMat1,
+         @_in-matrix_@ InMat2,
          @_inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_2k_update(
@@ -4781,8 +4784,8 @@ void symmetric_matrix_rank_2k_update(
 
 // [linalg.alg.blas3.rank2k.her2k],
 // rank-2k Hermitian matrix update
-template<in_matrix InMat1,
-         in_matrix InMat2,
+template<@_in-matrix_@ InMat1,
+         @_in-matrix_@ InMat2,
          @_inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_2k_update(
@@ -4791,8 +4794,8 @@ void hermitian_matrix_rank_2k_update(
   InOutMat C,
   Triangle t);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
-         in_matrix InMat2,
+         @_in-matrix_@ InMat1,
+         @_in-matrix_@ InMat2,
          @_inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_2k_update(
@@ -4808,11 +4811,11 @@ void hermitian_matrix_rank_2k_update(
 // [linalg.alg.blas3.trsm.left],
 // solve multiple triangular linear systems
 // with triangular matrix on the left
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
-         in_matrix InMat2,
-         out_matrix OutMat,
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_left_solve(
   InMat1 A,
@@ -4822,11 +4825,11 @@ void triangular_matrix_matrix_left_solve(
   OutMat X,
   BinaryDivideOp divide);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
-         in_matrix InMat2,
-         out_matrix OutMat,
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_left_solve(
   ExecutionPolicy&& exec,
@@ -4836,7 +4839,7 @@ void triangular_matrix_matrix_left_solve(
   InMat2 B,
   OutMat X,
   BinaryDivideOp divide);
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
          @_inout-matrix_@ InOutMat,
@@ -4848,7 +4851,7 @@ void triangular_matrix_matrix_left_solve(
   InOutMat B,
   BinaryDivideOp divide);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
          @_inout-matrix_@ InOutMat,
@@ -4861,11 +4864,11 @@ void triangular_matrix_matrix_left_solve(
   InOutMat B,
   BinaryDivideOp divide);
 
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
-         in_matrix InMat2,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat>
 void triangular_matrix_matrix_left_solve(
   InMat1 A,
   Triangle t,
@@ -4873,11 +4876,11 @@ void triangular_matrix_matrix_left_solve(
   InMat2 B,
   OutMat X);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
-         in_matrix InMat2,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat>
 void triangular_matrix_matrix_left_solve(
   ExecutionPolicy&& exec,
   InMat1 A,
@@ -4885,7 +4888,7 @@ void triangular_matrix_matrix_left_solve(
   DiagonalStorage d,
   InMat2 B,
   OutMat X);
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
          @_inout-matrix_@ InOutMat>
@@ -4895,7 +4898,7 @@ void triangular_matrix_matrix_left_solve(
   DiagonalStorage d,
   InOutMat B);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
          @_inout-matrix_@ InOutMat>
@@ -4909,11 +4912,11 @@ void triangular_matrix_matrix_left_solve(
 // [linalg.alg.blas3.trsm.right],
 // solve multiple triangular linear systems
 // with triangular matrix on the right
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
-         in_matrix InMat2,
-         out_matrix OutMat,
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_right_solve(
   InMat1 A,
@@ -4923,11 +4926,11 @@ void triangular_matrix_matrix_right_solve(
   OutMat X,
   BinaryDivideOp divide);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
-         in_matrix InMat2,
-         out_matrix OutMat,
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_right_solve(
   ExecutionPolicy&& exec,
@@ -4937,7 +4940,7 @@ void triangular_matrix_matrix_right_solve(
   InMat B,
   OutMat X,
   BinaryDivideOp divide);
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
          @_inout-matrix_@ InOutMat,
@@ -4949,7 +4952,7 @@ void triangular_matrix_matrix_right_solve(
   InOutMat B,
   BinaryDivideOp divide);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
          @_inout-matrix_@ InOutMat,
@@ -4962,11 +4965,11 @@ void triangular_matrix_matrix_right_solve(
   InOutMat B,
   BinaryDivideOp divide);
 
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
-         in_matrix InMat2,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat>
 void triangular_matrix_matrix_right_solve(
   InMat1 A,
   Triangle t,
@@ -4974,11 +4977,11 @@ void triangular_matrix_matrix_right_solve(
   InMat2 B,
   OutMat X);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
-         in_matrix InMat2,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat>
 void triangular_matrix_matrix_right_solve(
   ExecutionPolicy&& exec,
   InMat A,
@@ -4986,7 +4989,7 @@ void triangular_matrix_matrix_right_solve(
   DiagonalStorage d,
   InMat B,
   OutMat X);
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
          @_inout-matrix_@ InOutMat>
@@ -4996,7 +4999,7 @@ void triangular_matrix_matrix_right_solve(
   DiagonalStorage d,
   InOutMat B);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
          @_inout-matrix_@ InOutMat>
@@ -6993,14 +6996,14 @@ the mathematical expression for the algorithm is `obj[i...] = alpha * obj[i...]`
 #### Copy elements of one matrix or vector into another [linalg.algs.blas1.copy]
 
 ```c++
-template<in_object InObj,
-         out_object OutObj>
+template<@_in-object_@ InObj,
+         @_out-object_@ OutObj>
 void copy(InObj x,
           OutObj y);
 
 template<class ExecutionPolicy,
-         in_object InObj,
-         out_object OutObj>
+         @_in-object_@ InObj,
+         @_out-object_@ OutObj>
 void copy(ExecutionPolicy&& exec,
           InObj x,
           OutObj y);
@@ -7030,17 +7033,17 @@ void copy(ExecutionPolicy&& exec,
 #### Add vectors or matrices elementwise [linalg.algs.blas1.add]
 
 ```c++
-template<in_object InObj1,
-         in_object InObj2,
-         out_object OutObj>
+template<@_in-object_@ InObj1,
+         @_in-object_@ InObj2,
+         @_out-object_@ OutObj>
 void add(InObj1 x,
          InObj2 y,
          OutObj z);
 
 template<class ExecutionPolicy,
-         in_object InObj1,
-         in_object InObj2,
-         out_object OutObj>
+         @_in-object_@ InObj1,
+         @_in-object_@ InObj2,
+         @_out-object_@ OutObj>
 void add(ExecutionPolicy&& exec,
          InObj1 x,
          InObj2 y,
@@ -7088,15 +7091,15 @@ element types).  <i>-- end note]</i>
 Nonconjugated dot product with specified result type
 
 ```c++
-template<in_vector InVec1,
-         in_vector InVec2,
+template<@_in-vector_@ InVec1,
+         @_in-vector_@ InVec2,
          class T>
 T dot(InVec1 v1,
       InVec2 v2,
       T init);
 template<class ExecutionPolicy,
-         in_vector InVec1,
-         in_vector InVec2,
+         @_in-vector_@ InVec1,
+         @_in-vector_@ InVec2,
          class T>
 T dot(ExecutionPolicy&& exec,
       InVec1 v1,
@@ -7138,13 +7141,13 @@ below. <i>-- end note]</i>
 Nonconjugated dot product with default result type
 
 ```c++
-template<in_vector InVec1,
-         in_vector InVec2>
+template<@_in-vector_@ InVec1,
+         @_in-vector_@ InVec2>
 auto dot(InVec1 v1,
          InVec2 v2) -> /* see-below */;
 template<class ExecutionPolicy,
-         in_vector InVec1,
-         in_vector InVec2>
+         @_in-vector_@ InVec1,
+         @_in-vector_@ InVec2>
 auto dot(ExecutionPolicy&& exec,
          InVec1 v1,
          InVec2 v2) -> /* see-below */;
@@ -7169,15 +7172,15 @@ for both real and complex element types.
 Conjugated dot product with specified result type
 
 ```c++
-template<in_vector InVec1,
-         in_vector InVec2,
+template<@_in-vector_@ InVec1,
+         @_in-vector_@ InVec2,
          class T>
 T dotc(InVec1 v1,
        InVec2 v2,
        T init);
 template<class ExecutionPolicy,
-         in_vector InVec1,
-         in_vector InVec2,
+         @_in-vector_@ InVec1,
+         @_in-vector_@ InVec2,
          class T>
 T dotc(ExecutionPolicy&& exec,
        InVec1 v1,
@@ -7193,13 +7196,13 @@ T dotc(ExecutionPolicy&& exec,
 Conjugated dot product with default result type
 
 ```c++
-template<in_vector InVec1,
-         in_vector InVec2>
+template<@_in-vector_@ InVec1,
+         @_in-vector_@ InVec2>
 auto dotc(InVec1 v1,
           InVec2 v2) -> /* see-below */;
 template<class ExecutionPolicy,
-         in_vector InVec1,
-         in_vector InVec2>
+         @_in-vector_@ InVec1,
+         @_in-vector_@ InVec2>
 auto dotc(ExecutionPolicy&& exec,
           InVec1 v1,
           InVec2 v2) -> /* see-below */;
@@ -7218,13 +7221,13 @@ struct sum_of_squares_result {
   T scaling_factor;
   T scaled_sum_of_squares;
 };
-template<in_vector InVec,
+template<@_in-vector_@ InVec,
          class T>
 sum_of_squares_result<T> vector_sum_of_squares(
   InVec v,
   sum_of_squares_result<T> init);
 template<class ExecutionPolicy,
-         in_vector InVec,
+         @_in-vector_@ InVec,
          class T>
 sum_of_squares_result<T> vector_sum_of_squares(
   ExecutionPolicy&& exec,
@@ -7269,12 +7272,12 @@ sum_of_squares_result<T> vector_sum_of_squares(
 ##### Euclidean norm with specified result type
 
 ```c++
-template<in_vector InVec,
+template<@_in-vector_@ InVec,
          class T>
 T vector_norm2(InVec v,
                T init);
 template<class ExecutionPolicy,
-         in_vector InVec,
+         @_in-vector_@ InVec,
          class T>
 T vector_norm2(ExecutionPolicy&& exec,
                InVec v,
@@ -7328,10 +7331,10 @@ from `vector_sum_of_squares(x, {.scaling_factor=1.0, .scaled_sum_of_squares=init
 ##### Euclidean norm with default result type
 
 ```c++
-template<in_vector InVec>
+template<@_in-vector_@ InVec>
 auto vector_norm2(InVec v) -> /* see-below */;
 template<class ExecutionPolicy,
-         in_vector InVec>
+         @_in-vector_@ InVec>
 auto vector_norm2(ExecutionPolicy&& exec,
                   InVec v) -> /* see-below */;
 ```
@@ -7347,12 +7350,12 @@ auto vector_norm2(ExecutionPolicy&& exec,
 ##### Sum of absolute values with specified result type
 
 ```c++
-template<in_vector InVec,
+template<@_in-vector_@ InVec,
          class T>
 T vector_abs_sum(InVec v,
                  T init);
 template<class ExecutionPolicy,
-         in_vector InVec,
+         @_in-vector_@ InVec,
          class T>
 T vector_abs_sum(ExecutionPolicy&& exec,
                  InVec v,
@@ -7397,10 +7400,10 @@ The `abs`, `real`, and `imag` functions are invoked via unqualified lookup.
 ##### Sum of absolute values with default result type
 
 ```c++
-template<in_vector InVec>
+template<@_in-vector_@ InVec>
 auto vector_abs_sum(InVec v) -> /* see-below */;
 template<class ExecutionPolicy,
-         in_vector InVec>
+         @_in-vector_@ InVec>
 auto vector_abs_sum(ExecutionPolicy&& exec,
                     InVec v) -> /* see-below */;
 ```
@@ -7413,11 +7416,11 @@ auto vector_abs_sum(ExecutionPolicy&& exec,
 #### Index of maximum absolute value of vector elements [linalg.algs.blas1.iamax]
 
 ```c++
-template<in_vector InVec>
+template<@_in-vector_@ InVec>
 typename InVec::size_type idx_abs_max(InVec v);
 
 template<class ExecutionPolicy,
-         in_vector InVec>
+         @_in-vector_@ InVec>
 typename InVec::size_type idx_abs_max(
   ExecutionPolicy&& exec,
   InVec v);
@@ -7444,13 +7447,13 @@ The `abs` function is invoked via unqualified lookup.
 ##### Frobenius norm with specified result type
 
 ```c++
-template<in_matrix InMat,
+template<@_in-matrix_@ InMat,
          class T>
 T matrix_frob_norm(
   InMat A,
   T init);
 template<class ExecutionPolicy,
-         in_matrix InMat,
+         @_in-matrix_@ InMat,
          class T>
 T matrix_frob_norm(
   ExecutionPolicy&& exec,
@@ -7488,11 +7491,11 @@ The `abs` function is invoked via unqualified lookup.
 ##### Frobenius norm with default result type
 
 ```c++
-template<in_matrix InMat>
+template<@_in-matrix_@ InMat>
 auto matrix_frob_norm(
   InMat A) -> /* see-below */;
 template<class ExecutionPolicy,
-         in_matrix InMat>
+         @_in-matrix_@ InMat>
 auto matrix_frob_norm(
   ExecutionPolicy&& exec,
   InMat A) -> /* see-below */;
@@ -7509,13 +7512,13 @@ auto matrix_frob_norm(
 ##### One norm with specified result type
 
 ```c++
-template<in_matrix InMat,
+template<@_in-matrix_@ InMat,
          class T>
 T matrix_one_norm(
   InMat A,
   T init);
 template<class ExecutionPolicy,
-         in_matrix InMat,
+         @_in-matrix_@ InMat,
          class T>
 T matrix_one_norm(
   ExecutionPolicy&& exec,
@@ -7542,11 +7545,11 @@ T matrix_one_norm(
 ##### One norm with default result type
 
 ```c++
-template<in_matrix InMat>
+template<@_in-matrix_@ InMat>
 auto matrix_one_norm(
   InMat A) -> /* see-below */;
 template<class ExecutionPolicy,
-         in_matrix InMat>
+         @_in-matrix_@ InMat>
 auto matrix_one_norm(
   ExecutionPolicy&& exec,
   InMat A) -> /* see-below */;
@@ -7567,13 +7570,13 @@ The `abs` function is invoked via unqualified lookup.
 ##### Infinity norm with specified result type
 
 ```c++
-template<in_matrix InMat,
+template<@_in-matrix_@ InMat,
          class T>
 T matrix_inf_norm(
   InMat A,
   T init);
 template<class ExecutionPolicy,
-         in_matrix InMat,
+         @_in-matrix_@ InMat,
          class T>
 T matrix_inf_norm(
   ExecutionPolicy&& exec,
@@ -7604,11 +7607,11 @@ The `abs` function is invoked via unqualified lookup.
 ##### Infinity norm with default result type
 
 ```c++
-template<in_matrix InMat>
+template<@_in-matrix_@ InMat>
 auto matrix_inf_norm(
   InMat A) -> /* see-below */;
 template<class ExecutionPolicy,
-         in_matrix InMat>
+         @_in-matrix_@ InMat>
 auto matrix_inf_norm(
   ExecutionPolicy&& exec,
   InMat A) -> /* see-below */;
@@ -7658,17 +7661,17 @@ The following requirements apply to all functions in this section.
 ##### Overwriting matrix-vector product
 
 ```c++
-template<in_vector InVec,
-         in_matrix InMat,
-         out_vector OutVec>
+template<@_in-matrix_@ InMat,
+         @_in-vector_@ InVec,
+         @_out-vector_@ OutVec>
 void matrix_vector_product(InMat A,
                            InVec x,
                            OutVec y);
 
 template<class ExecutionPolicy,
-         in_vector InVec,
-         in_matrix InMat,
-         out_vector OutVec>
+         @_in-matrix_@ InMat,
+         @_in-vector_@ InVec,
+         @_out-vector_@ OutVec>
 void matrix_vector_product(ExecutionPolicy&& exec,
                            InMat A,
                            InVec x,
@@ -7714,20 +7717,20 @@ void scaled_matvec_2(mdspan<double, extents<size_t, num_rows, num_cols>> A,
 ##### Updating matrix-vector product
 
 ```c++
-template<in_vector InVec1,
-         in_matrix InMat,
-         in_vector InVec2,
-         out_vector OutVec>
+template<@_in-matrix_@ InMat,
+         @_in-vector_@ InVec1,
+         @_in-vector_@ InVec2,
+         @_out-vector_@ OutVec>
 void matrix_vector_product(InMat A,
                            InVec1 x,
                            InVec2 y,
                            OutVec z);
 
 template<class ExecutionPolicy,
-         in_vector InVec1,
-         in_matrix InMat,
-         in_vector InVec2,
-         out_vector OutVec>
+         @_in-matrix_@ InMat,
+         @_in-vector_@ InVec1,
+         @_in-vector_@ InVec2,
+         @_out-vector_@ OutVec>
 void matrix_vector_product(ExecutionPolicy&& exec,
                            InMat A,
                            InVec1 x,
@@ -7795,20 +7798,20 @@ The following requirements apply to all functions in this section.
 ##### Overwriting symmetric matrix-vector product
 
 ```c++
-template<in_matrix InMat,
+template<@_in-matrix_@ InMat,
          class Triangle,
-         in_vector InVec,
-         out_vector OutVec>
+         @_in-vector_@ InVec,
+         @_out-vector_@ OutVec>
 void symmetric_matrix_vector_product(InMat A,
                                      Triangle t,
                                      InVec x,
                                      OutVec y);
 
 template<class ExecutionPolicy,
-         in_matrix InMat,
+         @_in-matrix_@ InMat,
          class Triangle,
-         in_vector InVec,
-         out_vector OutVec>
+         @_in-vector_@ InVec,
+         @_out-vector_@ OutVec>
 void symmetric_matrix_vector_product(ExecutionPolicy&& exec,
                                      InMat A,
                                      Triangle t,
@@ -7821,11 +7824,11 @@ void symmetric_matrix_vector_product(ExecutionPolicy&& exec,
 ##### Updating symmetric matrix-vector product
 
 ```c++
-template<in_matrix InMat,
+template<@_in-matrix_@ InMat,
          class Triangle,
-         in_vector InVec1,
-         in_vector InVec2,
-         out_vector OutVec>
+         @_in-vector_@ InVec1,
+         @_in-vector_@ InVec2,
+         @_out-vector_@ OutVec>
 void symmetric_matrix_vector_product(
   InMat A,
   Triangle t,
@@ -7834,11 +7837,11 @@ void symmetric_matrix_vector_product(
   OutVec z);
 
 template<class ExecutionPolicy,
-         in_matrix InMat,
+         @_in-matrix_@ InMat,
          class Triangle,
-         in_vector InVec1,
-         in_vector InVec2,
-         out_vector OutVec>
+         @_in-vector_@ InVec1,
+         @_in-vector_@ InVec2,
+         @_out-vector_@ OutVec>
 void symmetric_matrix_vector_product(
   ExecutionPolicy&& exec,
   InMat A,
@@ -7908,20 +7911,20 @@ The following requirements apply to all functions in this section.
 ##### Overwriting Hermitian matrix-vector product
 
 ```c++
-template<in_matrix InMat,
+template<@_in-matrix_@ InMat,
          class Triangle,
-         in_vector InVec,
-         out_vector OutVec>
+         @_in-vector_@ InVec,
+         @_out-vector_@ OutVec>
 void hermitian_matrix_vector_product(InMat A,
                                      Triangle t,
                                      InVec x,
                                      OutVec y);
 
 template<class ExecutionPolicy,
-         in_matrix InMat,
+         @_in-matrix_@ InMat,
          class Triangle,
-         in_vector InVec,
-         out_vector OutVec>
+         @_in-vector_@ InVec,
+         @_out-vector_@ OutVec>
 void hermitian_matrix_vector_product(ExecutionPolicy&& exec,
                                      InMat A,
                                      Triangle t,
@@ -7934,11 +7937,11 @@ void hermitian_matrix_vector_product(ExecutionPolicy&& exec,
 ##### Updating Hermitian matrix-vector product
 
 ```c++
-template<in_matrix InMat,
+template<@_in-matrix_@ InMat,
          class Triangle,
-         in_vector InVec1,
-         in_vector InVec2,
-         out_vector OutVec>
+         @_in-vector_@ InVec1,
+         @_in-vector_@ InVec2,
+         @_out-vector_@ OutVec>
 void hermitian_matrix_vector_product(InMat A,
                                      Triangle t,
                                      InVec1 x,
@@ -7946,11 +7949,11 @@ void hermitian_matrix_vector_product(InMat A,
                                      OutVec z);
 
 template<class ExecutionPolicy,
-         in_matrix InMat,
+         @_in-matrix_@ InMat,
          class Triangle,
-         in_vector InVec1,
-         in_vector InVec2,
-         out_vector OutVec>
+         @_in-vector_@ InVec1,
+         @_in-vector_@ InVec2,
+         @_out-vector_@ OutVec>
 void hermitian_matrix_vector_product(ExecutionPolicy&& exec,
                                      InMat A,
                                      Triangle t,
@@ -8030,11 +8033,11 @@ The following requirements apply to all functions in this section.
 ##### Overwriting triangular matrix-vector product [linalg.algs.blas2.trmv.ov]
 
 ```c++
-template<in_matrix InMat,
+template<@_in-matrix_@ InMat,
          class Triangle,
          class DiagonalStorage,
-         in_vector InVec,
-         out_vector OutVec>
+         @_in-vector_@ InVec,
+         @_out-vector_@ OutVec>
 void triangular_matrix_vector_product(
   InMat A,
   Triangle t,
@@ -8042,11 +8045,11 @@ void triangular_matrix_vector_product(
   InVec x,
   OutVec y);
 template<class ExecutionPolicy,
-         in_matrix InMat,
+         @_in-matrix_@ InMat,
          class Triangle,
          class DiagonalStorage,
-         in_vector InVec,
-         out_vector OutVec>
+         @_in-vector_@ InVec,
+         @_out-vector_@ OutVec>
 void triangular_matrix_vector_product(
   ExecutionPolicy&& exec,
   InMat A,
@@ -8061,7 +8064,7 @@ void triangular_matrix_vector_product(
 ##### In-place triangular matrix-vector product [linalg.algs.blas2.trmv.in-place]
 
 ```c++
-template<in_matrix InMat,
+template<@_in-matrix_@ InMat,
          class Triangle,
          class DiagonalStorage,
          @_inout-vector_@ InOutVec>
@@ -8071,7 +8074,7 @@ void triangular_matrix_vector_product(
   DiagonalStorage d,
   InOutVec y);
 template<class ExecutionPolicy,
-         in_matrix InMat,
+         @_in-matrix_@ InMat,
          class Triangle,
          class DiagonalStorage,
          @_inout-vector_@ InOutVec>
@@ -8103,12 +8106,12 @@ This is why the `ExecutionPolicy` overload exists.
 ##### Updating triangular matrix-vector product [linalg.algs.blas2.trmv.up]
 
 ```c++
-template<in_matrix InMat,
+template<@_in-matrix_@ InMat,
          class Triangle,
          class DiagonalStorage,
-         in_vector InVec1,
-         in_vector InVec2,
-         out_vector OutVec>
+         @_in-vector_@ InVec1,
+         @_in-vector_@ InVec2,
+         @_out-vector_@ OutVec>
 void triangular_matrix_vector_product(InMat A,
                                       Triangle t,
                                       DiagonalStorage d,
@@ -8117,12 +8120,12 @@ void triangular_matrix_vector_product(InMat A,
                                       OutVec z);
 
 template<class ExecutionPolicy,
-         in_matrix InMat,
+         @_in-matrix_@ InMat,
          class Triangle,
          class DiagonalStorage,
-         in_vector InVec1,
-         in_vector InVec2,
-         out_vector OutVec>
+         @_in-vector_@ InVec1,
+         @_in-vector_@ InVec2,
+         @_out-vector_@ OutVec>
 void triangular_matrix_vector_product(ExecutionPolicy&& exec,
                                       InMat A,
                                       Triangle t,
@@ -8187,11 +8190,11 @@ The following requirements apply to all functions in this section.
 ##### Not-in-place triangular solve [linalg.algs.blas2.trsv.not-in-place]
 
 ```c++
-template<in_matrix InMat,
+template<@_in-matrix_@ InMat,
          class Triangle,
          class DiagonalStorage,
-         in_vector InVec,
-         out_vector OutVec,
+         @_in-vector_@ InVec,
+         @_out-vector_@ OutVec,
          class BinaryDivideOp>
 void triangular_matrix_vector_solve(
   InMat A,
@@ -8201,11 +8204,11 @@ void triangular_matrix_vector_solve(
   OutVec x,
   BinaryDivideOp divide);
 template<class ExecutionPolicy,
-         in_matrix InMat,
+         @_in-matrix_@ InMat,
          class Triangle,
          class DiagonalStorage,
-         in_vector InVec,
-         out_vector OutVec,
+         @_in-vector_@ InVec,
+         @_out-vector_@ OutVec,
          class BinaryDivideOp>
 void triangular_matrix_vector_solve(
   ExecutionPolicy&& exec,
@@ -8227,11 +8230,11 @@ void triangular_matrix_vector_solve(
 * *Effects:* Computes $x$ such that $b = A x$.  If no such $x$ exists, then the elements of $x$ are valid but unspecified.
 
 ```c++
-template<in_matrix InMat,
+template<@_in-matrix_@ InMat,
          class Triangle,
          class DiagonalStorage,
-         in_vector InVec,
-         out_vector OutVec>
+         @_in-vector_@ InVec,
+         @_out-vector_@ OutVec>
 void triangular_matrix_vector_solve(
   InMat A,
   Triangle t,
@@ -8244,11 +8247,11 @@ void triangular_matrix_vector_solve(
 
 ```c++
 template<class ExecutionPolicy,
-         in_matrix InMat,
+         @_in-matrix_@ InMat,
          class Triangle,
          class DiagonalStorage,
-         in_vector InVec,
-         out_vector OutVec>
+         @_in-vector_@ InVec,
+         @_out-vector_@ OutVec>
 void triangular_matrix_vector_solve(
   ExecutionPolicy&& exec,
   InMat A,
@@ -8263,7 +8266,7 @@ void triangular_matrix_vector_solve(
 ##### In-place triangular solve [linalg.algs.blas2.trsv.in-place]
 
 ```c++
-template<in_matrix InMat,
+template<@_in-matrix_@ InMat,
          class Triangle,
          class DiagonalStorage,
          @_inout-vector_@ InOutVec,
@@ -8275,7 +8278,7 @@ void triangular_matrix_vector_solve(
   InOutVec b,
   BinaryDivideOp divide);
 template<class ExecutionPolicy,
-         in_matrix InMat,
+         @_in-matrix_@ InMat,
          class Triangle,
          class DiagonalStorage,
          @_inout-vector_@ InOutVec,
@@ -8307,7 +8310,7 @@ This is why the `ExecutionPolicy` overload exists.
 * *Effects:* Overwrites $b$ with $x$ such that $b = A x$.  If no such $x$ exists, then the elements of $b$ are valid but unspecified.
 
 ```c++
-template<in_matrix InMat,
+template<@_in-matrix_@ InMat,
          class Triangle,
          class DiagonalStorage,
          @_inout-vector_@ InOutVec>
@@ -8322,7 +8325,7 @@ void triangular_matrix_vector_solve(
 
 ```c++
 template<class ExecutionPolicy,
-         in_matrix InMat,
+         @_in-matrix_@ InMat,
          class Triangle,
          class DiagonalStorage,
          @_inout-vector_@ InOutVec>
@@ -8341,8 +8344,8 @@ void triangular_matrix_vector_solve(
 ##### Nonsymmetric nonconjugated rank-1 update [linalg.algs.blas2.rank1.geru]
 
 ```c++
-template<in_vector InVec1,
-         in_vector InVec2,
+template<@_in-vector_@ InVec1,
+         @_in-vector_@ InVec2,
          @_inout-matrix_@ InOutMat>
 void matrix_rank_1_update(
   InVec1 x,
@@ -8350,8 +8353,8 @@ void matrix_rank_1_update(
   InOutMat A);
 
 template<class ExecutionPolicy,
-         in_vector InVec1,
-         in_vector InVec2,
+         @_in-vector_@ InVec1,
+         @_in-vector_@ InVec2,
          @_inout-matrix_@ InOutMat>
 void matrix_rank_1_update(
   ExecutionPolicy&& exec,
@@ -8400,8 +8403,8 @@ as the result of `conjugated`.  Alternately, they can use the shortcut
 ##### Nonsymmetric conjugated rank-1 update [linalg.algs.blas2.rank1.gerc]
 
 ```c++
-template<in_vector InVec1,
-         in_vector InVec2,
+template<@_in-vector_@ InVec1,
+         @_in-vector_@ InVec2,
          @_inout-matrix_@ InOutMat>
 void matrix_rank_1_update_c(
   InVec1 x,
@@ -8409,8 +8412,8 @@ void matrix_rank_1_update_c(
   InOutMat A);
 
 template<class ExecutionPolicy,
-         in_vector InVec1,
-         in_vector InVec2,
+         @_in-vector_@ InVec1,
+         @_in-vector_@ InVec2,
          @_inout-matrix_@ InOutMat>
 void matrix_rank_1_update_c(
   ExecutionPolicy&& exec,
@@ -8428,7 +8431,7 @@ note]*
 ##### Rank-1 update of a Symmetric matrix [linalg.algs.blas2.rank1.syr]
 
 ```c++
-template<in_vector InVec,
+template<@_in-vector_@ InVec,
          @_inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_1_update(
@@ -8436,7 +8439,7 @@ void symmetric_matrix_rank_1_update(
   InOutMat A,
   Triangle t);
 template<class ExecutionPolicy,
-         in_vector InVec,
+         @_in-vector_@ InVec,
          @_inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_1_update(
@@ -8445,7 +8448,7 @@ void symmetric_matrix_rank_1_update(
   InOutMat A,
   Triangle t);
 template<class T,
-         in_vector InVec,
+         @_in-vector_@ InVec,
          @_inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_1_update(
@@ -8455,7 +8458,7 @@ void symmetric_matrix_rank_1_update(
   Triangle t);
 template<class ExecutionPolicy,
          class T,
-         in_vector InVec,
+         @_in-vector_@ InVec,
          @_inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_1_update(
@@ -8528,7 +8531,7 @@ the mathematical expression for the algorithm is
 ##### Rank-1 update of a Hermitian matrix [linalg.algs.blas2.rank1.her]
 
 ```c++
-template<in_vector InVec,
+template<@_in-vector_@ InVec,
          @_inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_1_update(
@@ -8536,7 +8539,7 @@ void hermitian_matrix_rank_1_update(
   InOutMat A,
   Triangle t);
 template<class ExecutionPolicy,
-         in_vector InVec,
+         @_in-vector_@ InVec,
          @_inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_1_update(
@@ -8545,7 +8548,7 @@ void hermitian_matrix_rank_1_update(
   InOutMat A,
   Triangle t);
 template<class T,
-         in_vector InVec,
+         @_in-vector_@ InVec,
          @_inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_1_update(
@@ -8555,7 +8558,7 @@ void hermitian_matrix_rank_1_update(
   Triangle t);
 template<class ExecutionPolicy,
          class T,
-         in_vector InVec,
+         @_in-vector_@ InVec,
          @_inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_1_update(
@@ -8633,8 +8636,8 @@ the mathematical expression for the algorithm is
 #### Rank-2 update of a symmetric matrix [linalg.algs.blas2.rank2.syr2]
 
 ```c++
-template<in_vector InVec1,
-         in_vector InVec2,
+template<@_in-vector_@ InVec1,
+         @_in-vector_@ InVec2,
          @_inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_2_update(
@@ -8644,8 +8647,8 @@ void symmetric_matrix_rank_2_update(
   Triangle t);
 
 template<class ExecutionPolicy,
-         in_vector InVec1,
-         in_vector InVec2,
+         @_in-vector_@ InVec1,
+         @_in-vector_@ InVec2,
          @_inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_2_update(
@@ -8710,8 +8713,8 @@ the mathematical expression for the algorithm is
 #### Rank-2 update of a Hermitian matrix [linalg.algs.blas2.rank2.her2]
 
 ```c++
-template<in_vector InVec1,
-         in_vector InVec2,
+template<@_in-vector_@ InVec1,
+         @_in-vector_@ InVec2,
          @_inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_2_update(
@@ -8721,8 +8724,8 @@ void hermitian_matrix_rank_2_update(
   Triangle t);
 
 template<class ExecutionPolicy,
-         in_vector InVec1,
-         in_vector InVec2,
+         @_in-vector_@ InVec1,
+         @_in-vector_@ InVec2,
          @_inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_2_update(
@@ -8832,17 +8835,17 @@ The following requirements apply to all functions in this section.
 ##### Overwriting general matrix-matrix product
 
 ```c++
-template<in_matrix InMat1,
-         in_matrix InMat2,
-         out_matrix OutMat>
+template<@_in-matrix_@ InMat1,
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat>
 void matrix_product(InMat1 A,
                     InMat2 B,
                     OutMat C);
 
 template<class ExecutionPolicy,
-         in_matrix InMat1,
-         in_matrix InMat2,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat1,
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat>
 void matrix_product(ExecutionPolicy&& exec,
                     InMat1 A,
                     InMat2 B,
@@ -8860,20 +8863,20 @@ for all `k` such that `i,k` is in the domain of `A`.
 ##### Updating general matrix-matrix product
 
 ```c++
-template<in_matrix InMat1,
-         in_matrix InMat2,
-         in_matrix InMat3,
-         out_matrix OutMat>
+template<@_in-matrix_@ InMat1,
+         @_in-matrix_@ InMat2,
+         @_in-matrix_@ InMat3,
+         @_out-matrix_@ OutMat>
 void matrix_product(InMat1 A,
                     InMat2 B,
                     InMat3 E,
                     OutMat C);
 
 template<class ExecutionPolicy,
-         in_matrix InMat1,
-         in_matrix InMat2,
-         in_matrix InMat3,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat1,
+         @_in-matrix_@ InMat2,
+         @_in-matrix_@ InMat3,
+         @_out-matrix_@ OutMat>
 void matrix_product(ExecutionPolicy&& exec,
                     InMat1 A,
                     InMat2 B,
@@ -9008,20 +9011,20 @@ The following requirements apply to all overloads of
 ##### Overwriting symmetric matrix-matrix left product [linalg.algs.blas3.symm.ov.left]
 
 ```c++
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
-         in_matrix InMat2,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat>
 void symmetric_matrix_left_product(
   InMat1 A,
   Triangle t,
   InMat2 B,
   OutMat C);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
-         in_matrix InMat2,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat>
 void symmetric_matrix_left_product(
   ExecutionPolicy&& exec,
   InMat1 A,
@@ -9047,20 +9050,20 @@ and in the triangle of `A` specified by `t`.
 ##### Overwriting symmetric matrix-matrix right product [linalg.algs.blas3.symm.ov.right]
 
 ```c++
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
-         in_matrix InMat2,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat>
 void symmetric_matrix_right_product(
   InMat1 A,
   Triangle t,
   InMat2 B,
   OutMat C);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
-         in_matrix InMat2,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat>
 void symmetric_matrix_right_product(
   ExecutionPolicy&& exec,
   InMat1 A,
@@ -9087,11 +9090,11 @@ and in the triangle of `A` specified by `t`.
 ##### Updating symmetric matrix-matrix left product [linalg.algs.blas3.symm.up.left]
 
 ```c++
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
-         in_matrix InMat2,
-         in_matrix InMat3,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_in-matrix_@ InMat3,
+         @_out-matrix_@ OutMat>
 void symmetric_matrix_left_product(
   InMat1 A,
   Triangle t,
@@ -9099,11 +9102,11 @@ void symmetric_matrix_left_product(
   InMat3 E,
   OutMat C);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
-         in_matrix InMat2,
-         in_matrix InMat3,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_in-matrix_@ InMat3,
+         @_out-matrix_@ OutMat>
 void symmetric_matrix_left_product(
   ExecutionPolicy&& exec,
   InMat1 A,
@@ -9130,11 +9133,11 @@ and in the triangle of `A` specified by `t`.
 ##### Updating symmetric matrix-matrix right product [linalg.algs.blas3.symm.up.right]
 
 ```c++
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
-         in_matrix InMat2,
-         in_matrix InMat3,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_in-matrix_@ InMat3,
+         @_out-matrix_@ OutMat>
 void symmetric_matrix_right_product(
   InMat1 A,
   Triangle t,
@@ -9142,11 +9145,11 @@ void symmetric_matrix_right_product(
   InMat3 E,
   OutMat C);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
-         in_matrix InMat2,
-         in_matrix InMat3,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_in-matrix_@ InMat3,
+         @_out-matrix_@ OutMat>
 void symmetric_matrix_right_product(
   ExecutionPolicy&& exec,
   InMat1 A,
@@ -9287,20 +9290,20 @@ The following requirements apply to all overloads of
 ##### Overwriting Hermitian matrix-matrix left product [linalg.algs.blas3.hemm.ov.left]
 
 ```c++
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
-         in_matrix InMat2,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat>
 void hermitian_matrix_left_product(
   InMat1 A,
   Triangle t,
   InMat2 B,
   OutMat C);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
-         in_matrix InMat2,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat>
 void hermitian_matrix_left_product(
   ExecutionPolicy&& exec,
   InMat1 A,
@@ -9327,20 +9330,20 @@ and in the triangle of `A` specified by `t`.
 ##### Overwriting Hermitian matrix-matrix right product [linalg.algs.blas3.hemm.ov.right]
 
 ```c++
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
-         in_matrix InMat2,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat>
 void hermitian_matrix_right_product(
   InMat1 A,
   Triangle t,
   InMat2 B,
   OutMat C);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
-         in_matrix InMat2,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat>
 void hermitian_matrix_right_product(
   ExecutionPolicy&& exec,
   InMat1 A,
@@ -9367,11 +9370,11 @@ and in the triangle of `A` specified by `t`.
 ##### Updating Hermitian matrix-matrix left product [linalg.algs.blas3.hemm.up.left]
 
 ```c++
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
-         in_matrix InMat2,
-         in_matrix InMat3,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_in-matrix_@ InMat3,
+         @_out-matrix_@ OutMat>
 void hermitian_matrix_left_product(
   InMat1 A,
   Triangle t,
@@ -9379,11 +9382,11 @@ void hermitian_matrix_left_product(
   InMat3 E,
   OutMat C);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
-         in_matrix InMat2,
-         in_matrix InMat3,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_in-matrix_@ InMat3,
+         @_out-matrix_@ OutMat>
 void hermitian_matrix_left_product(
   ExecutionPolicy&& exec,
   InMat1 A,
@@ -9411,11 +9414,11 @@ and in the triangle of `A` specified by `t`.
 ##### Updating Hermitian matrix-matrix right product [linalg.algs.blas3.hemm.up.right]
 
 ```c++
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
-         in_matrix InMat2,
-         in_matrix InMat3,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_in-matrix_@ InMat3,
+         @_out-matrix_@ OutMat>
 void hermitian_matrix_right_product(
   InMat1 A,
   Triangle t,
@@ -9423,11 +9426,11 @@ void hermitian_matrix_right_product(
   InMat3 E,
   OutMat C);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
-         in_matrix InMat2,
-         in_matrix InMat3,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_in-matrix_@ InMat3,
+         @_out-matrix_@ OutMat>
 void hermitian_matrix_right_product(
   ExecutionPolicy&& exec,
   InMat1 A,
@@ -9568,11 +9571,11 @@ The following requirements apply to all overloads of
 Not-in-place overwriting triangular matrix-matrix left product
 
 ```c++
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
-         in_matrix InMat2,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat>
 void triangular_matrix_left_product(
   InMat1 A,
   Triangle t,
@@ -9580,11 +9583,11 @@ void triangular_matrix_left_product(
   InMat2 B,
   OutMat C);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
-         in_matrix InMat2,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat>
 void triangular_matrix_left_product(
   ExecutionPolicy&& exec,
   InMat1 A,
@@ -9606,7 +9609,7 @@ and in the triangle of `A` specified by `t` and `d`.
 In-place overwriting triangular matrix-matrix left product
 
 ```c++
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
          @_inout-matrix_@ InOutMat>
@@ -9616,7 +9619,7 @@ void triangular_matrix_left_product(
   DiagonalStorage d,
   InOutMat C);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
          @_inout-matrix_@ InOutMat>
@@ -9647,11 +9650,11 @@ and in the triangle of `A` specified by `t` and `d`.
 
 Not-in-place overwriting triangular matrix-matrix right product
 ```c++
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
-         in_matrix InMat2,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat>
 void triangular_matrix_right_product(
   InMat1 A,
   Triangle t,
@@ -9659,11 +9662,11 @@ void triangular_matrix_right_product(
   InMat2 B,
   OutMat C);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
-         in_matrix InMat2,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat>
 void triangular_matrix_right_product(
   ExecutionPolicy&& exec,
   InMat1 A,
@@ -9684,7 +9687,7 @@ and in the triangle of `A` specified by `t` and `d`.
 
 In-place overwriting triangular matrix-matrix right product
 ```c++
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
          @_inout-matrix_@ InOutMat>
@@ -9694,7 +9697,7 @@ void triangular_matrix_right_product(
   DiagonalStorage d,
   InOutMat C);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
          @_inout-matrix_@ InOutMat>
@@ -9724,12 +9727,12 @@ and in the triangle of `A` specified by `t` and `d`.
 ##### Updating triangular matrix-matrix left product [linalg.algs.blas3.trmm.up.left]
 
 ```c++
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
-         in_matrix InMat2,
-         in_matrix InMat3,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_in-matrix_@ InMat3,
+         @_out-matrix_@ OutMat>
 void triangular_matrix_left_product(
   InMat1 A,
   Triangle t,
@@ -9738,12 +9741,12 @@ void triangular_matrix_left_product(
   InMat3 E,
   OutMat C);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
-         in_matrix InMat2,
-         in_matrix InMat3,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_in-matrix_@ InMat3,
+         @_out-matrix_@ OutMat>
 void triangular_matrix_left_product(
   ExecutionPolicy&& exec,
   InMat1 A,
@@ -9766,12 +9769,12 @@ and in the triangle of `A` specified by `t` and `d`.
 ##### Updating triangular matrix-matrix right product [linalg.algs.blas3.trmm.up.right]
 
 ```c++
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
-         in_matrix InMat2,
-         in_matrix InMat3,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_in-matrix_@ InMat3,
+         @_out-matrix_@ OutMat>
 void triangular_matrix_right_product(
   InMat1 A,
   Triangle t,
@@ -9780,12 +9783,12 @@ void triangular_matrix_right_product(
   InMat3 E,
   OutMat C);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
-         in_matrix InMat2,
-         in_matrix InMat3,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_in-matrix_@ InMat3,
+         @_out-matrix_@ OutMat>
 void triangular_matrix_right_product(
   ExecutionPolicy&& exec,
   InMat1 A,
@@ -9819,7 +9822,7 @@ to the input matrix. <i>-- end note]</i>
 
 ```c++
 template<class T,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          @_inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_k_update(
@@ -9829,7 +9832,7 @@ void symmetric_matrix_rank_k_update(
   Triangle t);
 template<class ExecutionPolicy,
          class T,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          @_inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_k_update(
@@ -9898,7 +9901,7 @@ for all `k` such that `i,k` is in the domain of `A`.
 
 ```c++
 template<class T,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          @_inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_k_update(
@@ -9908,7 +9911,7 @@ void hermitian_matrix_rank_k_update(
   Triangle t);
 template<class ExecutionPolicy,
          class T,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          @_inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_k_update(
@@ -9986,8 +9989,8 @@ to the input matrices. <i>-- end note]</i>
 ##### Rank-2k symmetric matrix update [linalg.alg.blas3.rank2k.syr2k]
 
 ```c++
-template<in_matrix InMat1,
-         in_matrix InMat2,
+template<@_in-matrix_@ InMat1,
+         @_in-matrix_@ InMat2,
          @_inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_2k_update(
@@ -9996,8 +9999,8 @@ void symmetric_matrix_rank_2k_update(
   InOutMat C,
   Triangle t);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
-         in_matrix InMat2,
+         @_in-matrix_@ InMat1,
+         @_in-matrix_@ InMat2,
          @_inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_2k_update(
@@ -10065,8 +10068,8 @@ for all `k2` such that `i,k2` is in the domain of `B`.
 ##### Rank-2k Hermitian matrix update [linalg.alg.blas3.rank2k.her2k]
 
 ```c++
-template<in_matrix InMat1,
-         in_matrix InMat2,
+template<@_in-matrix_@ InMat1,
+         @_in-matrix_@ InMat2,
          @_inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_2k_update(
@@ -10076,8 +10079,8 @@ void hermitian_matrix_rank_2k_update(
   Triangle t);
 
 template<class ExecutionPolicy,
-         in_matrix InMat1,
-         in_matrix InMat2,
+         @_in-matrix_@ InMat1,
+         @_in-matrix_@ InMat2,
          @_inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_2k_update(
@@ -10202,11 +10205,11 @@ The following requirements apply to all functions in this section.
 Not-in-place left solve of multiple triangular systems
 
 ```c++
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
-         in_matrix InMat2,
-         out_matrix OutMat,
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_left_solve(
   InMat1 A,
@@ -10216,11 +10219,11 @@ void triangular_matrix_matrix_left_solve(
   OutMat X,
   BinaryDivideOp divide);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
-         in_matrix InMat2,
-         out_matrix OutMat,
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_left_solve(
   ExecutionPolicy&& exec,
@@ -10231,11 +10234,11 @@ void triangular_matrix_matrix_left_solve(
   OutMat X,
   BinaryDivideOp divide);
 
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
-         in_matrix InMat2,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat>
 void triangular_matrix_matrix_left_solve(
   InMat1 A,
   Triangle t,
@@ -10243,11 +10246,11 @@ void triangular_matrix_matrix_left_solve(
   InMat2 B,
   OutMat X);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
-         in_matrix InMat2,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat>
 void triangular_matrix_matrix_left_solve(
   ExecutionPolicy&& exec,
   InMat1 A,
@@ -10299,7 +10302,7 @@ in the subset of the domain of `A` specified by `t`.
 In-place left solve of multiple triangular systems
 
 ```c++
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
          @_inout-matrix_@ InOutMat,
@@ -10311,7 +10314,7 @@ void triangular_matrix_matrix_left_solve(
   InOutMat B,
   BinaryDivideOp divide);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
          @_inout-matrix_@ InOutMat,
@@ -10324,7 +10327,7 @@ void triangular_matrix_matrix_left_solve(
   InOutMat B,
   BinaryDivideOp divide);
 
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
          @_inout-matrix_@ InOutMat>
@@ -10334,7 +10337,7 @@ void triangular_matrix_matrix_left_solve(
   DiagonalStorage d,
   InOutMat B);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
          @_inout-matrix_@ InOutMat>
@@ -10405,11 +10408,11 @@ in the subset of the domain of `A` specified by `t`.
 Not-in-place right solve of multiple triangular systems
 
 ```c++
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
-         in_matrix InMat2,
-         out_matrix OutMat,
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_right_solve(
   InMat1 A,
@@ -10419,11 +10422,11 @@ void triangular_matrix_matrix_right_solve(
   OutMat X,
   BinaryDivideOp divide);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
-         in_matrix InMat2,
-         out_matrix OutMat,
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat,
          class BinaryDivideOp>
 void triangular_matrix_matrix_right_solve(
   ExecutionPolicy&& exec,
@@ -10434,11 +10437,11 @@ void triangular_matrix_matrix_right_solve(
   OutMat X,
   BinaryDivideOp divide);
 
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
-         in_matrix InMat2,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat>
 void triangular_matrix_matrix_right_solve(
   InMat1 A,
   Triangle t,
@@ -10446,11 +10449,11 @@ void triangular_matrix_matrix_right_solve(
   InMat2 B,
   OutMat X);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
-         in_matrix InMat2,
-         out_matrix OutMat>
+         @_in-matrix_@ InMat2,
+         @_out-matrix_@ OutMat>
 void triangular_matrix_matrix_right_solve(
   ExecutionPolicy&& exec,
   InMat1 A,
@@ -10519,7 +10522,7 @@ is the product of the reversed matrices in transposed order.
 In-place right solve of multiple triangular systems
 
 ```c++
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
          @_inout-matrix_@ InOutMat,
@@ -10531,7 +10534,7 @@ void triangular_matrix_matrix_right_solve(
   InOutMat B,
   BinaryDivideOp divide);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
          @_inout-matrix_@ InOutMat,
@@ -10544,7 +10547,7 @@ void triangular_matrix_matrix_right_solve(
   InOutMat B,
   BinaryDivideOp divide);  
 
-template<in_matrix InMat1,
+template<@_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
          @_inout-matrix_@ InOutMat>
@@ -10554,7 +10557,7 @@ void triangular_matrix_matrix_right_solve(
   DiagonalStorage d,
   InOutMat B);
 template<class ExecutionPolicy,
-         in_matrix InMat1,
+         @_in-matrix_@ InMat1,
          class Triangle,
          class DiagonalStorage,
          @_inout-matrix_@ InOutMat>
@@ -10733,10 +10736,10 @@ example in-place in the matrix `A`.  The example assumes that
 `cholesky_factor(A, t)` returned `nullopt`, indicating no zero or NaN pivots.
 
 ```c++
-template<in_matrix InMat,
+template<@_in-matrix_@ InMat,
          class Triangle,
-         in_vector InVec,
-         out_vector OutVec>
+         @_in-vector_@ InVec,
+         @_out-vector_@ OutVec>
 void cholesky_solve(
   InMat A,
   Triangle t,
@@ -10777,7 +10780,7 @@ means that the matrix has many more rows than columns.
 ```c++
 // Compute QR factorization A = Q R, with A storing Q.
 template<@_inout-matrix_@ InOutMat,
-         out_matrix OutMat>
+         @_out-matrix_@ OutMat>
 optional<typename InOutMat::size_type>
 cholesky_tsqr_one_step(
   InOutMat A, // A on input, Q on output
@@ -10828,10 +10831,10 @@ cholesky_tsqr_one_step(
 
 // Compute QR factorization A = Q R.  Use R_tmp as temporary R factor
 // storage for iterative refinement.
-template<in_matrix InMat,
-         out_matrix OutMat1,
-         out_matrix OutMat2,
-         out_matrix OutMat3>
+template<@_in-matrix_@ InMat,
+         @_out-matrix_@ OutMat1,
+         @_out-matrix_@ OutMat2,
+         @_out-matrix_@ OutMat3>
 optional<typename OutMat1::size_type>
 cholesky_tsqr(
   InMat A,

--- a/D1673/P1673.md
+++ b/D1673/P1673.md
@@ -8113,7 +8113,18 @@ void triangular_matrix_vector_solve(
   in_vector_t b,
   out_vector_t x,
   BinaryDivideOp divide);
+```
 
+* *Preconditions:* `A.extent(0)` equals `x.extent(0)`.
+
+* *Constraints:* `x.rank()` equals 1 and `b.rank()` equals 1.
+
+* *Mandates:* If neither `A.static_extent(0)` nor `x.static_extent(0)` equals
+    `dynamic_extent`, then `A.static_extent(0)` equals `x.static_extent(0)`.
+
+* *Effects:* Computes $x$ such that $b = A x$.  If no such $x$ exists, then the elements of $x$ are valid but unspecified.
+
+```c++
 template<class in_matrix_t,
          class Triangle,
          class DiagonalStorage,
@@ -8125,6 +8136,11 @@ void triangular_matrix_vector_solve(
   DiagonalStorage d,
   in_vector_t b,
   out_vector_t x);
+```
+
+* *Effects:* Equivalent to `triangular_matrix_vector_solve(A, t, d, b, x, [](const auto& A_ii, const auto& b_i) { return A_ii / b_i; });`.
+
+```c++
 template<class ExecutionPolicy,
          class in_matrix_t,
          class Triangle,
@@ -8140,36 +8156,7 @@ void triangular_matrix_vector_solve(
   out_vector_t x);
 ```
 
-If `DiagonalStorage` is `explicit_diagonal_t`,
-then for `i` in the domain of `x`,
-the mathematical expression for the algorithm is
-
-* `x[i] = divide(b[i] - s, A[i,i])`
-    for overloads with a `divide` parameter, and
-
-* `x[i] = (b[i] - s) / A[i,i]` for all other overloads,
-
-where `s` is the sum of `A[i,j] * x[j]`
-for all `j` not equal to `i`
-in the subset of the domain of `A` specified by `t` and `d`.
-
-If `DiagonalStorage` is `implicit_unit_diagonal_t`,
-then for `i` in the domain of `x`,
-the mathematical expression for the algorithm is
-`x[i] = b[i] - s`,
-where `s` is the sum of `A[i,j] * x[j]`
-for all `j` not equal to `i`
-in the subset of the domain of `A` specified by `t` and `d`.
-
-* *Preconditions:* `A.extent(0)` equals `x.extent(0)`.
-
-* *Constraints:* `x.rank()` equals 1 and `b.rank()` equals 1.
-
-* *Mandates:* If neither `A.static_extent(0)` nor `x.static_extent(0)` equals
-    `dynamic_extent`, then `A.static_extent(0)` equals `x.static_extent(0)`.
-
-* *Effects:* Assigns to the elements of `x` the result of solving the
-    triangular linear system Ax=b.
+* *Effects:* Equivalent to `triangular_matrix_vector_solve(forward<ExecutionPolicy>(exec), A, t, d, b, x, [](const auto& A_ii, const auto& b_i) { return A_ii / b_i; });`.
 
 ##### In-place triangular solve [linalg.algs.blas2.trsv.in-place]
 
@@ -8198,7 +8185,26 @@ void triangular_matrix_vector_solve(
   DiagonalStorage d,
   inout_vector_t b,
   BinaryDivideOp divide);
+```
 
+*[Note:*
+
+Performing triangular solve in place hinders parallelization.
+However, other `ExecutionPolicy`-specific optimizations,
+such as vectorization, are still possible.
+This is why the `ExecutionPolicy` overload exists.
+
+--*end note]*
+
+* *Preconditions:* `A.extent(0)` equals `b.extent(0)`.
+
+* *Mandates:* If neither `A.static_extent(0)` nor `b.static_extent(0)`
+    equals `dynamic_extent`,
+    then `A.static_extent(0)` equals `b.static_extent(0)`.
+
+* *Effects:* Overwrites $b$ with $x$ such that $b = A x$.  If no such $x$ exists, then the elements of $b$ are valid but unspecified.
+
+```c++
 template<class in_matrix_t,
          class Triangle,
          class DiagonalStorage,
@@ -8208,6 +8214,11 @@ void triangular_matrix_vector_solve(
   Triangle t,
   DiagonalStorage d,
   inout_vector_t b);
+```
+
+* *Effects:* Equivalent to `triangular_matrix_vector_solve(A, t, d, b, [](const auto& A_ii, const auto& b_i){ return A_ii / b_i; });`.
+
+```c++
 template<class ExecutionPolicy,
          class in_matrix_t,
          class Triangle,
@@ -8221,44 +8232,7 @@ void triangular_matrix_vector_solve(
   inout_vector_t b);
 ```
 
-*[Note:*
-
-Performing triangular solve in place hinders parallelization.
-However, other `ExecutionPolicy`-specific optimizations,
-such as vectorization, are still possible.
-This is why the `ExecutionPolicy` overload exists.
-
---*end note]*
-
-If `DiagonalStorage` is `explicit_diagonal_t`,
-then for `i` in the domain of `x`,
-the mathematical expression for the algorithm is
-
-* `b[i] = divide(b[i] - s, A[i,i])`
-    for overloads with a `divide` parameter, and
-
-* `b[i] = (b[i] - s) / A[i,i]` for all other overloads,
-
-where `s` is the sum of `A[i,j] * b[j]`
-for all `j` not equal to `i`
-in the subset of the domain of `A` specified by `t` and `d`.
-
-If `DiagonalStorage` is `implicit_unit_diagonal_t`,
-then for `i` in the domain of `x`,
-the mathematical expression for the algorithm is
-`b[i] = b[i] - s`,
-where `s` is the sum of `A[i,j] * b[j]`
-for all `j` not equal to `i`
-in the subset of the domain of `A` specified by `t` and `d`.
-
-* *Preconditions:* `A.extent(0)` equals `b.extent(0)`.
-
-* *Mandates:* If neither `A.static_extent(0)` nor `b.static_extent(0)`
-    equals `dynamic_extent`,
-    then `A.static_extent(0)` equals `b.static_extent(0)`.
-
-* *Effects:* Overwrites `b` with the result of solving the triangular
-    linear system Ax=b for x.
+* *Effects:* Equivalent to `triangular_matrix_vector_solve(forward<ExecutionPolicy>(exec), A, t, d, b, [](const auto& A_ii, const auto& b_i){ return A_ii / b_i; });`.
 
 #### Rank-1 (outer product) update of a matrix [linalg.algs.blas2.rank1]
 


### PR DESCRIPTION
@crtrott @dalg24 

* Make document build with Pandoc and produce reasonable output.  (Pandoc conversion is ongoing; its completion can be deferred to future pull requests.)

* Replace name-based mdspan requirements with exposition-only concepts.

* Experimentally simplify `*_matrix_vector_product` wording (please review that part with care).