### PR TITLE
P1673: Address constraints issue; fix some formatting

### DIFF
--- a/D1673/P1673.md
+++ b/D1673/P1673.md
@@ -470,10 +470,23 @@ toc: true
   * Make `matrix_vector_product` template parameter order
       consistent with parameter order.
 
-  * Add new exposition-only constraint _`possibly-packed-inout-matrix`_
-      to account for symmetric or Hermitian update algorithms.
+  * Add new exposition-only concept _`possibly-packed-inout-matrix`_
+      to constrain symmetric and Hermitian update algorithms.
       These may write either to a unique-layout mdspan
       or to a `layout_blas_packed` mdspan (whose layout is nonunique).
+
+  * Remove Constraints made redundant by the new exposition-only concepts.
+
+  * Follow LEWG guidance to simplify Effects and Constraints
+    (e.g., removing wording referring to the
+    "the mathematical expression for the algorithm")
+    by describing them mathematically (in math font).
+    ("Mathematical expression for the algorithm"
+    remains in a few places that call for more careful analysis.)
+
+  * Change `matrix_one_norm` Precondition (that the result of `abs` of a matrix element is convertible to `T`) to a Constraint.
+
+  * Change `vector_abs_sum` Precondition (that the result of `init + abs(v[i])` is convertible to `T`) to a Constraint.
 
 # Purpose of this paper
 
@@ -1846,7 +1859,7 @@ These operations change both the matrix's mathematical properties and its repres
 For example, one might have an N x N array representing a matrix that is symmetric in theory,
 but computed and stored in a way that might not result in exactly symmetric data.
 In order to solve linear systems with this matrix,
-one might give the array to LAPACK's `xSYTRF` to compute an LDL^T factorization,
+one might give the array to LAPACK's `xSYTRF` to compute an $L D L^T$ factorization,
 asking `xSYTRF` only to access the array's lower triangle.
 If `xSYTRF` finishes successfully,
 it has overwritten the lower triangle of its input
@@ -1855,7 +1868,7 @@ and the block diagonal matrix D,
 as computed assuming that the matrix is the sum of the lower triangle
 and the transpose of the lower triangle.
 The resulting N x N array no longer represents a symmetric matrix.
-Rather, it contains part of the representation of a LDL^T factorization of the matrix.
+Rather, it contains part of the representation of a $L D L^T$ factorization of the matrix.
 The upper triangle still contains the original input matrix's data.
 One may then solve linear systems by giving `xSYTRS` the lower triangle,
 along with other output of `xSYTRF`.
@@ -3620,13 +3633,13 @@ void swap_elements(ExecutionPolicy&& exec,
 template<class Scalar,
          @_inout-object_@ InOutObj>
 void scale(const Scalar alpha,
-           InOutObj obj);
+           InOutObj x);
 template<class ExecutionPolicy,
          class Scalar,
          @_inout-object_@ InOutObj>
 void scale(ExecutionPolicy&& exec,
            const Scalar alpha,
-           InOutObj obj);
+           InOutObj x);
 
 // [linalg.algs.blas1.copy], copy elements
 template<@_in-object_@ InObj,
@@ -5409,7 +5422,7 @@ constexpr mapping(const extents_type& e) noexcept;
 
     * `e.extent(0)` equals `e.extent(1)`.
 
-* *Effects:* Direct-non-list-initializes _`extents_`_ with `e`.
+* *Effects:* Direct-non-list-initializes _`the-extents`_ with `e`.
 
 ```c++
 template<class OtherExtents>
@@ -5422,7 +5435,7 @@ template<class OtherExtents>
 *Preconditions:* `other.required_span_size()` is representable as a value
     of type `index_type` (**[basic.fundamental]**).
 
-*Effects:* Direct-non-list-initializes _`extents_`_ with `other.extents()`.
+*Effects:* Direct-non-list-initializes _`the-extents`_ with `other.extents()`.
 
 ```c++
 constexpr index_type required_span_size() const noexcept;
@@ -5447,7 +5460,7 @@ template<class ... Indices>
   * `(is_nothrow_constructible_v<index_type, Indices>)` is `true`.
 
 *Preconditions:* `extents_type::`_`index-cast`_`(k)` is
-    a multidimensional index in _`extents_`_ (**[mdspan.overview]**).
+    a multidimensional index in _`the-extents`_ (**[mdspan.overview]**).
 
 *Returns:* Let `N` equal `extent(0)`, let `i` be the zeroth element of `k`,
     and let `j` be the first element of `k`.  Then:
@@ -6927,12 +6940,16 @@ These functions correspond to the BLAS function `xROT`.  `c` and `s`
 form a plane (Givens) rotation.  Users normally would compute `c` and
 `s` using `givens_rotation_setup`, but they are not required to do
 this.
-<i>-- end note]</i>
 
 For `i` in the domains of both `x` and `y`,
-the mathematical expressions for the algorithm are
-`x[i] = c*x[i] + s*y[i]` and
-`y[i] = c*y[i] - `_`conj-if-needed`_`(s)*x[i]`.
+if $x_i$ is the value of `x[i]` on input
+and $y_i$ is the value of `y[i]` on input,
+then this algorithm computes
+$x_i'$ such that $x_i' = c x_i + s y_i$ and
+$y_i'$ such that $y_i' = c y_i - \bar{s} x_i$
+(where $\bar{s}$ denotes the complex conjugate of $s$),
+and assigns $x_i'$ to `x[i]` and $y_i'$ to `y[i]`.
+<i>-- end note]</i>
 
 * *Preconditions:* `x.extent(0)` equals `y.extent(0)`.
 
@@ -6967,22 +6984,14 @@ void swap_elements(ExecutionPolicy&& exec,
 * *Preconditions:* For all `r` in 0, 1, ..., `x.rank()` - 1,
     `x.extent(r)` equals `y.extent(r)`.
 
-* *Constraints:*
-
-    * `x.rank()` equals `y.rank()`.
-
-    * `x.rank()` is no more than 2.
-
-    * For `i...` in the domain of `x` and `y`,
-        the expression `x[i...] = y[i...]` is well formed.
+* *Constraints:* `x.rank()` equals `y.rank()`.
 
 * *Mandates:* For all `r` in 0, 1, ..., `x.rank()` - 1,
     if neither `x.static_extent(r)` nor `y.static_extent(r)`
     equals `dynamic_extent`,
     then `x.static_extent(r)` equals `y.static_extent(r)`.
 
-* *Effects:* Swap all corresponding elements of the objects
-    `x` and `y`.
+* *Effects:* Swap all corresponding elements of `x` and `y`.
 
 #### Multiply the elements of an object in place by a scalar [linalg.algs.blas1.scal]
 
@@ -6990,26 +6999,20 @@ void swap_elements(ExecutionPolicy&& exec,
 template<class Scalar,
          @_inout-object_@ InOutObj>
 void scale(const Scalar alpha,
-           InOutObj obj);
+           InOutObj x);
 
 template<class ExecutionPolicy,
          class Scalar,
          @_inout-object_@ InOutObj>
 void scale(ExecutionPolicy&& exec,
            const Scalar alpha,
-           InOutObj obj);
+           InOutObj x);
 ```
 
 <i>[Note:</i> These functions correspond to the BLAS function `xSCAL`.
 <i>-- end note]</i>
 
-For `i...` in the domain of `obj`,
-the mathematical expression for the algorithm is `obj[i...] = alpha * obj[i...]`.
-
-* *Constraints:* `obj.rank()` is less than or equal to 2.
-
-* *Effects*: Replace each element of `obj` in place
-    by the product of `alpha` and that element.
+* *Effects*: Overwrites $x$ with the result of computing the elementwise multiplication $alpha x$.
 
 #### Copy elements of one matrix or vector into another [linalg.algs.blas1.copy]
 
@@ -7033,20 +7036,15 @@ void copy(ExecutionPolicy&& exec,
 * *Preconditions:* For all `r` in 0, 1, ..., `x.rank()` - 1,
     `x.extent(r)` equals `y.extent(r)`.
 
-* *Constraints:*
-
-    * `x.rank()` equals `y.rank()`.
-
-    * For all `i...` in the domain of `x` and `y`,
-        the expression `y[i...] = x[i...]` is well formed.
+* *Constraints:* `x.rank()` equals `y.rank()`.
 
 * *Mandates:* For all `r` in 0, 1, ..., `x.rank()` - 1, if neither
     `x.static_extent(r)` nor `y.static_extent(r)` equals
     `dynamic_extent`, then `x.static_extent(r)` equals
     `y.static_extent(r)`.
 
-* *Effects:* Overwrite each element of `y` with the corresponding
-    element of `x`.
+* *Effects:* Overwrites the elements of $y$
+    with the corresponding elements of $x$.
 
 #### Add vectors or matrices elementwise [linalg.algs.blas1.add]
 
@@ -7071,9 +7069,6 @@ void add(ExecutionPolicy&& exec,
 <i>[Note:</i> These functions correspond to the BLAS function `xAXPY`.
 <i>-- end note]</i>
 
-For `i...` in the domains of `x`, `y`, and `z`,
-the mathematical expression for the algorithm is `z[i...] = x[i...] + y[i...]`.
-
 * *Preconditions:* For all `r` in 0, 1, ..., `x.rank()` - 1,
 
     * `x.extent(r)` equals `z.extent(r)`.
@@ -7096,7 +7091,7 @@ the mathematical expression for the algorithm is `z[i...] = x[i...] + y[i...]`.
         `dynamic_extent`, then `x.static_extent(r)` equals
         `y.static_extent(r)`;
 
-* *Effects*: Compute the elementwise sum z = x + y.
+* *Effects*: Computes $z$ such that $z = x + y$.
 
 #### Dot product of two vectors [linalg.algs.blas1.dot]
 
@@ -7124,11 +7119,6 @@ T dot(ExecutionPolicy&& exec,
       InVec2 v2,
       T init);
 ```
-
-For `N` equal to `v1.extent(0)`,
-the mathematical expression for the algorithm is
-`init = init` plus the sum of `v1[i] * v2[i]`
-for all `i` in the domain of `v1`.
 
 * *Preconditions:* `v1.extent(0)` equals `v2.extent(0)`.
 
@@ -7171,9 +7161,11 @@ auto dot(ExecutionPolicy&& exec,
          InVec2 v2) -> /* see-below */;
 ```
 
-* *Effects:* Let `T` be `decltype(v1[0]*v2[0])`.  Then, the
-    two-parameter overload is equivalent to `dot(v1, v2, T{});`, and the
-    three-parameter overload is equivalent to `dot(exec, v1, v2, T{});`.
+* *Effects:* Let `T` be `decltype(declval<typename InVec1::value_type>() * declval<typename InVec2::value_type>())`.
+    Then, the two-parameter overload is equivalent to
+    `dot(v1, v2, T{});`,
+    and the three-parameter overload is equivalent to
+    `dot(exec, v1, v2, T{});`.
 
 ##### Conjugated dot product of two vectors [linalg.algs.blas1.dot.dotc]
 
@@ -7226,7 +7218,7 @@ auto dotc(ExecutionPolicy&& exec,
           InVec2 v2) -> /* see-below */;
 ```
 
-* *Effects:* Let `T` be `decltype(`_`conj-if-needed`_`(v1[0]) * v2[0])`.
+* *Effects:* Let `T` be `decltype(`_`conj-if-needed`_`(declval<typename InVec1::value_type>()]) * declval<typename InVec2::value_type>())`.
     Then, the two-parameter overload is
     equivalent to `dotc(v1, v2, T{});`, and the three-parameter overload
     is equivalent to `dotc(exec, v1, v2, T{});`.
