### PR TITLE
Remove "we use `*` in a typename [as a wildcard]" language.  First, t…

### DIFF
--- a/D1673/P1673.md
+++ b/D1673/P1673.md
@@ -6867,9 +6867,7 @@ or to a `layout_blas_packed` mdspan
 
 [1]{.pnum} Throughout this Clause, where the template parameters are not
 constrained, the names of template parameters are used to express type
-requirements.  In the requirements below, we use `*` in a typename to
-denote a "wildcard," that matches zero characters, `_1`, `_2`, `_3`,
-or other things as appropriate.
+requirements.
 
   * [1.1]{.pnum} Algorithms that have a template parameter
       named `ExecutionPolicy` are parallel algorithms


### PR DESCRIPTION
…here's no

"we" in the standard. :) Second, there do not appear to be any template parameters that contain "_2" (I did not search for the others), and I cannot find any template parameters that follow this sentence that contain a "*" either.  If there are, you shold just list all the variations, rather than including a pattern.