### PR TITLE
Replace the use of the word "method" with function; simplify "algorit…

### DIFF
--- a/D1673/P1673.md
+++ b/D1673/P1673.md
@@ -5113,7 +5113,7 @@ void triangular_matrix_matrix_right_solve(
 [1]{.pnum} This clause lists the minimum requirements for all algorithms and classes in **[linalg]**,
 and for the following types:
 
-* [1.1]{.pnum} for any input or output `mdspan` parameter(s) of any algorithm or method in **[linalg]**,
+* [1.1]{.pnum} for any input or output `mdspan` parameter(s) of any function in **[linalg]**,
     the parameter(s)' `value_type` and `reference` type aliases;
 
 * [1.2]{.pnum} the `Scalar` template parameter (if any) of any algorithm or class in **[linalg]**;
@@ -5130,16 +5130,16 @@ asymptotic complexity requirements, if any, are satisfied.
 * [3.1]{.pnum} Any linear algebra value type
     meets the requirements of `semiregular`.
 
-* [3.2]{.pnum} The algorithm or method may perform read-only access
+* [3.2]{.pnum} The function may perform read-only access
     on any input or output `mdspan` arbitrarily many times.
 
-* [3.3]{.pnum} The algorithm or method may make
+* [3.3]{.pnum} The function may make
     arbitrarily many objects
     of any linear algebra value type,
     value-initializing or direct-initializing them
     with any existing object of that type.
 
-* [3.4]{.pnum} The algorithm or method may assign
+* [3.4]{.pnum} The function may assign
     arbitrarily many times to any reference
     resulting from a valid output `mdspan` access.
 
@@ -5170,7 +5170,7 @@ asymptotic complexity requirements, if any, are satisfied.
     and any assignment
     is well formed.
 
-* [3.6]{.pnum} Otherwise, the algorithm or method
+* [3.6]{.pnum} Otherwise, the function
     will use a sequence of evaluations of
     `*`, `*=`, `+`, `+=`, and `=` operators
     that would produce the result
@@ -5185,7 +5185,7 @@ asymptotic complexity requirements, if any, are satisfied.
     and any assignment
     is well formed.
 
-* [3.7]{.pnum} If the wording for the algorithm or method
+* [3.7]{.pnum} If the wording for the function
     additionally includes
     
     * _`conj-if-needed`_`(z)` for some expression `z`
@@ -5200,32 +5200,32 @@ asymptotic complexity requirements, if any, are satisfied.
     where it would be mathematically appropriate
     is well formed.
 
-* [3.10]{.pnum} If the algorithm or method has an output `mdspan`,
+* [3.10]{.pnum} If the function has an output `mdspan`,
     then all addends
     (or subtrahends, if applicable)
     (or results of `divide` on intermediate terms, if applicable)
     are assignable and convertible to the output `mdspan`'s `value_type`.
 
-* [3.11]{.pnum} The algorithm or method may reorder
+* [3.11]{.pnum} The function may reorder
     addends and partial sums arbitrarily.
     <i>[Note:</i>
     Factors in each product are not reordered;
     multiplication is not necessarily commutative.
     <i>-- end note]</i>
 
-* [3.12]{.pnum} The algorithm or method may replace any value
+* [3.12]{.pnum} The function may replace any value
     with the sum of that value
     and a value-initialized object
     of any input or output `mdspan`'s `value_type`.
 
-* [3.13]{.pnum} If the algorithm or method has a `T init` parameter,
-    then the algorithm or method may replace any value
+* [3.13]{.pnum} If the function has a `T init` parameter,
+    then the function may replace any value
     with the sum of that value
     and a value-initialized object of type `T`.
 
-### Requirements for algorithms and methods on floating-point values [linalg.reqs.flpt]
+### Requirements for functions on floating-point values [linalg.reqs.flpt]
 
-[1]{.pnum} For all algorithms and classes in **[linalg]**, suppose that
+[1]{.pnum} For all functions in **[linalg]**, suppose that
 
 * [1.1]{.pnum} all input and output `mdspan` have `value_type` a floating-point type,
 
@@ -5233,12 +5233,12 @@ asymptotic complexity requirements, if any, are satisfied.
 
 * [1.3]{.pnum} any argument corresponding to the `T init` parameter has a floating-point type.
 
-[2]{.pnum} Then, algorithms and classes' methods may do the following:
+[2]{.pnum} Then, functions may do the following:
 
 * [2.1]{.pnum} compute floating-point sums in any way that improves their accuracy for arbitrary input;
 
 * [2.2]{.pnum} perform additional arithmetic operations
-    (other than those specified by the algorithm's or method's wording
+    (other than those specified by the function's wording
     and **[linalg.reqs.val]**)
     in order to improve performance or accuracy; and
 
@@ -5249,9 +5249,9 @@ asymptotic complexity requirements, if any, are satisfied.
 
 as long as
 
-* [2.4]{.pnum} the algorithm or method satisfies the complexity requirements; and
+* [2.4]{.pnum} the function satisfies the complexity requirements; and
 
-* [2.5]{.pnum} the algorithm or method is *logarithmically stable*,
+* [2.5]{.pnum} the function is *logarithmically stable*,
     as defined in
     J. Demmel, I. Dumitriu, and O. Holtz,
     "Fast linear algebra is stable,"


### PR DESCRIPTION
…hm and/or

function" text to just "function".  The word "method" has no meaning in the standard.