@@ -7273,7 +7265,8 @@ sum_of_squares_result<T> vector_sum_of_squares(
 
     * `scaled_sum_of_squares`: a value such that
         `scaling_factor * scaling_factor * scaled_sum_of_squares`
-        equals the sum of squares of `abs(x[i])` plus
+        equals the sum of squares of `abs(x[i])`
+        for all `i` in the domain of `v`, plus
         `init.scaling_factor * init.scaling_factor * init.scaled_sum_of_squares`.
 
 * *Remarks:* If `InVec::value_type` is either a floating-point type
@@ -7305,21 +7298,11 @@ T vector_norm2(ExecutionPolicy&& exec,
 <i>[Note:</i> These functions correspond to the BLAS function `xNRM2`.
 <i>-- end note]</i>
 
-For `N` equal to `v.extent(0)`,
-the mathematical expression for the algorithm is
-`sqrt(init + s)`,
-where `s` is the sum of `abs(v[i]) * abs(v[i])`
-for all `i` in the domain of `v`.
-<i>[Note:</i>
-This does not imply a recommended implementation for floating-point types.
-See *Remarks* below.
-<i>-- end note]</i>
-
 * *Preconditions:* `init + abs(declval<InVec::value_type>())*abs(declval<InVec::value_type>())`
     shall be convertible to `T`.
 
 * *Effects:* Returns the square root of the sum of squares
-    of `init` and the absolute values of the elements of `A`.
+    of (`init` and the absolute values of the elements of `A`).
     <i>[Note:</i>
     For `init` equal to zero, this is the Euclidean norm
     (also called 2-norm) of the vector `v`.
@@ -7357,7 +7340,7 @@ auto vector_norm2(ExecutionPolicy&& exec,
                   InVec v) -> /* see-below */;
 ```
 
-* *Effects:* Let `T` be `decltype(abs(v[0]) * abs(v[0]))`.
+* *Effects:* Let `T` be `decltype(abs(declval<typename InVec::value_type>()) * abs(declval<typename InVec::value_type>()))`.
     Then, the one-parameter overload is equivalent to
     `vector_norm2(v, T{});`,
     and the two-parameter overload is equivalent to
@@ -7386,19 +7369,23 @@ element types is based on the observation that this lower-cost
 approximation of the one-norm serves just as well as the actual
 one-norm for many linear algebra algorithms in practice. <i>-- end note]</i>
 
+
+
 For `N` equal to `v.extent(0)`,
 the mathematical expression for the algorithm is
 `init` plus the sum of `abs(v[i])`
 for all `i` in the domain of `v`.
 
-* *Preconditions:* For `i` in the domain of `v`,
-    `init + abs(v[i])` shall be convertible to `T`.
+* *Constraints:*
+    `decltype(init + abs(declval<typename InVec::value_type>()))`
+    and `decltype(init + abs(declval<typename InVec::value_type>()))`
+    are both convertible to `T`.
 
 * *Effects:* Let `N` be `v.extent(0)`:
 
     * If `N` is zero, returns `init`;
 
-    * else, if `InVec::value_type` is `complex<R>` for some `R`,
+    * else, if `typename InVec::value_type` is `complex<R>` for some `R`,
         then returns *GENERALIZED_SUM*(`plus<>()`, `init`,
         `abs(real(v[0])) + abs(imag(v[0]))`, ...,
         `abs(real(v[N-1])) + abs(imag(v[N-1]))`).
@@ -7426,7 +7413,7 @@ auto vector_abs_sum(ExecutionPolicy&& exec,
                     InVec v) -> /* see-below */;
 ```
 
-* *Effects:* Let `T` be `decltype(abs(v[0]))`.  Then, the
+* *Effects:* Let `T` be `typename InVec::value_type`.  Then, the
     one-parameter overload is equivalent to `vector_abs_sum(v, T{});`,
     and the two-parameter overload is equivalent to
     `vector_abs_sum(exec, v, T{});`.
@@ -7519,7 +7506,7 @@ auto matrix_frob_norm(
   InMat A) -> /* see-below */;
 ```
 
-* *Effects:* Let `T` be `abs(declval<InMat::value_type>())*abs(declval<InMat::value_type>())`.
+* *Effects:* Let `T` be `abs(declval<typename InMat::value_type>())*abs(declval<typename InMat::value_type>())`.
     Then, the one-parameter overload is equivalent to
     `matrix_frob_norm(A, T{});`,
     and the two-parameter overload is equivalent to
@@ -7544,20 +7531,24 @@ T matrix_one_norm(
   T init);
 ```
 
-* *Preconditions:* `abs(A[0,0])` shall be convertible to `T`.
+* *Constraints:* `abs(declval<typename InMat::value_type>())`
+    is convertible to `T`.
 
 * *Effects:*
 
     * If `A.extent(1)` is zero, returns `init`;
 
-    * else, returns the sum of `init` and the one norm of the matrix `A`.
-        The one norm of the matrix `A` is the maximum over all columns of `A`,
-        of the sum of the absolute values of the elements of the column.
+    * else, returns the sum of `init` and the one norm of the matrix $A$.
 
-* *Remarks:* If `InMat::value_type` is a floating-point type
+<i>[Note:</i>
+The one norm of the matrix `A` is the maximum over all columns of `A`,
+of the sum of the absolute values of the elements of the column.
+<i>-- end note]</i>
+
+* *Remarks:* If `typename InMat::value_type` is a floating-point type
     or `complex<R>` for some floating-point type `R`,
     if `T` is a floating-point type,
-    and if `T` has higher precision than `InMat::value_type`,
+    and if `T` has higher precision than `typename InMat::value_type`,
     then intermediate terms in each sum use `T`'s precision or greater.
 
 ##### One norm with default result type
@@ -7573,7 +7564,7 @@ auto matrix_one_norm(
   InMat A) -> /* see-below */;
 ```
 
-* *Effects:* Let `T` be `decltype(abs(A[0,0])`.
+* *Effects:* Let `T` be `decltype(abs(declval<typename InMat::value_type>())`.
     Then, the one-parameter overload is equivalent to
     `matrix_one_norm(A, T{});`,
     and the two-parameter overload is equivalent to
@@ -7635,7 +7626,7 @@ auto matrix_inf_norm(
   InMat A) -> /* see-below */;
 ```
 
-* *Effects:* Let `T` be `decltype(abs(A[0,0])`.
+* *Effects:* Let `T` be `decltype(abs(declval<typename InMat::value_type>())`.
     Then, the one-parameter overload is equivalent to
     `matrix_inf_norm(A, T{});`,
     and the two-parameter overload is equivalent to
@@ -7777,14 +7768,9 @@ The following requirements apply to all functions in this section.
 
 * *Constraints:*
 
-    * `InMat` either has unique layout, or `layout_blas_packed` layout.
-
     * If `InMat` has `layout_blas_packed` layout, then the
         layout's `Triangle` template argument has the same type as
         the function's `Triangle` template argument.
-
-    * `A.rank()` equals 2, `x.rank()` equals 1, `y.rank()` equals 1, and
-        `z.rank()` equals 1 (if applicable).
 
 * *Mandates:*
 
@@ -7890,14 +7876,9 @@ The following requirements apply to all functions in this section.
 
 * *Constraints:*
 
-    * `InMat` either has unique layout, or `layout_blas_packed` layout.
-
     * If `InMat` has `layout_blas_packed` layout, then the
         layout's `Triangle` template argument has the same type as
         the function's `Triangle` template argument.
-
-    * `A.rank()` equals 2, `x.rank()` equals 1, `y.rank()` equals 1, and
-        `z.rank()` equals 1.
 
 * *Mandates:*
 
@@ -7923,7 +7904,7 @@ The following requirements apply to all functions in this section.
 
 * *Remarks:* The functions will only access the triangle of `A` specified by
     the `Triangle` argument `t`, and will interpret the value `A[i,j]`
-    as equal to _`conj-if-needed`_`A[j,i]` for indices `i,j`
+    as equal to _`conj-if-needed`_`(A[j,i])` for indices `i,j`
     in the domain of `A` but outside the triangle specified by `t`.
 
 ##### Overwriting Hermitian matrix-vector product
@@ -8001,19 +7982,9 @@ The following requirements apply to all functions in this section.
 
 * *Constraints:*
 
-    * `InMat` either has unique layout, or `layout_blas_packed` layout;
-
     * if `InMat` has `layout_blas_packed` layout, then the
         layout's `Triangle` template argument has the same type as
         the function's `Triangle` template argument;
-
-    * `A.rank()` equals 2;
-
-    * `y.rank()` equals 1;
-
-    * `x.rank()` equals 1 (if applicable); and
-
-    * `z.rank()` equals 1 (if applicable).
 
 * *Mandates:*
 
@@ -8170,12 +8141,6 @@ The following requirements apply to all functions in this section.
 
 * *Constraints:*
 
-    * `A.rank()` equals 2;
-
-    * `b.rank()` equals 1;
-
-    * `InMat` either has unique layout, or `layout_blas_packed` layout; and
-
     * if `InMat` has `layout_blas_packed` layout, then the
         layout's `Triangle` template argument has the same type as
         the function's `Triangle` template argument.
@@ -8240,12 +8205,12 @@ void triangular_matrix_vector_solve(
 
 * *Preconditions:* `A.extent(0)` equals `x.extent(0)`.
 
-* *Constraints:* `x.rank()` equals 1 and `b.rank()` equals 1.
-
 * *Mandates:* If neither `A.static_extent(0)` nor `x.static_extent(0)` equals
     `dynamic_extent`, then `A.static_extent(0)` equals `x.static_extent(0)`.
 
-* *Effects:* Computes $x$ such that $b = A x$.  If no such $x$ exists, then the elements of $x$ are valid but unspecified.
+* *Effects:* Computes $x$ such that $b = A x$.
+    If no such $x$ exists,
+    then the elements of $x$ are valid but unspecified.
 
 ```c++
 template<@_in-matrix_@ InMat,
@@ -8325,7 +8290,9 @@ This is why the `ExecutionPolicy` overload exists.
     equals `dynamic_extent`,
     then `A.static_extent(0)` equals `b.static_extent(0)`.
 
-* *Effects:* Overwrites $b$ with $x$ such that $b = A x$.  If no such $x$ exists, then the elements of $b$ are valid but unspecified.
+* *Effects:* Overwrites $b$ with $x$ such that $b = A x$.
+    If no such $x$ exists,
+    then the elements of $b$ are valid but unspecified.
 
 ```c++
 template<@_in-matrix_@ InMat,
@@ -8385,18 +8352,11 @@ void matrix_rank_1_update(
 real element types) and `xGERU` (for complex element types). --*end
 note]*
 
-For `i,j` in the domain of `A`,
-the mathematical expression for the algorithm is
-`A[i,j] += x[i] * y[j]`.
-
 * *Preconditions:*
 
     * `A.extent(0)` equals `x.extent(0)`, and
 
     * `A.extent(1)` equals `y.extent(0)`.
-
-* *Constraints:* `A.rank()` equals 2, `x.rank()` equals 1,
-    and `y.rank()` equals 1.
 
 * *Mandates:*
 
@@ -8408,8 +8368,8 @@ the mathematical expression for the algorithm is
         `dynamic_extent`, then `A.static_extent(1)` equals
         `y.static_extent(0)`.
 
-* *Effects:* Assigns to `A` on output the sum of `A` on input, and the
-    outer product of `x` and `y`.
+* *Effects:* Overwrites $A$ with $A'$ such that $A' = x y^T$,
+    where $y^T$ denotes the transpose of the column vector $y$.
 
 * *Complexity:* The count of `mdspan` array accesses and arithmetic operations
     is linear in `x.extent(0)` times `y.extent(0)`.
@@ -8487,20 +8447,12 @@ void symmetric_matrix_rank_1_update(
   Triangle t);
 ```
 
-<i>[Note:</i>
+<i>[Note:</i> These functions correspond to the BLAS functions
+`xSYR` and `xSPR`.
 
-These functions correspond to the BLAS functions `xSYR` and `xSPR`.
-
-They have overloads taking a scaling factor `alpha`, because it would be
-impossible to express updates like C = C - x x^T otherwise.
-
- <i>-- end note]</i>
-
-For `i,j` in the domain of `A`
-and in the triangle of `A` specified by `t`,
-the mathematical expression for the algorithm is
-`A[i,j] += x[i] * x[j]` for overloads without an `alpha` parameter, and
-`A[i,j] += alpha * x[i] * x[j]` for overloads with an `alpha` parameter.
+They have overloads taking a scaling factor `alpha`,
+because it would be impossible to express updates
+like $C = C - x x^T$ otherwise. <i>-- end note]</i>
 
 * *Preconditions:*
 
@@ -8509,8 +8461,6 @@ the mathematical expression for the algorithm is
     * `A.extent(0)` equals `x.extent(0)`.
 
 * *Constraints:*
-
-    * `A.rank()` equals 2 and `x.rank()` equals 1.
 
     * `A` either has unique layout, or `layout_blas_packed` layout.
 
@@ -8530,13 +8480,13 @@ the mathematical expression for the algorithm is
 
 * *Effects:*
 
-    * Overloads without an `alpha` parameter assign to `A` on output,
-        the elementwise sum of `A` on input,
-        with (the outer product of `x` and `x`).
+    * Overloads without an `alpha` parameter overwrite $A$
+        with $A'$ such that $A' = A + x x^T$,
+        where $x^T$ denotes the transpose of the column vector $x$.
 
-    * Overloads with an `alpha` parameter assign to `A` on output,
-        the elementwise sum of `A` on input,
-        with the product of alpha and (the outer product of `x` and `x`).
+    * Overloads with an `alpha` parameter overwrite $A$
+        with $A'$ such that $A' = A + alpha x x^T$,
+        where $x^T$ denotes the transpose of the column vector $x$.
 
 * *Complexity:* The count of `mdspan` array accesses and arithmetic operations
     is linear in `x.extent(0)` times `x.extent(0)`.
@@ -8587,20 +8537,12 @@ void hermitian_matrix_rank_1_update(
   Triangle t);
 ```
 
-<i>[Note:</i>
+<i>[Note:</i> These functions correspond to the BLAS functions
+`xHER` and `xHPR`.
 
-These functions correspond to the BLAS functions `xHER` and `xHPR`.
-
-They have overloads taking a scaling factor `alpha`, because it would be
-impossible to express the update A = A - x x^H otherwise.
-
-<i>-- end note]</i>
-
-For `i,j` in the domain of `A`
-and in the triangle of `A` specified by `t`,
-the mathematical expression for the algorithm is
-`A[i,j] += x[i] * `_`conj-if-needed`_`(x[j])` for overloads without an `alpha` parameter, and
-`A[i,j] += alpha * x[i] * `_`conj-if-needed`_`(x[j])` for overloads with an `alpha` parameter.
+They have overloads taking a scaling factor `alpha`,
+because it would be impossible to express the update
+$A = A - x x^H$ otherwise. <i>-- end note]</i>
 
 * *Preconditions:*
 
@@ -8609,10 +8551,6 @@ the mathematical expression for the algorithm is
     * `A.extent(0)` equals `x.extent(0)`.
 
 * *Constraints:*
-
-    * `A.rank()` equals 2 and `x.rank()` equals 1.
-
-    * `A` either has unique layout, or `layout_blas_packed` layout.
 
     * If `A` has `layout_blas_packed` layout, then the layout's
         `Triangle` template argument has the same type as the function's
@@ -8630,13 +8568,15 @@ the mathematical expression for the algorithm is
 
 * *Effects:*
 
-    * Overloads without `alpha` assign to `A` on output, the elementwise
-        sum of `A` on input, with (the outer product of `x` and the
-        conjugate of `x`).
+    * Overloads without an `alpha` parameter overwrite $A$
+        with $A'$ such that $A' = A + x x^H$,
+        where $x^H$ denotes the conjugate transpose
+        of the column vector $x$.
 
-    * Overloads with `alpha` assign to `A` on output, the elementwise
-        sum of `A` on input, with alpha times (the outer product of `x`
-        and the conjugate of `x`).
+    * Overloads with an `alpha` parameter overwrite $A$
+        with $A'$ such that $A' = A + alpha x x^H$,
+        where $x^H$ denotes the conjugate transpose
+        of the column vector $x$.
 
 * *Complexity:* The count of `mdspan` array accesses and arithmetic operations
     is linear in `x.extent(0)` times `x.extent(0)`.
@@ -8677,13 +8617,8 @@ void symmetric_matrix_rank_2_update(
   Triangle t);
 ```
 
-<i>[Note:</i> These functions correspond to the BLAS functions `xSYR2` and
-`xSPR2`. <i>-- end note]</i>
-
-For `i,j` in the domain of `A`
-and in the triangle of `A` specified by `t`,
-the mathematical expression for the algorithm is
-`A[i,j] += x[i] * y[j] + y[i] * x[j]`.
+<i>[Note:</i> These functions correspond to the BLAS functions
+`xSYR2` and `xSPR2`. <i>-- end note]</i>
 
 * *Preconditions:*
 
@@ -8694,10 +8629,6 @@ the mathematical expression for the algorithm is
     * `A.extent(0)` equals `y.extent(0)`.
 
 * *Constraints:*
-
-    * `A.rank()` equals 2, `x.rank()` equals 1, and `y.rank()` equals 1.
-
-    * `A` either has unique layout, or `layout_blas_packed` layout.
 
     * If `A` has `layout_blas_packed` layout, then the layout's
         `Triangle` template argument has the same type as the function's
@@ -8717,8 +8648,9 @@ the mathematical expression for the algorithm is
         `dynamic_extent`, then `A.static_extent(0)` equals
         `y.static_extent(0)`.
 
-* *Effects:* Assigns to `A` on output the sum of `A` on input, the
-    outer product of `x` and `y`, and the outer product of `y` and `x`.
+* *Effects:* Overwrites $A$ with $A'$ such that $A' = A + x y^T + y x^T$,
+    where $x^T$ denotes the transpose of the column vector $x$,
+    and $y^T$ denotes the transpose of the column vector $y$.
 
 * *Complexity:* The count of `mdspan` array accesses and arithmetic operations
     is linear in `x.extent(0)` times `y.extent(0)`.
@@ -8754,13 +8686,8 @@ void hermitian_matrix_rank_2_update(
   Triangle t);
 ```
 
-<i>[Note:</i> These functions correspond to the BLAS functions `xHER2` and
-`xHPR2`. <i>-- end note]</i>
-
-For `i,j` in the domain of `A`
-and in the triangle of `A` specified by `t`,
-the mathematical expression for the algorithm is
-`A[i,j] += x[i] * `_`conj-if-needed`_`(y[j]) + y[i] * `_`conj-if-needed`_`(x[j])`.
+<i>[Note:</i> These functions correspond to the BLAS functions
+`xHER2` and `xHPR2`. <i>-- end note]</i>
 
 * *Preconditions:*
 
@@ -8771,10 +8698,6 @@ the mathematical expression for the algorithm is
     * `A.extent(0)` equals `y.extent(0)`.
 
 * *Constraints:*
-
-    * `A.rank()` equals 2, `x.rank()` equals 1, and `y.rank()` equals 1.
-
-    * `A` either has unique layout, or `layout_blas_packed` layout.
 
     * If `A` has `layout_blas_packed` layout, then the layout's
         `Triangle` template argument has the same type as the function's
@@ -8794,16 +8717,16 @@ the mathematical expression for the algorithm is
         `dynamic_extent`, then `A.static_extent(0)` equals
         `y.static_extent(0)`.
 
-* *Effects:* Assigns to `A` on output the sum of `A` on input,
-    the outer product of `x` and the conjugate of `y`,
-    and the outer product of `y` and the conjugate of `x`.
+* *Effects:* Overwrites $A$ with $A'$ such that $A' = A + x y^H + y x^H$,
+    where $x^H$ denotes the conjugate transpose of the column vector $x$,
+    and $y^H$ denotes the conjugate transpose of the column vector $y$.
 
 * *Complexity:* The count of `mdspan` array accesses and arithmetic operations
     is linear in `x.extent(0)` times `y.extent(0)`.
 
 * *Remarks:* The functions will only access the triangle of `A` specified by
     the `Triangle` argument `t`, and will interpret the value `A[i,j]`
-    as equal to _`conj-if-needed`_`A[j,i]` for indices `i,j`
+    as equal to _`conj-if-needed`_`(A[j,i])` for indices `i,j`
     in the domain of `A` but outside the triangle specified by `t`.
 
 ### BLAS 3 functions [linalg.algs.blas3]
@@ -8870,13 +8793,7 @@ void matrix_product(ExecutionPolicy&& exec,
                     OutMat C);
 ```
 
-For `i,j` in the domain of `C`,
-the mathematical expression for the algorithm is
-`C[i,j] =` the sum of `A[i,k] * B[k,j]`
-for all `k` such that `i,k` is in the domain of `A`.
-
-* *Effects:* Assigns to the elements of the matrix `C` the product of
-    the matrices `A` and `B`.
+* *Effects:* Computes $C$ such that $C = A B$.
 
 ##### Updating general matrix-matrix product
 
@@ -8902,13 +8819,7 @@ void matrix_product(ExecutionPolicy&& exec,
                     OutMat C);
 ```
 
-For `i,j` in the domain of `C`,
-the mathematical expression for the algorithm is
-`C[i,j] = E[i,j]` plus the sum of `A[i,k] * B[k,j]`
-for all `k` such that `i,k` is in the domain of `A`.
-
-* *Effects:* Assigns to the elements of the matrix `C` on output, the
-    elementwise sum of `E` and the product of the matrices `A` and `B`.
+* *Effects:* Computes $C$ such that $C = E + A B$.
 
 * *Remarks:* `C` and `E` may refer to the same matrix.
     If so, then they must have the same layout.
@@ -8936,18 +8847,9 @@ The following requirements apply to all functions in this section.
 
 * *Constraints:*
 
-    * `InMat1` either has unique layout,
-        or `layout_blas_packed` layout.
-
-    * `InMat2`, `InMat3` (if applicable),
-        and `OutMat` have unique layout.
-
     * If `InMat1` has `layout_blas_packed` layout, then the
         layout's `Triangle` template argument has the same type as
         the function's `Triangle` template argument.
-
-    * `A.rank()` equals 2, `B.rank()` equals 2, `C.rank()` equals 2, and
-        `E.rank()` (if applicable) equals 2.
 
 * *Mandates:*
 
@@ -9051,19 +8953,7 @@ void symmetric_matrix_left_product(
   OutMat C);
 ```
 
-For `i,j` in the domain of `C`,
-the mathematical expression for the algorithm is
-`C[i,j] = A[i,i] * B[i,j]` plus the sum of `A[i,k1] * B[k1,j]`
-for all `k1` not equal to `i`
-such that `i,k1` is in the domain of `A`
-and in the triangle of `A` specified by `t`,
-plus the sum of `A[k2,i] * B[k2,j]`
-for all `k2` not equal to `i`
-such that `k2,i` is in the domain of `A`
-and in the triangle of `A` specified by `t`.
-
-* *Effects:* Assigns to the elements of the matrix `C`
-    the product of the matrices `A` and `B`.
+* *Effects:* Computes $C$ such that $C = A B$.
 
 ##### Overwriting symmetric matrix-matrix right product [linalg.algs.blas3.symm.ov.right]
 
@@ -9090,20 +8980,7 @@ void symmetric_matrix_right_product(
   OutMat C);
 ```
 
-For `i,j` in the domain of `C`,
-the mathematical expression for the algorithm is
-`C[i,j] = B[i,j] * A[i,i]`
-plus the sum of `B[i,k1] * A[k1,j]`
-for all `k1` not equal to `j`
-such that `k1,j` is in the domain of `A`
-and in the triangle of `A` specified by `t`,
-plus the sum of `B[i,k2] * A[j,k2]`
-for all `k2` not equal to `j`
-such that `k2,j` is in the domain of `A`
-and in the triangle of `A` specified by `t`.
-
-* *Effects:* Assigns to the elements of the matrix `C`
-    the product of the matrices `B` and `A`.
+* *Effects:* Computes $C$ such that $C = B A$.
 
 ##### Updating symmetric matrix-matrix left product [linalg.algs.blas3.symm.up.left]
 
@@ -9134,19 +9011,7 @@ void symmetric_matrix_left_product(
   OutMat C);
 ```
 
-For `i,j` in the domain of `C`,
-the mathematical expression for the algorithm is
-`C[i,j] = E[i,j] + A[i,i] * B[i,j]` plus the sum of `A[i,k1] * B[k1,j]`
-for all `k1` not equal to `i`
-such that `i,k1` is in the domain of `A`
-and in the triangle of `A` specified by `t`,
-plus the sum of `A[k2,i] * B[k2,j]`
-for all `k2` not equal to `i`
-such that `k2,i` is in the domain of `A`
-and in the triangle of `A` specified by `t`.
-
-* *Effects:* assigns to the elements of the matrix `C` on output,
-    the elementwise sum of `E` and the product of the matrices `A` and `B`.
+* *Effects:* Computes $C$ such that $C = E + A B$.
 
 ##### Updating symmetric matrix-matrix right product [linalg.algs.blas3.symm.up.right]
 
@@ -9177,20 +9042,7 @@ void symmetric_matrix_right_product(
   OutMat C);
 ```
 
-For `i,j` in the domain of `C`,
-the mathematical expression for the algorithm is
-`C[i,j] = E[i,j] + B[i,j] * A[i,i]`
-plus the sum of `B[i,k1] * A[k1,j]`
-for all `k1` not equal to `j`
-such that `k1,j` is in the domain of `A`
-and in the triangle of `A` specified by `t`,
-plus the sum of `B[i,k2] * A[j,k2]`
-for all `k2` not equal to `j`
-such that `k2,j` is in the domain of `A`
-and in the triangle of `A` specified by `t`.
-
-* *Effects:* assigns to the elements of the matrix `C` on output, the
-    elementwise sum of `E` and the product of the matrices `B` and `A`.
+* *Effects:* Computes $C$ such that $C = E + B A$.
 
 #### Hermitian matrix-matrix product [linalg.algs.blas3.hemm]
 
@@ -9215,18 +9067,9 @@ The following requirements apply to all functions in this section.
 
 * *Constraints:*
 
-    * `InMat1` either has unique layout,
-        or `layout_blas_packed` layout.
-
-    * `InMat2`, `InMat3` (if applicable), and
-        `OutMat` have unique layout.
-
     * If `InMat1` has `layout_blas_packed` layout, then the
         layout's `Triangle` template argument has the same type as
         the function's `Triangle` template argument.
-
-    * `A.rank()` equals 2, `B.rank()` equals 2, `C.rank()` equals 2, and
-        `E.rank()` (if applicable) equals 2.
 
 * *Mandates:*
 
@@ -9243,7 +9086,7 @@ The following requirements apply to all functions in this section.
 
     * The functions will only access the triangle of `A` specified by
         the `Triangle` argument `t`, and will interpret the value `A[i,j]`
-        as equal to _`conj-if-needed`_`A[j,i]` for indices `i,j`
+        as equal to _`conj-if-needed`_`(A[j,i])` for indices `i,j`
         in the domain of `A` but outside the triangle specified by `t`.
 
     * `C` and `E` (if applicable) may refer to the same matrix.
@@ -9330,20 +9173,7 @@ void hermitian_matrix_left_product(
   OutMat C);
 ```
 
-For `i,j` in the domain of `C`,
-the mathematical expression for the algorithm is
-`C[i,j] = A[i,i] * B[i,j]`
-plus the sum of `A[i,k1] * B[k1,j]`
-for all `k1` not equal to `i`
-such that `i,k1` is in the domain of `A`
-and in the triangle of `A` specified by `t`,
-plus the sum of _`conj-if-needed`_`(A[k2,i]) * B[k2,j]`
-for all `k2` not equal to `i`
-such that `k2,i` is in the domain of `A`
-and in the triangle of `A` specified by `t`.
-
-* *Effects:* Assigns to the elements of the matrix `C` the product of
-    the matrices `A` and `B`.
+* *Effects:* Computes $C$ such that $C = A B$.
 
 ##### Overwriting Hermitian matrix-matrix right product [linalg.algs.blas3.hemm.ov.right]
 
@@ -9370,20 +9200,7 @@ void hermitian_matrix_right_product(
   OutMat C);
 ```
 
-For `i,j` in the domain of `C`,
-the mathematical expression for the algorithm is
-`C[i,j] = B[i,j] * A[i,i]`
-plus the sum of `B[i,k1] * A[k1,j]`
-for all `k1` not equal to `j`
-such that `k1,j` is in the domain of `A`
-and in the triangle of `A` specified by `t`,
-plus the sum of `B[i,k2] * `_`conj-if-needed`_`(A[j,k2])`
-for all `k2` not equal to `j`
-such that `k2,j` is in the domain of `A`
-and in the triangle of `A` specified by `t`.
-
-* *Effects:* Assigns to the elements of the matrix `C` the product of
-    the matrices `B` and `A`.
+* *Effects:* Computes $C$ such that $C = B A$.
 
 ##### Updating Hermitian matrix-matrix left product [linalg.algs.blas3.hemm.up.left]
 
@@ -9414,20 +9231,7 @@ void hermitian_matrix_left_product(
   OutMat C);
 ```
 
-For `i,j` in the domain of `C`,
-the mathematical expression for the algorithm is
-`C[i,j] = E[i,j] + A[i,i] * B[i,j]`
-plus the sum of `A[i,k1] * B[k1,j]`
-for all `k1` not equal to `i`
-such that `i,k1` is in the domain of `A`
-and in the triangle of `A` specified by `t`,
-plus the sum of _`conj-if-needed`_`(A[k2,i]) * B[k2,j]`
-for all `k2` not equal to `i`
-such that `k2,i` is in the domain of `A`
-and in the triangle of `A` specified by `t`.
-
-* *Effects:* Assigns to the elements of the matrix `C` on output,
-    the elementwise sum of `E` and the product of the matrices `A` and `B`.
+* *Effects:* Computes $C$ such that $C = E + A B$.
 
 ##### Updating Hermitian matrix-matrix right product [linalg.algs.blas3.hemm.up.right]
 
@@ -9458,20 +9262,7 @@ void hermitian_matrix_right_product(
   OutMat C);
 ```
 
-For `i,j` in the domain of `C`,
-the mathematical expression for the algorithm is
-`C[i,j] = E[i,j] + B[i,j] * A[i,i]`
-plus the sum of `B[i,k1] * A[k1,j]`
-for all `k1` not equal to `j`
-such that `k1,j` is in the domain of `A`
-and in the triangle of `A` specified by `t`,
-plus the sum of `B[i,k2] * `_`conj-if-needed`_`(A[j,k2])`
-for all `k2` not equal to `j`
-such that `k2,j` is in the domain of `A`
-and in the triangle of `A` specified by `t`.
-
-* *Effects:* Assigns to the elements of the matrix `C` on output, the
-    elementwise sum of `E` and the product of the matrices `B` and `A`.
+* *Effects:* Computes $C$ such that $C = E + B A$.
 
 #### Triangular matrix-matrix product [linalg.algs.blas3.trmm]
 
@@ -9490,18 +9281,9 @@ The following requirements apply to all functions in this section.
 
 * *Constraints:*
 
-    * `InMat1` either has unique layout,
-        or `layout_blas_packed` layout.
-
-    * `InMat2` and `InMat3` (if applicable)
-        have unique layout.
-
     * If `InMat1` has `layout_blas_packed` layout, then the
         layout's `Triangle` template argument has the same type as
         the function's `Triangle` template argument.
-
-    * `A.rank()` equals 2, `B.rank()` equals 2, `C.rank()` equals 2, and
-        `E.rank()` (if applicable) equals 2.
 
 * *Mandates:*
 
@@ -9615,14 +9397,7 @@ void triangular_matrix_left_product(
   OutMat C);
 ```
 
-For `i,j` in the domain of `C`,
-the mathematical expression for the algorithm is
-`C[i,j] = ` the sum of `A[i,k] * B[k,j]`
-for all `k` such that `i,k` is in the domain of `A`
-and in the triangle of `A` specified by `t` and `d`.
-
-* *Effects:* Assigns to the elements of the matrix `C`
-    the product of the matrices `A` and `B`.
+* *Effects:* Computes $C$ such that $C = A B$.
 
 In-place overwriting triangular matrix-matrix left product
 
@@ -9649,20 +9424,13 @@ void triangular_matrix_left_product(
   InOutMat C);
 ```
 
-For `i,j` in the domain of `C`,
-the mathematical expression for the algorithm is
-`C[i,j] = ` the sum of `A[i,k] * C[k,j]`
-for all `k` such that `i,k` is in the domain of `A`
-and in the triangle of `A` specified by `t` and `d`.
-
 * *Preconditions:* `A.extent(1)` equals `C.extent(0)`.
 
 * *Mandates:* If neither `A.static_extent(1)` nor `C.static_extent(0)`
     equals `dynamic_extent`,
     then `A.static_extent(1)` equals `C.static_extent(0)`.
 
-* *Effects:* Overwrites `C` on output with the product of the matrices
-    `A` and `C` (on input).
+* *Effects:* Overwrites $C$ with $C'$ such that $C' = A C$.
 
 ##### Overwriting triangular matrix-matrix right product [linalg.algs.blas3.trmm.ov.right]
 
@@ -9694,14 +9462,7 @@ void triangular_matrix_right_product(
   OutMat C);
 ```
 
-For `i,j` in the domain of `C`,
-the mathematical expression for the algorithm is
-`C[i,j] = ` the sum of `B[i,k] * A[k,j]`
-for all `k` such that `k,j` is in the domain of `A`
-and in the triangle of `A` specified by `t` and `d`.
-
-* *Effects:* Assigns to the elements of the matrix `C`
-    the product of the matrices `B` and `A`.
+* *Effects:* Computes $C$ such that $C = B A$.
 
 In-place overwriting triangular matrix-matrix right product
 ```c++
@@ -9727,20 +9488,13 @@ void triangular_matrix_right_product(
   InOutMat C);
 ```
 
-For `i,j` in the domain of `C`,
-the mathematical expression for the algorithm is
-`C[i,j] = ` the sum of `C[i,k] * A[k,j]`
-for all `k` such that `k,j` is in the domain of `A`
-and in the triangle of `A` specified by `t` and `d`.
-
 * *Preconditions:* `C.extent(1)` equals `A.extent(0)`.
 
 * *Mandates:* If neither `C.static_extent(1)` nor `A.static_extent(0)`
     equals `dynamic_extent`, then `C.static_extent(1)` equals
     `A.static_extent(0)`.
 
-* *Effects:* Overwrites `C` on output
-    with the product of the matrices `C` (on input) and `A`.
+* *Effects:* Overwrites $C$ with $C'$ such that $C' = C A$.
 
 ##### Updating triangular matrix-matrix left product [linalg.algs.blas3.trmm.up.left]
 
@@ -9775,14 +9529,7 @@ void triangular_matrix_left_product(
   OutMat C);
 ```
 
-For `i,j` in the domain of `C`,
-the mathematical expression for the algorithm is
-`C[i,j] = E[i,j]` plus the sum of `A[i,k] * B[k,j]`
-for all `k` such that `i,k` is in the domain of `A`
-and in the triangle of `A` specified by `t` and `d`.
-
-* *Effects:* Assigns to the elements of the matrix `C` on output,
-    the elementwise sum of `E` and the product of the matrices `A` and `B`.
+* *Effects:* Computes $C$ such that $C = E + A B$.
 
 ##### Updating triangular matrix-matrix right product [linalg.algs.blas3.trmm.up.right]
 
@@ -9817,14 +9564,7 @@ void triangular_matrix_right_product(
   OutMat C);
 ```
 
-For `i,j` in the domain of `C`,
-the mathematical expression for the algorithm is
-`C[i,j] = E[i,j]` plus the sum of `B[i,k] * A[k,j]`
-for all `k` such that `k,j` is in the domain of `A`
-and in the triangle of `A` specified by `t` and `d`.
-
-* *Effects:* Assigns to the elements of the matrix `C` on output,
-    the elementwise sum of `E` and the product of the matrices `B` and `A`.
+* *Effects:* Computes $C$ such that $C = E + B A$.
 
 #### Rank-k update of a symmetric or Hermitian matrix [linalg.alg.blas3.rank-k]
 
@@ -9866,17 +9606,11 @@ void symmetric_matrix_rank_k_update(
 These functions correspond to the BLAS function `xSYRK`.
 
 They take a scaling factor `alpha`, because it would be
-impossible to express the update C = C - A A^T otherwise.
+impossible to express the update $C = C - A A^T$ otherwise.
 The scaling factor parameter is required
 in order to avoid ambiguity with `ExecutionPolicy`.
 
 <i>-- end note]</i>
-
-For `i,j` in the domain of `C`
-and in the triangle of `C` specified by `t`,
-the mathematical expression for the algorithm is
-`C[i,j] = C[i,j]` plus the sum of `alpha * A[i,k] * A[j,k]`
-for all `k` such that `i,k` is in the domain of `A`.
 
 * *Preconditions:*
 
@@ -9885,10 +9619,6 @@ for all `k` such that `i,k` is in the domain of `A`.
     * `C.extent(0)` equals `C.extent(1)`.
 
 * *Constraints:*
-
-    * `A.rank()` equals 2 and `C.rank()` equals 2.
-
-    * `C` either has unique layout, or `layout_blas_packed` layout.
 
     * If `C` has `layout_blas_packed` layout, then the layout's
         `Triangle` template argument has the same type as the function's
@@ -9904,11 +9634,8 @@ for all `k` such that `i,k` is in the domain of `A`.
         `dynamic_extent`, then `C.static_extent(0)` equals
         `C.static_extent(1)`.
 
-* *Effects:*
-
-    * Assigns to `C` on output, the elementwise sum of `C` on input
-        with `alpha` times (the matrix product of `A`
-        and the nonconjugated transpose of `A`).
+* *Effects:* Overwrites $C$ with $C'$ such that $C' = C + alpha A A^T$,
+    where $A^T$ denotes the transpose of the matrix $A$.
 
 * *Remarks:* The functions will only access the triangle of `C` specified by
     the `Triangle` argument `t`, and will interpret the value `C[i,j]`
@@ -9940,23 +9667,13 @@ void hermitian_matrix_rank_k_update(
   Triangle t);
 ```
 
-<i>[Note:</i>
+<i>[Note:</i> These functions correspond to the BLAS function `xHERK`.
 
-These functions correspond to the BLAS function `xHERK`.
-
-They take a scaling factor `alpha`, because it would be
-impossible to express the updates C = C - A A^T or C = C - A A^H
-otherwise.
+They take a scaling factor `alpha`,
+because it would be impossible to express the updates
+$C = C - A A^T$ or $C = C - A A^H$ otherwise.
 The scaling factor parameter is required
-in order to avoid ambiguity with `ExecutionPolicy`.
-
-<i>-- end note]</i>
-
-For `i,j` in the domain of `C`
-and in the triangle of `C` specified by `t`,
-the mathematical expression for the algorithm is
-`C[i,j] = C[i,j]` plus the sum of `alpha * A[i,k] * `_`conj-if-needed`_`(A[j,k])`
-for all `k` such that `i,k` is in the domain of `A`.
+in order to avoid ambiguity with `ExecutionPolicy`. <i>-- end note]</i>
 
 * *Preconditions:*
 
@@ -9965,10 +9682,6 @@ for all `k` such that `i,k` is in the domain of `A`.
     * `C.extent(0)` equals `C.extent(1)`.
 
 * *Constraints:*
-
-    * `A.rank()` equals 2 and `C.rank()` equals 2.
-
-    * `C` either has unique layout, or `layout_blas_packed` layout.
 
     * If `C` has `layout_blas_packed` layout, then the layout's
         `Triangle` template argument has the same type as the function's
@@ -9984,11 +9697,8 @@ for all `k` such that `i,k` is in the domain of `A`.
         `dynamic_extent`, then `C.static_extent(0)` equals
         `C.static_extent(1)`.
 
-* *Effects:*
-
-    * Assigns to `C` on output, the elementwise
-        sum of `C` on input with alpha times (the matrix product of `A`
-        and the conjugated transpose of `A`).
+* *Effects:* Overwrites $C$ with $C'$ such that $C' = C + alpha A A^H$,
+    where $A^H$ denotes the conjugate transpose of the matrix $A$.
 
 * *Remarks:* The functions will only access the triangle of `C` specified by
     the `Triangle` argument `t`, and will interpret the value `C[i,j]`
@@ -10033,14 +9743,6 @@ void symmetric_matrix_rank_2k_update(
 The BLAS "quick reference" has a typo; the "ALPHA" argument of
 `CSYR2K` and `ZSYR2K` should not be conjugated.  <i>-- end note]</i>
 
-For `i,j` in the domain of `C`
-and in the triangle of `C` specified by `t`,
-the mathematical expression for the algorithm is
-`C[i,j] = C[i,j]` plus the sum of `A[i,k1] * B[j,k1]`
-for all `k1` such that `i,k1` is in the domain of `A`,
-plus the sum of `B[i,k2] * A[j,k2]`
-for all `k2` such that `i,k2` is in the domain of `B`.
-
 * *Preconditions:*
 
     * `A.extent(0)` equals `B.extent(0)`,
@@ -10050,10 +9752,6 @@ for all `k2` such that `i,k2` is in the domain of `B`.
     * `A.extent(0)` equals `C.extent(0)`.
 
 * *Constraints:*
-
-    * `A.rank()` equals 2, `B.rank()` equals 2, and `C.rank()` equals 2.
-
-    * `C` either has unique layout, or `layout_blas_packed` layout.
 
     * If `C` has `layout_blas_packed` layout, then the layout's
         `Triangle` template argument has the same type as the function's
@@ -10073,10 +9771,9 @@ for all `k2` such that `i,k2` is in the domain of `B`.
         `dynamic_extent`, then `A.static_extent(0)` equals
         `C.static_extent(0)`.
 
-* *Effects:* Assigns to `C` on output, the elementwise sum of `C` on
-    input with (the matrix product of `A` and the nonconjugated
-    transpose of `B`) and (the matrix product of `B` and the
-    nonconjugated transpose of `A`.)
+* *Effects:* Overwrites $C$ with $C'$ such that $C' = C + A B^T + B A^T$,
+    where $A^T$ denotes the transpose of the matrix $A$
+    and $B^T$ denotes the transpose of the matrix $B$.
 
 * *Remarks:* The functions will only access the triangle of `C` specified by
     the `Triangle` argument `t`, and will interpret the value `C[i,j]`
@@ -10109,16 +9806,8 @@ void hermitian_matrix_rank_2k_update(
   Triangle t);
 ```
 
-<i>[Note:</i> These functions correspond to the BLAS function `xHER2K`.
-<i>-- end note]</i>
-
-For `i,j` in the domain of `C`
-and in the triangle of `C` specified by `t`,
-the mathematical expression for the algorithm is
-`C[i,j] = C[i,j]` plus the sum of `A[i,k1] * `_`conj-if-needed`_`(B[j,k1])`
-for all `k1` such that `i,k1` is in the domain of `A`,
-plus the sum of `B[i,k2] * `_`conj-if-needed`_`(A[j,k2])`
-for all `k2` such that `i,k2` is in the domain of `B`.
+<i>[Note:</i> These functions correspond to the BLAS function
+`xHER2K`. <i>-- end note]</i>
 
 * *Preconditions:*
 
@@ -10129,10 +9818,6 @@ for all `k2` such that `i,k2` is in the domain of `B`.
     * `A.extent(0)` equals `C.extent(0)`.
 
 * *Constraints:*
-
-    * `A.rank()` equals 2, `B.rank()` equals 2, and `C.rank()` equals 2.
-
-    * `C` either has unique layout, or `layout_blas_packed` layout.
 
     * If `C` has `layout_blas_packed` layout, then the layout's
         `Triangle` template argument has the same type as the function's
@@ -10152,20 +9837,19 @@ for all `k2` such that `i,k2` is in the domain of `B`.
         `dynamic_extent`, then `A.static_extent(0)` equals
         `C.static_extent(0)`.
 
-* *Effects:* Assigns to `C` on output,
-    the elementwise sum of `C` on input with
-    (the matrix product of `A` and the conjugate transpose of `B`) and
-    (the matrix product of `B` and the conjugate transpose of `A`.)
+* *Effects:* Overwrites $C$ with $C'$ such that $C' = C + A B^H + B A^H$,
+    where $A^H$ denotes the conjugate transpose of the matrix $A$
+    and $B^H$ denotes the conjugate transpose of the matrix $B$.
 
 * *Remarks:* The functions will only access the triangle of `C` specified by
     the `Triangle` argument `t`, and will interpret the value `C[i,j]`
-    as equal to _`conj-if-needed`_`C[j,i]` for indices `i,j`
+    as equal to _`conj-if-needed`_`(C[j,i])` for indices `i,j`
     in the domain of `C` but outside the triangle specified by `t`.
 
 #### Solve multiple triangular linear systems [linalg.alg.blas3.trsm]
 
-<i>[Note:</i> These functions correspond to the BLAS function `xTRSM`.  The
-Reference BLAS does not have a `xTPSM` function. <i>-- end note]</i>
+<i>[Note:</i> These functions correspond to the BLAS function `xTRSM`.
+The Reference BLAS does not have a `xTPSM` function. <i>-- end note]</i>
 
 The following requirements apply to all functions in this section.
 
@@ -10177,14 +9861,6 @@ The following requirements apply to all functions in this section.
     * `A.extent(0)` equals `A.extent(1)`.
 
 * *Constraints:*
-
-    * `A.rank()` equals 2 and `B.rank()` equals 2;
-
-    * `X.rank()` equals 2 (if applicable);
-
-    * `InMat1` either has unique layout, or `layout_blas_packed` layout;
-
-    * `InMat2` has unique layout (if applicable);
 
     * if `r,j` is in the domain of `X` and `B`, then the expression
         `X[r,j] = B[r,j]` is well formed (if applicable); and
@@ -10314,8 +9990,9 @@ in the subset of the domain of `A` specified by `t`.
     equals `dynamic_extent`, then
     `A.static_extent(1)` equals `B.static_extent(0)`.
 
-* *Effects:* Assigns to the elements of `X`
-    the result of solving the triangular linear system(s) AX=B for X.
+* *Effects:* Computes $X$ such that $AX = B$.
+    If so such $X$ exists,
+    then the elements of $X$ are valid but unspecified.
 
 In-place left solve of multiple triangular systems
 
@@ -10367,17 +10044,13 @@ void triangular_matrix_matrix_left_solve(
   InOutMat B);
 ```
 
-<i>[Note:</i>
-
-This algorithm makes it possible to compute factorizations like
-Cholesky and LU in place.
+<i>[Note:</i> This algorithm makes it possible
+to compute factorizations like Cholesky and LU in place.
 
 Performing triangular solve in place hinders parallelization.
 However, other `ExecutionPolicy`-specific optimizations,
-such as vectorization, are still possible.
-This is why the `ExecutionPolicy` overload exists.
-
-<i>-- end note]</i>
+such as vectorization, are still possible.  This is why
+the `ExecutionPolicy` overload exists. <i>-- end note]</i>
 
 If `DiagonalStorage` is `explicit_diagonal_t`,
 then for `i,j` in the domain of `B`,
@@ -10415,8 +10088,9 @@ in the subset of the domain of `A` specified by `t`.
     equals `dynamic_extent`, then
     `A.static_extent(1)` equals `B.static_extent(0)`.
 
-* *Effects:* Overwrites `B` with the result of solving the triangular
-     linear system(s) AX=B for X.
+* *Effects:* Overwrites $B$ with $X$ such that $AX = B$.
+    If no such $X$ exists,
+    then the elements of $X$ are valid but unspecified.
 
 ##### Solve multiple triangular linear systems with triangular matrix on the right [linalg.alg.blas3.trsm.right]
 
@@ -10513,7 +10187,6 @@ for all `k` not equal to `j`
 in the subset of the domain of `A` specified by `t`.
 
 <i>[Note:</i>
-
 One can derive these mathematical expressions
 from the mathematical expressions of the
 `triangular_matrix_matrix_left_solve()` algorithm,
@@ -10525,7 +10198,6 @@ This is because
 taking the transpose of both sides does not change the equation,
 and the transpose of a product of two matrices
 is the product of the reversed matrices in transposed order.
-
 <i>-- end note]</i>
 
 * *Preconditions:* `A.extent(1)` equals `B.extent(1)`.
@@ -10534,8 +10206,9 @@ is the product of the reversed matrices in transposed order.
     equals `dynamic_extent`, then
     `A.static_extent(1)` equals `B.static_extent(1)`.
 
-* *Effects:* Assigns to the elements of `X`
-    the result of solving the triangular linear system(s) XA=B for X.
+* *Effects:* Computes $X$ such that $XA = B$.
+    If so such $X$ exists,
+    then the elements of $X$ are valid but unspecified.
 
 In-place right solve of multiple triangular systems
 
@@ -10588,7 +10261,6 @@ void triangular_matrix_matrix_right_solve(
 ```
 
 <i>[Note:</i>
-
 This algorithm makes it possible to compute factorizations like
 Cholesky and LU in place.
 
@@ -10596,7 +10268,6 @@ Performing triangular solve in place hinders parallelization.
 However, other `ExecutionPolicy`-specific optimizations,
 such as vectorization, are still possible.
 This is why the `ExecutionPolicy` overload exists.
-
 <i>-- end note]</i>
 
 If `DiagonalStorage` is `explicit_diagonal_t`,
@@ -10636,8 +10307,9 @@ in the subset of the domain of `A` specified by `t`.
     equals `dynamic_extent`, then
     `A.static_extent(1)` equals `B.static_extent(1)`.
 
-* *Effects:* Overwrites `B` with the result of solving the triangular
-     linear system(s) XA=B for X.
+* *Effects:* Overwrites $B$ with $X$ such that $XA = B$.
+    If no such $X$ exists,
+    then the elements of $X$ are valid but unspecified.
 
 # Examples
 
@@ -10648,9 +10320,9 @@ symmetric positive definite matrix A stored as an `mdspan` with a
 unique non-packed layout.
 The algorithm imitates `DPOTRF2` in LAPACK 3.9.0.
 If `Triangle` is `upper_triangle_t`,
-then it computes the factorization A = U^T U in place,
+then it computes the factorization $A = U^T U$ in place,
 with U stored in the upper triangle of A on output.
-Otherwise, it computes the factorization A = L L^T in place,
+Otherwise, it computes the factorization $A = L L^T$ in place,
 with L stored in the lower triangle of A on output.
 The function returns 0 if success, else k+1
 if row/column k has a zero or NaN (not a number) diagonal entry.

--- a/D1673/P1673.md
+++ b/D1673/P1673.md
@@ -5343,7 +5343,7 @@ public:
     using layout_type = layout_blas_packed<Triangle, StorageOrder>;
 
   private:
-    Extents @_extents__@{}; // exposition only
+    Extents @_the-extents_@{}; // exposition only
 
   public:
     constexpr mapping() noexcept = default;
@@ -5355,7 +5355,7 @@ public:
 
     constexpr mapping& operator=(const mapping&) noexcept = default;
 
-    constexpr extents_type extents() const noexcept { return @_extents__@; }
+    constexpr extents_type extents() const noexcept { return @_the-extents_@; }
 
     constexpr size_type required_span_size() const noexcept;
 
@@ -5607,8 +5607,8 @@ public:
   template<class Rhs, enable_if_t<is_base_of_v<@_proxy-reference-base_@, Rhs>, bool> = true>
   constexpr friend auto operator+ (derived_type lhs, Rhs rhs)
   {
-    using rhs_value_type = typename Rhs::value_type; // exposition only
-    return value_type(lhs) + rhs_value_type(rhs);
+    using @_rhs-value-type_@ = typename Rhs::value_type; // exposition only
+    return value_type(lhs) + @_rhs-value-type_@(rhs);
   }
   template<class Rhs, enable_if_t<! is_base_of_v<@_proxy-reference-base_@, Rhs>, bool> = true>
   constexpr friend auto operator+ (derived_type lhs, Rhs rhs)
@@ -5624,8 +5624,8 @@ public:
   template<class Rhs, enable_if_t<is_base_of_v<@_proxy-reference-base_@, Rhs>, bool> = true>
   constexpr friend auto operator- (derived_type lhs, Rhs rhs)
   {
-    using rhs_value_type = typename Rhs::value_type; // exposition only
-    return value_type(lhs) - rhs_value_type(rhs);
+    using @_rhs-value-type_@ = typename Rhs::value_type; // exposition only
+    return value_type(lhs) - @_rhs-value-type_@(rhs);
   }
   template<class Rhs, enable_if_t<! is_base_of_v<@_proxy-reference-base_@, Rhs>, bool> = true>
   constexpr friend auto operator- (derived_type lhs, Rhs rhs)
@@ -5641,8 +5641,8 @@ public:
   template<class Rhs, enable_if_t<is_base_of_v<@_proxy-reference-base_@, Rhs>, bool> = true>
   constexpr friend auto operator* (derived_type lhs, Rhs rhs)
   {
-    using rhs_value_type = typename Rhs::value_type; // exposition only
-    return value_type(lhs) * rhs_value_type(rhs);
+    using @_rhs-value-type_@ = typename Rhs::value_type; // exposition only
+    return value_type(lhs) * @_rhs-value-type_@(rhs);
   }
   template<class Rhs, enable_if_t<! is_base_of_v<@_proxy-reference-base_@, Rhs>, bool> = true>
   constexpr friend auto operator* (derived_type lhs, Rhs rhs)
@@ -5658,8 +5658,8 @@ public:
   template<class Rhs, enable_if_t<is_base_of_v<@_proxy-reference-base_@, Rhs>, bool> = true>
   constexpr friend auto operator/ (derived_type lhs, Rhs rhs)
   {
-    using rhs_value_type = typename Rhs::value_type; // exposition only
-    return value_type(lhs) / rhs_value_type(rhs);
+    using @_rhs-value-type_@ = typename Rhs::value_type; // exposition only
+    return value_type(lhs) / @_rhs-value-type_@(rhs);
   }
   template<class Rhs, enable_if_t<! is_base_of_v<@_proxy-reference-base_@, Rhs>, bool> = true>
   constexpr friend auto operator/ (derived_type lhs, Rhs rhs)
@@ -5679,8 +5679,6 @@ public:
   constexpr friend auto imag(const derived_type& x);
 
   constexpr friend auto conj(const derived_type& x);
-
-  <!-- TODO (mfh 2022/07/06) Do we need sqrt here? -->
 };
 ```
 
@@ -5811,7 +5809,7 @@ private:
   ScalingFactor @_scaling-factor_@; // exposition only
 
   using @_my-type_@ = @_scaled-scalar_@<ScalingFactor, Reference, ReferenceValue>; // exposition only
-  using base_type = @_proxy-reference_@<Reference, ReferenceValue, @_my-type_@>; // exposition only
+  using @_base-type_@ = @_proxy-reference_@<Reference, ReferenceValue, @_my-type_@>; // exposition only
 public:
   explicit @_scaled-scalar_@(const ScalingFactor& scaling_factor, const Reference& reference);
 
@@ -5847,7 +5845,7 @@ explicit scaled_scalar(const ScalingFactor& scaling_factor, const Reference& ref
 
 *Effects:*
 
-  * Direct non-list-initializes `static_cast<base_type&>(*this)` with `reference`, and
+  * Direct non-list-initializes `static_cast<` _`base-type`_ `&>(*this)` with `reference`, and
 
   * direct non-list-initializes _`scaling-factor`_ with `scaling_factor`.
 
@@ -6027,7 +6025,7 @@ class @_conjugated-scalar_@ : // exposition only
 {
 private:
   using @_my-type_@ = @_conjugated-scalar_@<Reference, ReferenceValue>; // exposition only
-  using base_type = @_proxy-reference_@<Reference, ReferenceValue, @_my-type_@>; // exposition only
+  using @_base-type_@ = @_proxy-reference_@<Reference, ReferenceValue, @_my-type_@>; // exposition only
 
 public:
   constexpr explicit @_conjugated-scalar_@(Reference reference);
@@ -6051,7 +6049,7 @@ using value_type = /* see below */;
 constexpr explicit @_conjugated-scalar_@(Reference reference);
 ```
 
-* *Effects:* Initializes `base_type` with `reference`.
+* *Effects:* Initializes _`base-type`_ with `reference`.
 
 ```c++
 constexpr static auto to_value(Reference value_type);

--- a/D1673/P1673.md
+++ b/D1673/P1673.md
@@ -7369,13 +7369,6 @@ element types is based on the observation that this lower-cost
 approximation of the one-norm serves just as well as the actual
 one-norm for many linear algebra algorithms in practice. <i>-- end note]</i>
 
-
-
-For `N` equal to `v.extent(0)`,
-the mathematical expression for the algorithm is
-`init` plus the sum of `abs(v[i])`
-for all `i` in the domain of `v`.
-
 * *Constraints:*
     `decltype(init + abs(declval<typename InVec::value_type>()))`
     and `decltype(init + abs(declval<typename InVec::value_type>()))`

--- a/D1673/P1673.md
+++ b/D1673/P1673.md
@@ -431,44 +431,12 @@ toc: true
       have unique layout.
 
   * Change from name-based requirements (`in_{vector,matrix,object}*_t`)
-      to exposition-only concepts (following LEWG feedback).
-      Remove the requirement that
-      vector / matrix / object template parameters
-      may deduce a `const` lvalue reference
-      or a (non-`const`) rvalue reference to an `mdspan`.
+      to exposition-only concepts.
+      (This is our interpretation of LEWG's Kona 2022/11/10 request
+      to "explore expressing constraints with concepts
+      instead of named type requirements"
+      (see https://github.com/cplusplus/papers/issues/557#issuecomment-1311054803).)
       Add new section for exposition-only concepts and traits.
-
-  * Fix `dot` Remarks to include both vector types
-      and to use `value_type` instead of `element_type`.
-
-  * Fix `vector_sum_of_squares`, `vector_norm2`, and `vector_abs_sum`
-      Remarks to use `value_type` instead of `element_type`.
-
-  * Fix QR factorization example
-      to use `value_type` instead of `element_type`.
-
-  * Remove redundant unique layout constraints on
-      out and inout matrix parameter(s) of
-      *[linalg.algs.blas3.trmm]* and *[linalg.alg.blas3.trsm]*.
-
-  * Fix `matrix_frob_norm`, `matrix_one_norm` and `matrix_inf_norm`
-      Remarks to use `value_type` instead of `element_type`.
-
-  * Remove unnecessary constraint on *[linalg.algs.blas2.gemv]*
-      that input matrix parameter(s) have unique layout,
-      and remove all other constraints there, as they are redundant
-      with the new exposition-only concepts.
-      (Retain the unique layout constraint
-      for symmetric and Hermitian matrix-vector product.)
-
-  * Remove all constraints on *[linalg.algs.blas3.gemm]*.
-      It is unnecessary to constrain input matrix parameter(s)
-      to have unique layout.
-      All other constraints were redundant
-      with the new exposition-only concepts.
-
-  * Make `matrix_vector_product` template parameter order
-      consistent with parameter order.
 
   * Add new exposition-only concept _`possibly-packed-inout-matrix`_
       to constrain symmetric and Hermitian update algorithms.
@@ -477,12 +445,36 @@ toc: true
 
   * Remove Constraints made redundant by the new exposition-only concepts.
 
+  * Remove unnecessary constraint on all algorithms
+    that input mdspan parameter(s) have unique layout.
+
+  * Remove the requirement that
+      vector / matrix / object template parameters
+      may deduce a `const` lvalue reference
+      or a (non-`const`) rvalue reference to an `mdspan`.
+      The new exposition-only concepts make this unnecessary.
+
+  * Fix `dot` Remarks to include both vector types.
+
+  * Fix wording of several functions and examples
+    to use mdspan's `value_type` alias
+    instead of its (potentially cv-qualified) `element_type` alias.
+    This includes `dot`, `vector_sum_of_squares`, `vector_norm2`,
+    `vector_abs_sum`, `matrix_frob_norm`, `matrix_one_norm`,
+    `matrix_inf_norm`, and the QR factorization example.
+
+  * Make `matrix_vector_product` template parameter order
+      consistent with parameter order.
+
   * Follow LEWG guidance to simplify Effects and Constraints
     (e.g., removing wording referring to the
     "the mathematical expression for the algorithm")
     by describing them mathematically (in math font).
     ("Mathematical expression for the algorithm"
     remains in a few places that call for more careful analysis.)
+    This is our interpretation of the "hand wavy do math" poll option
+    that received a majority of votes at Kona on 2022/11/10
+    (see https://github.com/cplusplus/papers/issues/557#issuecomment-1311054803).
 
   * Change `matrix_one_norm` Precondition (that the result of `abs` of a matrix element is convertible to `T`) to a Constraint.
 

--- a/D1673/P1673.md
+++ b/D1673/P1673.md
@@ -462,13 +462,18 @@ toc: true
       for symmetric and Hermitian matrix-vector product.)
 
   * Remove all constraints on *[linalg.algs.blas3.gemm]*.
-      It is unnecessary to constraint input matrix parameter(s)
+      It is unnecessary to constrain input matrix parameter(s)
       to have unique layout.
       All other constraints were redundant
       with the new exposition-only concepts.
 
   * Make `matrix_vector_product` template parameter order
       consistent with parameter order.
+
+  * Add new exposition-only constraint _`possibly-packed-inout-matrix`_
+      to account for symmetric or Hermitian update algorithms.
+      These may write either to a unique-layout mdspan
+      or to a `layout_blas_packed` mdspan (whose layout is nonunique).
 
 # Purpose of this paper
 
@@ -3534,6 +3539,9 @@ template<class T>
 concept @_inout-matrix_@; = // exposition only
 
 template<class T>
+concept @_possibly-packed-inout-matrix_@; = // exposition only
+
+template<class T>
 concept @_in-object_@; = // exposition only
 
 template<class T>
@@ -4192,7 +4200,7 @@ void matrix_rank_1_update_c(
 // [linalg.algs.blas2.rank1.syr],
 // symmetric rank-1 matrix update
 template<@_in-vector_@ InVec,
-         @_inout-matrix_@ InOutMat,
+         @_possibly-packed-inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_1_update(
   InVec x,
@@ -4200,7 +4208,7 @@ void symmetric_matrix_rank_1_update(
   Triangle t);
 template<class ExecutionPolicy,
          @_in-vector_@ InVec,
-         @_inout-matrix_@ InOutMat,
+         @_possibly-packed-inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_1_update(
   ExecutionPolicy&& exec,
@@ -4209,7 +4217,7 @@ void symmetric_matrix_rank_1_update(
   Triangle t);
 template<class T,
          @_in-vector_@ InVec,
-         @_inout-matrix_@ InOutMat,
+         @_possibly-packed-inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_1_update(
   T alpha,
@@ -4219,7 +4227,7 @@ void symmetric_matrix_rank_1_update(
 template<class ExecutionPolicy,
          class T,
          @_in-vector_@ InVec,
-         @_inout-matrix_@ InOutMat,
+         @_possibly-packed-inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_1_update(
   ExecutionPolicy&& exec,
@@ -4231,7 +4239,7 @@ void symmetric_matrix_rank_1_update(
 // [linalg.algs.blas2.rank1.her],
 // Hermitian rank-1 matrix update
 template<@_in-vector_@ InVec,
-         @_inout-matrix_@ InOutMat,
+         @_possibly-packed-inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_1_update(
   InVec x,
@@ -4239,7 +4247,7 @@ void hermitian_matrix_rank_1_update(
   Triangle t);
 template<class ExecutionPolicy,
          @_in-vector_@ InVec,
-         @_inout-matrix_@ InOutMat,
+         @_possibly-packed-inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_1_update(
   ExecutionPolicy&& exec,
@@ -4248,7 +4256,7 @@ void hermitian_matrix_rank_1_update(
   Triangle t);
 template<class T,
          @_in-vector_@ InVec,
-         @_inout-matrix_@ InOutMat,
+         @_possibly-packed-inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_1_update(
   T alpha,
@@ -4258,7 +4266,7 @@ void hermitian_matrix_rank_1_update(
 template<class ExecutionPolicy,
          class T,
          @_in-vector_@ InVec,
-         @_inout-matrix_@ InOutMat,
+         @_possibly-packed-inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_1_update(
   ExecutionPolicy&& exec,
@@ -4271,7 +4279,7 @@ void hermitian_matrix_rank_1_update(
 // symmetric rank-2 matrix update
 template<@_in-vector_@ InVec1,
          @_in-vector_@ InVec2,
-         @_inout-matrix_@ InOutMat,
+         @_possibly-packed-inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_2_update(
   InVec1 x,
@@ -4281,7 +4289,7 @@ void symmetric_matrix_rank_2_update(
 template<class ExecutionPolicy,
          @_in-vector_@ InVec1,
          @_in-vector_@ InVec2,
-         @_inout-matrix_@ InOutMat,
+         @_possibly-packed-inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_2_update(
   ExecutionPolicy&& exec,
@@ -4294,7 +4302,7 @@ void symmetric_matrix_rank_2_update(
 // Hermitian rank-2 matrix update
 template<@_in-vector_@ InVec1,
          @_in-vector_@ InVec2,
-         @_inout-matrix_@ InOutMat,
+         @_possibly-packed-inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_2_update(
   InVec1 x,
@@ -4304,7 +4312,7 @@ void hermitian_matrix_rank_2_update(
 template<class ExecutionPolicy,
          @_in-vector_@ InVec1,
          @_in-vector_@ InVec2,
-         @_inout-matrix_@ InOutMat,
+         @_possibly-packed-inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_2_update(
   ExecutionPolicy&& exec,
@@ -4717,7 +4725,7 @@ void triangular_matrix_right_product(
 // rank-k symmetric matrix update
 template<class T,
          @_in-matrix_@ InMat1,
-         @_inout-matrix_@ InOutMat,
+         @_possibly-packed-inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_k_update(
   T alpha,
@@ -4727,7 +4735,7 @@ void symmetric_matrix_rank_k_update(
 template<class T,
          class ExecutionPolicy,
          @_in-matrix_@ InMat1,
-         @_inout-matrix_@ InOutMat,
+         @_possibly-packed-inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_k_update(
   ExecutionPolicy&& exec,
@@ -4740,7 +4748,7 @@ void symmetric_matrix_rank_k_update(
 // rank-k Hermitian matrix update
 template<class T,
          @_in-matrix_@ InMat1,
-         @_inout-matrix_@ InOutMat,
+         @_possibly-packed-inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_k_update(
   T alpha,
@@ -4750,7 +4758,7 @@ void hermitian_matrix_rank_k_update(
 template<class ExecutionPolicy,
          class T,
          @_in-matrix_@ InMat1,
-         @_inout-matrix_@ InOutMat,
+         @_possibly-packed-inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_k_update(
   ExecutionPolicy&& exec,
@@ -4763,7 +4771,7 @@ void hermitian_matrix_rank_k_update(
 // rank-2k symmetric matrix update
 template<@_in-matrix_@ InMat1,
          @_in-matrix_@ InMat2,
-         @_inout-matrix_@ InOutMat,
+         @_possibly-packed-inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_2k_update(
   InMat1 A,
@@ -4773,7 +4781,7 @@ void symmetric_matrix_rank_2k_update(
 template<class ExecutionPolicy,
          @_in-matrix_@ InMat1,
          @_in-matrix_@ InMat2,
-         @_inout-matrix_@ InOutMat,
+         @_possibly-packed-inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_2k_update(
   ExecutionPolicy&& exec,
@@ -4786,7 +4794,7 @@ void symmetric_matrix_rank_2k_update(
 // rank-2k Hermitian matrix update
 template<@_in-matrix_@ InMat1,
          @_in-matrix_@ InMat2,
-         @_inout-matrix_@ InOutMat,
+         @_possibly-packed-inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_2k_update(
   InMat1 A,
@@ -4796,7 +4804,7 @@ void hermitian_matrix_rank_2k_update(
 template<class ExecutionPolicy,
          @_in-matrix_@ InMat1,
          @_in-matrix_@ InMat2,
-         @_inout-matrix_@ InOutMat,
+         @_possibly-packed-inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_2k_update(
   ExecutionPolicy&& exec,
@@ -6730,6 +6738,13 @@ concept @_inout-matrix_@ = // exposition only
   T::is_always_unique();
 
 template<class T>
+concept @_possibly-packed-inout-matrix_@ = // exposition only
+  @_is-mdspan_@<T>::value &&
+  T::rank() == 2 &&
+  is_same_v<remove_const_t<typename T::element_type>, typename T::element_type> &&
+  (T::is_always_unique() || is_same_v<typename T::layout_type, layout_blas_packed>);
+
+template<class T>
 concept @_in-object_@ = // exposition only
   @_is-mdspan_@<T>::value &&
   (T::rank() == 1 || T::rank() == 2);
@@ -6762,6 +6777,13 @@ with a const `element_type`. <i>-- end note]</i>
 If an algorithm in *[linalg.algs]* accesses the elements
 of an _`out-vector`_, _`out-matrix`_, or _`out-object`_,
 it will do so in write-only fashion.
+
+<i>[Note:</i> The exposition-only concept
+_`possibly-packed-inout-matrix`_
+constrains symmetric and Hermitian update algorithms.
+These may write either to a unique-layout mdspan
+or to a `layout_blas_packed` mdspan
+(whose layout is nonunique). <i>-- end note]</i>
 
 ## Algorithms [linalg.algs]
 
@@ -8432,7 +8454,7 @@ note]*
 
 ```c++
 template<@_in-vector_@ InVec,
-         @_inout-matrix_@ InOutMat,
+         @_possibly-packed-inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_1_update(
   InVec x,
@@ -8440,7 +8462,7 @@ void symmetric_matrix_rank_1_update(
   Triangle t);
 template<class ExecutionPolicy,
          @_in-vector_@ InVec,
-         @_inout-matrix_@ InOutMat,
+         @_possibly-packed-inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_1_update(
   ExecutionPolicy&& exec,
@@ -8449,7 +8471,7 @@ void symmetric_matrix_rank_1_update(
   Triangle t);
 template<class T,
          @_in-vector_@ InVec,
-         @_inout-matrix_@ InOutMat,
+         @_possibly-packed-inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_1_update(
   T alpha,
@@ -8459,7 +8481,7 @@ void symmetric_matrix_rank_1_update(
 template<class ExecutionPolicy,
          class T,
          @_in-vector_@ InVec,
-         @_inout-matrix_@ InOutMat,
+         @_possibly-packed-inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_1_update(
   ExecutionPolicy&& exec,
@@ -8532,7 +8554,7 @@ the mathematical expression for the algorithm is
 
 ```c++
 template<@_in-vector_@ InVec,
-         @_inout-matrix_@ InOutMat,
+         @_possibly-packed-inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_1_update(
   InVec x,
@@ -8540,7 +8562,7 @@ void hermitian_matrix_rank_1_update(
   Triangle t);
 template<class ExecutionPolicy,
          @_in-vector_@ InVec,
-         @_inout-matrix_@ InOutMat,
+         @_possibly-packed-inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_1_update(
   ExecutionPolicy&& exec,
@@ -8549,7 +8571,7 @@ void hermitian_matrix_rank_1_update(
   Triangle t);
 template<class T,
          @_in-vector_@ InVec,
-         @_inout-matrix_@ InOutMat,
+         @_possibly-packed-inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_1_update(
   T alpha,
@@ -8559,7 +8581,7 @@ void hermitian_matrix_rank_1_update(
 template<class ExecutionPolicy,
          class T,
          @_in-vector_@ InVec,
-         @_inout-matrix_@ InOutMat,
+         @_possibly-packed-inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_1_update(
   ExecutionPolicy&& exec,
@@ -8638,7 +8660,7 @@ the mathematical expression for the algorithm is
 ```c++
 template<@_in-vector_@ InVec1,
          @_in-vector_@ InVec2,
-         @_inout-matrix_@ InOutMat,
+         @_possibly-packed-inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_2_update(
   InVec1 x,
@@ -8649,7 +8671,7 @@ void symmetric_matrix_rank_2_update(
 template<class ExecutionPolicy,
          @_in-vector_@ InVec1,
          @_in-vector_@ InVec2,
-         @_inout-matrix_@ InOutMat,
+         @_possibly-packed-inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_2_update(
   ExecutionPolicy&& exec,
@@ -8715,7 +8737,7 @@ the mathematical expression for the algorithm is
 ```c++
 template<@_in-vector_@ InVec1,
          @_in-vector_@ InVec2,
-         @_inout-matrix_@ InOutMat,
+         @_possibly-packed-inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_2_update(
   InVec1 x,
@@ -8726,7 +8748,7 @@ void hermitian_matrix_rank_2_update(
 template<class ExecutionPolicy,
          @_in-vector_@ InVec1,
          @_in-vector_@ InVec2,
-         @_inout-matrix_@ InOutMat,
+         @_possibly-packed-inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_2_update(
   ExecutionPolicy&& exec,
@@ -9823,7 +9845,7 @@ to the input matrix. <i>-- end note]</i>
 ```c++
 template<class T,
          @_in-matrix_@ InMat1,
-         @_inout-matrix_@ InOutMat,
+         @_possibly-packed-inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_k_update(
   T alpha,
@@ -9833,7 +9855,7 @@ void symmetric_matrix_rank_k_update(
 template<class ExecutionPolicy,
          class T,
          @_in-matrix_@ InMat1,
-         @_inout-matrix_@ InOutMat,
+         @_possibly-packed-inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_k_update(
   ExecutionPolicy&& exec,
@@ -9902,7 +9924,7 @@ for all `k` such that `i,k` is in the domain of `A`.
 ```c++
 template<class T,
          @_in-matrix_@ InMat1,
-         @_inout-matrix_@ InOutMat,
+         @_possibly-packed-inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_k_update(
   T alpha,
@@ -9912,7 +9934,7 @@ void hermitian_matrix_rank_k_update(
 template<class ExecutionPolicy,
          class T,
          @_in-matrix_@ InMat1,
-         @_inout-matrix_@ InOutMat,
+         @_possibly-packed-inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_k_update(
   ExecutionPolicy&& exec,
@@ -9991,7 +10013,7 @@ to the input matrices. <i>-- end note]</i>
 ```c++
 template<@_in-matrix_@ InMat1,
          @_in-matrix_@ InMat2,
-         @_inout-matrix_@ InOutMat,
+         @_possibly-packed-inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_2k_update(
   InMat1 A,
@@ -10001,7 +10023,7 @@ void symmetric_matrix_rank_2k_update(
 template<class ExecutionPolicy,
          @_in-matrix_@ InMat1,
          @_in-matrix_@ InMat2,
-         @_inout-matrix_@ InOutMat,
+         @_possibly-packed-inout-matrix_@ InOutMat,
          class Triangle>
 void symmetric_matrix_rank_2k_update(
   ExecutionPolicy&& exec,
@@ -10070,7 +10092,7 @@ for all `k2` such that `i,k2` is in the domain of `B`.
 ```c++
 template<@_in-matrix_@ InMat1,
          @_in-matrix_@ InMat2,
-         @_inout-matrix_@ InOutMat,
+         @_possibly-packed-inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_2k_update(
   InMat1 A,
@@ -10081,7 +10103,7 @@ void hermitian_matrix_rank_2k_update(
 template<class ExecutionPolicy,
          @_in-matrix_@ InMat1,
          @_in-matrix_@ InMat2,
-         @_inout-matrix_@ InOutMat,
+         @_possibly-packed-inout-matrix_@ InOutMat,
          class Triangle>
 void hermitian_matrix_rank_2k_update(
   ExecutionPolicy&& exec,

--- a/D1673/P1673.md
+++ b/D1673/P1673.md
@@ -6309,43 +6309,43 @@ public:
   template<class Extents>
   struct mapping {
   private:
-    using nested_mapping_type =
+    using @_nested-mapping-type_@ =
       typename Layout::template mapping<
         @_transpose-extents-t_@<Extents>>; // exposition only
-    nested_mapping_type nested_mapping_; // exposition only
+    @_nested-mapping-type_@ @_nested-mapping_@; // exposition only
 
   public:
     using extents_type = Extents;
     using size_type = typename extents_type::size_type;
     using layout_type = layout_transpose;
 
-    constexpr explicit mapping(const nested_mapping_type& map);
+    constexpr explicit mapping(const @_nested-mapping-type_@& map);
 
     constexpr extents_type extents() const
-      noexcept(noexcept(nested_mapping_.extents()));
+      noexcept(noexcept(@_nested-mapping_@.extents()));
 
     constexpr size_type required_span_size() const
-      noexcept(noexcept(nested_mapping_.required_span_size()));
+      noexcept(noexcept(@_nested-mapping_@.required_span_size()));
 
     template<class... Indices>
       constexpr size_type operator()(Indices... indices) const
-        noexcept(noexcept(nested_mapping_(indices...)));
+        noexcept(noexcept(@_nested-mapping_@(indices...)));
 
-    constexpr nested_mapping_type nested_mapping() const;
+    constexpr @_nested-mapping-type_@ nested_mapping() const;
 
     static constexpr bool is_always_unique();
     static constexpr bool is_always_contiguous();
     static constexpr bool is_always_strided();
 
     constexpr bool is_unique() const
-      noexcept(noexcept(nested_mapping_.is_unique()));
+      noexcept(noexcept(@_nested-mapping_@.is_unique()));
     constexpr bool is_contiguous() const
-      noexcept(noexcept(nested_mapping_.is_contiguous()));
+      noexcept(noexcept(@_nested-mapping_@.is_contiguous()));
     constexpr bool is_strided() const
-      noexcept(noexcept(nested_mapping_.is_strided()));
+      noexcept(noexcept(@_nested-mapping_@.is_strided()));
 
     constexpr size_type stride(size_t r) const
-      noexcept(noexcept(nested_mapping_.stride(r)));
+      noexcept(noexcept(@_nested-mapping_@.stride(r)));
 
     template<class OtherExtents>
       friend constexpr bool
@@ -6359,92 +6359,92 @@ public:
 * *Constraints:* `Extents::rank()` equals 2.
 
 ```c++
-constexpr explicit mapping(const nested_mapping_type& map);
+constexpr explicit mapping(const @_nested-mapping-type_@& map);
 ```
 
-* *Effects:* Initializes `nested_mapping_` with `map`.
+* *Effects:* Initializes _`nested-mapping`_ with `map`.
 
 ```c++
 constexpr extents_type extents() const
-  noexcept(noexcept(nested_mapping_.extents()));
+  noexcept(noexcept(@_nested-mapping_@.extents()));
 ```
 
 * *Effects:* Equivalent to
-    `return` _`transpose-extents`_`(nested_mapping_.extents());`.
+    `return` _`transpose-extents`_ `(` _`nested_mapping`_ `.extents());`.
 
 ```c++
 constexpr size_type required_span_size() const
-  noexcept(noexcept(nested_mapping_.required_span_size()));
+  noexcept(noexcept(@_nested-mapping_@.required_span_size()));
 ```
 
-* *Effects:* Equivalent to `return nested_mapping_.required_span_size();`.
+* *Effects:* Equivalent to `return ` _`nested-mapping`_ `.required_span_size();`.
 
 ```c++
 template<class... Indices>
   constexpr size_type operator()(Indices... indices) const
-    noexcept(noexcept(nested_mapping_(indices...)));
+    noexcept(noexcept(@_nested-mapping_@(indices...)));
 ```
 
-* *Effects:* Equivalent to `return nested_mapping_(last_two_indices_reversed);`,
-    where `last_two_indices_reversed` is the result of
+* *Effects:* Equivalent to `return ` _`nested-mapping`_ `(last_2_indices_reversed);`,
+    where `last_2_indices_reversed` is the result of
     reversing the last two elements of `indices`.
 
 ```c++
-constexpr nested_mapping_type nested_mapping() const;
+constexpr @_nested-mapping-type_@ nested_mapping() const;
 ```
 
-* *Effects:* Equivalent to `return nested_mapping_;`.
+* *Effects:* Equivalent to `return ` _`nested-mapping`_ `;`.
 
 ```c++
 static constexpr bool is_always_unique();
 ```
 
 * *Effects:* Equivalent to
-    `return nested_mapping_type::is_always_unique();`.
+    `return ` _`nested-mapping-type`_ `::is_always_unique();`.
 
 ```c++
 static constexpr bool is_always_contiguous();
 ```
 
 * *Effects:* Equivalent to
-    `return nested_mapping_type::is_always_contiguous();`.
+    `return ` _`nested-mapping-type`_ `::is_always_contiguous();`.
 
 ```c++
 static constexpr bool is_always_strided();
 ```
 
 * *Effects:* Equivalent to
-    `return nested_mapping_type::is_always_strided();`.
+    `return ` _`nested-mapping-type`_ `::is_always_strided();`.
 
 ```c++
 constexpr bool is_unique() const
-  noexcept(noexcept(nested_mapping_.is_unique()));
+  noexcept(noexcept(@_nested-mapping_@.is_unique()));
 ```
 
-* *Effects:* Equivalent to `return nested_mapping_.is_unique();`.
+* *Effects:* Equivalent to `return ` _`nested-mapping`_ `.is_unique();`.
 
 ```c++
 constexpr bool is_contiguous() const
-  noexcept(noexcept(nested_mapping_.is_contiguous()));
+  noexcept(noexcept(@_nested-mapping_@.is_contiguous()));
 ```
 
-* *Effects:* Equivalent to `return nested_mapping_.is_contiguous();`.
+* *Effects:* Equivalent to `return ` _`nested-mapping`_ `.is_contiguous();`.
 
 ```c++
 constexpr bool is_strided() const
-  noexcept(noexcept(nested_mapping_.is_strided()));
+  noexcept(noexcept(@_nested-mapping_@.is_strided()));
 ```
 
-* *Effects:* Equivalent to `return nested_mapping_.is_strided();`.
+* *Effects:* Equivalent to `return ` _`nested-mapping`_ `.is_strided();`.
 
 ```c++
 constexpr size_type stride(size_t r) const
-  noexcept(noexcept(nested_mapping_.stride(r)));
+  noexcept(noexcept(@_nested-mapping_@.stride(r)));
 ```
 
 * *Constraints:* `is_always_strided()` is `true`.
 
-* *Effects:* Equivalent to `return nested_mapping_.stride(s);`, where
+* *Effects:* Equivalent to `return ` _`nested-mapping`_ `.stride(s);`, where
 
     * `s` is `rank()` - 2 if `r` equals `rank()` - 1,
 
@@ -6460,11 +6460,11 @@ template<class OtherExtents>
 
 * *Constraints:*
 
-    * `nested_mapping_type` and `decltype(m.nested_mapping_)` are equality comparable, and
+    * _`nested-mapping-type`_ and `decltype(m.` _`nested-mapping`_ `)` are equality comparable, and
 
     * `OtherExtents::rank()` equals `rank()`.
 
-* *Effects:* Equivalent to `nested_mapping_ == m.nested_mapping_;`.
+* *Effects:* Equivalent to _`nested-mapping`_ ` == m.` _`nested-mapping`_ `;`.
 
 ### `transposed` [linalg.transp.transposed]
 
@@ -6518,12 +6518,10 @@ where
         where
 
         * `OppositeTriangle` names the type
-            `conditional_t<is_same_v<Triangle, upper_triangle_t>,
-            lower_triangle_t, upper_triangle_t>`, and
+            `conditional_t<is_same_v<Triangle, upper_triangle_t>, lower_triangle_t, upper_triangle_t>`, and
 
         * `OppositeStorageOrder` names the type
-            `conditional_t<is_same_v<StorageOrder, column_major_t>,
-            row_major_t, column_major_t>`;
+            `conditional_t<is_same_v<StorageOrder, column_major_t>, row_major_t, column_major_t>`;
 
     * else if `Layout` is `layout_transpose<NestedLayout>`
         for some `NestedLayout`, then `NestedLayout` <i>[Note:</i>


### PR DESCRIPTION
@crtrott @dalg24 

* Remove Constraints made redundant by the new exposition-only concepts.

* Follow LEWG guidance to simplify Effects and Constraints
      (e.g., removing wording referring to the
      "the mathematical expression for the algorithm")
      by describing them mathematically (in math font).
      ("Mathematical expression for the algorithm"
      remains in a few places that call for more careful analysis.)

* Change `matrix_one_norm` Precondition (that the result of
      `abs` of a matrix element is convertible to `T`) to a Constraint.

* Change `vector_abs_sum` Precondition (that the result of
      `init + abs(v[i])` is convertible to `T`) to a Constraint.

* Address [issue](https://github.com/ORNL/cpp-proposals-pub/pull/314#issuecomment-1370334893) with constraints for symmetric and Hermitian update algorithms.

* Fix some formatting issues.


