### PR TITLE
Replace the use of "complex versions" of floating point types.  "complex

### DIFF
--- a/D1673/P1673.md
+++ b/D1673/P1673.md
@@ -7204,7 +7204,7 @@ If `N` is zero, returns `init`, else returns
 *GENERALIZED_SUM*(`plus<>()`, `init`, `v1[0]*v2[0]`, ..., `v1[N-1]*v2[N-1]`).
 
 [5]{.pnum} *Remarks:* If `InVec1::value_type`, `InVec2::value_type`, and `T` are all
-floating-point types or complex versions thereof, and if `T` has
+floating-point types or specializations of `complex`, and if `T` has
 higher precision than `InVec1::value_type` or `InVec2::value_type`, then
 intermediate terms in the sum use `T`'s precision or greater.
 
@@ -7382,7 +7382,7 @@ This description does not imply a recommended implementation
 for floating-point types.  See *Remarks* below. <i>-- end note]</i>
 
 [3]{.pnum} *Remarks:* If `InVec::value_type` is a floating-point type
-    or a complex version thereof, and if `T` is a floating-point type, then
+    or a specialization of `complex`, and if `T` is a floating-point type, then
 
   * [3.1]{.pnum} if `T` has higher precision than `InVec::value_type`, then
       intermediate terms in the sum use `T`'s precision or greater; and
@@ -7457,7 +7457,7 @@ are both convertible to `T`.
       `abs(v[0])`, ..., `abs(v[N-1])`).
 
 [3]{.pnum} *Remarks:* If `InVec::value_type` is a floating-point type
-    or a complex version thereof, if `T` is a floating-point type,
+    or a specialization of `complex`, if `T` is a floating-point type,
     and if `T` has higher precision than `InVec::value_type`,
     then intermediate terms in the sum use `T`'s precision or greater.
 


### PR DESCRIPTION
versions" doesn't have any meaning in the standard.  To say what I think you meant, you should say "specializations of `complex`".  In the standard, a "specialization of `foo`" means an what we would verbally say is an "instantiation of the template foo".