### PR TITLE
Remove notes that say things like "users can ...".  User tips are not…

### DIFF
--- a/D1673/P1673.md
+++ b/D1673/P1673.md
@@ -6666,7 +6666,7 @@ return R(a.data(),
       for some `NestedLayout`, then equivalent to
       <i>[Note:</i> getting the nested mapping
       untransposes the extents <i>-- end note]</i>
-```c++        
+```c++
 return R(a.data(), a.mapping().nested_mapping(), a.accessor());
 ```
 
@@ -7207,17 +7207,6 @@ If `N` is zero, returns `init`, else returns
 floating-point types or complex versions thereof, and if `T` has
 higher precision than `InVec1::value_type` or `InVec2::value_type`, then
 intermediate terms in the sum use `T`'s precision or greater.
-
-<i>[Note:</i> Like `reduce`, `dot` applies binary `operator+` in an
-unspecified order.  This may yield a nondeterministic result for
-non-associative or non-commutative `operator+` such as floating-point
-addition.  However, implementations may perform extra work to make the
-result deterministic.  They may do so for all `dot` overloads, or just
-for specific `ExecutionPolicy` types. <i>-- end note]</i>
-
-<i>[Note:</i> Users can get `xDOTC` behavior by giving the first argument
-as the result of `conjugated`.  Alternately, they can use the shortcut `dotc`
-below. <i>-- end note]</i>
 
 [6]{.pnum} Nonconjugated dot product with default result type
 
@@ -8460,10 +8449,6 @@ where $y^T$ denotes the transpose of the column vector $y$.
 
 [4]{.pnum} *Complexity:* The count of `mdspan` array accesses and arithmetic operations is linear in `x.extent(0)` times `y.extent(0)`.
 
-<i>[Note:</i> Users can get `xGERC` behavior by giving the second argument
-as the result of `conjugated`.  Alternately, they can use the shortcut
-`matrix_rank_1_update_c` below. <i>-- end note]</i>
-
 ##### Nonsymmetric conjugated rank-1 update [linalg.algs.blas2.rank1.gerc]
 
 ```c++
@@ -9680,11 +9665,6 @@ void triangular_matrix_right_product(
 
 #### Rank-k update of a symmetric or Hermitian matrix [linalg.alg.blas3.rank-k]
 
-<i>[Note:</i> Users can achieve the effect
-of the `TRANS` argument of these BLAS functions,
-by applying `transposed` or `conjugate_transposed`
-to the input matrix. <i>-- end note]</i>
-
 [1]{.pnum} *Complexity:* For all algorithms in this Clause,
 the count of `mdspan` array accesses and arithmetic operations
 is linear in `A.extent(0)` times `A.extent(1)` times `A.extent(0)`.
@@ -9821,11 +9801,6 @@ for indices `i,j` in the domain of `C`
 but outside the triangle specified by `t`.
 
 #### Rank-2k update of a symmetric or Hermitian matrix [linalg.alg.blas3.rank2k]
-
-<i>[Note:</i> Users can achieve the effect
-of the `TRANS` argument of these BLAS functions,
-by applying `transposed` or `conjugate_transposed`
-to the input matrices. <i>-- end note]</i>
 
 [1]{.pnum} *Complexity:* The count of `mdspan` array accesses
 and arithmetic operations is linear in


### PR DESCRIPTION
… part of

the standard.