### PR TITLE
In the standard, "Effects: Equivalent to: `X`" means, "The standard l…

### DIFF
--- a/D1673/P1673.md
+++ b/D1673/P1673.md
@@ -5123,6 +5123,14 @@ and mathematical expression $EXPR$), the following apply:
     the result of the computation is written to the elements of the function
     parameter `R`.
 
+[2]{.pnum} For any function `F` that takes a `Triangle t` parameter, `t`
+applies to accesses to the previous parameter to the function.  Let `M` be
+such an access-modified function parameter.  `F` will only access the triangle
+of `M` specified by `t`.  For accesses `M[i, j]` in the domain of `M` but
+outside the triangle specified by `t`, `F` will interpret the value `M[i, j]`
+as equal to _`conj-if-needed`_`(M[j, i])` if the name of `F` starts with
+`hermitian`, and `M[j, i]` otherwise.
+
 ## Requirements [linalg.reqs]
 
 ### Value and reference requirements [linalg.reqs.val]
@@ -7818,12 +7826,6 @@ void matrix_vector_product(ExecutionPolicy&& exec,
 perform a count of `mdspan` array accesses and arithmetic operations
 that is linear in `x.extent(0)` times `A.extent(1)`.
 
-[6]{.pnum} *Remarks:* The functions will only access
-the triangle of `A` specified by the `Triangle` argument `t`,
-and will interpret the value `A[i,j]`
-as equal to `A[j,i]` for indices `i,j` in the domain of `A`
-but outside the triangle specified by `t`.
-
 ##### Overwriting symmetric matrix-vector product
 
 ```c++
@@ -7929,13 +7931,6 @@ void symmetric_matrix_vector_product(
 perform a count of `mdspan` array accesses and arithmetic operations
 that is linear in `x.extent(0)` times `A.extent(1)`.
 
-[6]{.pnum} *Remarks:* The functions will only access
-the triangle of `A` specified by the `Triangle` argument `t`,
-and will interpret the value `A[i,j]`
-as equal to _`conj-if-needed`_`(A[j,i])` for indices `i,j`
-in the domain of `A`
-but outside the triangle specified by `t`.
-
 ##### Overwriting Hermitian matrix-vector product
 
 ```c++
@@ -8037,16 +8032,10 @@ has the same type as the function's `Triangle` template argument.
 perform a count of `mdspan` array accesses and arithmetic operations
 that is linear in `x.extent(0)` times `A.extent(1)`.
 
-[6]{.pnum} *Remarks:*
-
-  * [6.1]{.pnum} The functions will only access the triangle of `A`
-      specified by the `Triangle` argument `t`.
-
-  * [6.2]{.pnum} If the `DiagonalStorage` template argument has type
-      `implicit_unit_diagonal_t`,
-      then the functions will not access the diagonal of `A`,
-      and will interpret `A` as if each of its diagonal elements
-      behaves as a two-sided multiplicative identity.
+[6]{.pnum} *Remarks:* If the `DiagonalStorage` template argument has type
+`implicit_unit_diagonal_t`, then the functions will not access the diagonal of
+`A`, and will interpret `A` as if each of its diagonal elements behaves as a
+two-sided multiplicative identity.
 
 ##### Overwriting triangular matrix-vector product [linalg.algs.blas2.trmv.ov]
 
@@ -8184,16 +8173,10 @@ the function's `Triangle` template argument.
 perform a count of `mdspan` array accesses and arithmetic operations
 that is linear in `x.extent(0)` times `A.extent(1)`.
 
-[6]{.pnum} *Remarks:*
-
-  * [6.1]{.pnum} The functions will only access the triangle of `A`
-      specified by the `Triangle` argument `t`.
-
-  * [6.2]{.pnum} If the `DiagonalStorage` template argument has type
-      `implicit_unit_diagonal_t`,
-      then the functions will not access the diagonal of `A`,
-      and will interpret `A` as if each of its diagonal elements
-      behaves as a two-sided multiplicative identity.
+[6]{.pnum} *Remarks:* If the `DiagonalStorage` template argument has type
+`implicit_unit_diagonal_t`, then the functions will not access the diagonal of
+`A`, and will interpret `A` as if each of its diagonal elements behaves as a
+two-sided multiplicative identity.
 
 ##### Not-in-place triangular solve [linalg.algs.blas2.trsv.not-in-place]
 
@@ -8523,11 +8506,6 @@ parameter, and `alpha` otherwise.  Computes $A = A + \alpha x x^T$.
 and arithmetic operations is linear in
 `x.extent(0)` times `x.extent(0)`.
 
-[6]{.pnum} *Remarks:* The functions will only access
-the triangle of `A` specified by the `Triangle` argument `t`,
-and will interpret the value `A[i,j]` as equal to `A[j,i]`
-for indices `i,j` in the domain `A` but outside that triangle.
-
 ##### Rank-1 update of a Hermitian matrix [linalg.algs.blas2.rank1.her]
 
 ```c++
@@ -8605,17 +8583,6 @@ parameter, and `alpha` otherwise.  Computes $A = A + \alpha x x^H$.
 and arithmetic operations is linear in
 `x.extent(0)` times `x.extent(0)`.
 
-[6]{.pnum} *Remarks:*
-
-  * [6.1]{.pnum} The functions will only access
-      the triangle of `A` specified by
-      the `Triangle` argument `t`.
-
-  * [6.2]{.pnum} For indices `i,j` in the domain of `A`
-      but outside the triangle specified by `t`,
-      the functions will interpret the value `A[i,j]`
-      as equal to _`conj-if-needed`_`(A[j,i])`.
-
 #### Rank-2 update of a symmetric matrix [linalg.algs.blas2.rank2.syr2]
 
 ```c++
@@ -8679,11 +8646,6 @@ the function's `Triangle` template argument.
 and arithmetic operations is linear in
 `x.extent(0)` times `y.extent(0)`.
 
-[6]{.pnum} *Remarks:* The functions will only access
-the triangle of `A` specified by the `Triangle` argument `t`,
-and will interpret the value `A[i,j]` as equal to `A[j,i]`
-for indices `i,j` in the domain `A` but outside that triangle.
-
 #### Rank-2 update of a Hermitian matrix [linalg.algs.blas2.rank2.her2]
 
 ```c++
@@ -8746,12 +8708,6 @@ the function's `Triangle` template argument.
 [5]{.pnum} *Complexity:* The count of `mdspan` array accesses
 and arithmetic operations is linear in
 `x.extent(0)` times `y.extent(0)`.
-
-[6]{.pnum} *Remarks:* The functions will only access
-the triangle of `A` specified by the `Triangle` argument `t`,
-and will interpret the value `A[i,j]`
-as equal to _`conj-if-needed`_`(A[j,i])` for indices `i,j`
-in the domain of `A` but outside the triangle specified by `t`.
 
 ### BLAS 3 functions [linalg.algs.blas3]
 
@@ -8884,15 +8840,8 @@ the function's `Triangle` template argument.
       equals `dynamic_extent`, then `C.static_extent(r)` equals
       `E.static_extent(r)` (if applicable).
 
-[5]{.pnum} *Remarks:*
-
-  * [5.1]{.pnum} The functions will only access the triangle of `A`
-      specified by the `Triangle` argument `t`,
-      and will interpret the value `A[i,j]` as equal to `A[j,i]`
-      for indices `i,j` in the domain `A` but outside that triangle.
-
-  * [5.2]{.pnum} `C` and `E` (if applicable)
-      may refer to the same matrix.
+[5]{.pnum} *Remarks:* `C` and `E` (if applicable) may refer to the same
+matrix.
 
 [6]{.pnum} The following requirements apply to all overloads of
 `symmetric_matrix_left_product`.
@@ -9105,18 +9054,8 @@ the function's `Triangle` template argument.
       then `C.static_extent(r)` equals `E.static_extent(r)`
       (if applicable).
 
-[5]{.pnum} *Remarks:*
-
-  * [5.1]{.pnum} The functions will only access
-      the triangle of `A` specified by
-      the `Triangle` argument `t`,
-      and will interpret the value `A[i,j]`
-      as equal to _`conj-if-needed`_`(A[j,i])`
-      for indices `i,j` in the domain of `A`
-      but outside the triangle specified by `t`.
-
-  * [5.1]{.pnum} `C` and `E` (if applicable)
-      may refer to the same matrix.
+[5]{.pnum} *Remarks:* `C` and `E` (if applicable) may refer to the same
+matrix.
 
 [6]{.pnum} The following requirements apply to all overloads of
 `hermitian_matrix_left_product`.
@@ -9327,10 +9266,6 @@ to all functions in this section.
       (if applicable).
 
 [5]{.pnum} *Remarks:*
-
-  * [5.1]{.pnum} The functions will only access
-      the triangle of `A` specified by
-      the `Triangle` argument `t`.
 
   * [5.2]{.pnum} If the `DiagonalStorage` template argument
       has type `implicit_unit_diagonal_t`,
@@ -9674,12 +9609,6 @@ If `C` has `layout_blas_packed` layout, then the layout's
 
 [4]{.pnum} *Effects:* Computes $C = C + \alpha A A^T$.
 
-[5]{.pnum} *Remarks:* The functions will only access
-the triangle of `C` specified by the `Triangle` argument `t`,
-and will interpret the value `C[i,j]` as equal to `C[j,i]`
-for indices `i,j` in the domain of `C`
-but outside the triangle specified by `t`.
-
 ##### Rank-k Hermitian matrix update [linalg.alg.blas3.rank-k.herk]
 
 ```c++
@@ -9736,12 +9665,6 @@ If `C` has `layout_blas_packed` layout, then the layout's
       then `C.static_extent(0)` equals `C.static_extent(1)`.
 
 [4]{.pnum} *Effects:* Computes $C = C + \alpha A A^H$.
-
-[5]{.pnum} *Remarks:* The functions will only access
-the triangle of `C` specified by the `Triangle` argument `t`,
-and will interpret the value `C[i,j]` as equal to `C[j,i]`
-for indices `i,j` in the domain of `C`
-but outside the triangle specified by `t`.
 
 #### Rank-2k update of a symmetric or Hermitian matrix [linalg.alg.blas3.rank2k]
 
@@ -9815,12 +9738,6 @@ the function's `Triangle` template argument.
 
 [4]{.pnum} *Effects:* Computes $C = C + A B^T + B A^T$.
 
-[5]{.pnum} *Remarks:* The functions will only access
-the triangle of `C` specified by the `Triangle` argument `t`,
-and will interpret the value `C[i,j]` as equal to `C[j,i]`
-for indices `i,j` in the domain of `C`
-but outside the triangle specified by `t`.
-
 ##### Rank-2k Hermitian matrix update [linalg.alg.blas3.rank2k.her2k]
 
 ```c++
@@ -9879,13 +9796,6 @@ If `C` has `layout_blas_packed` layout, then the layout's
 
 [4]{.pnum} *Effects:* Computes $C = C + A B^H + B A^H$.
 
-[5]{.pnum} *Remarks:* The functions will only access
-the triangle of `C` specified by the `Triangle` argument `t`,
-and will interpret the value `C[i,j]`
-as equal to _`conj-if-needed`_`(C[j,i])`
-for indices `i,j` in the domain of `C`
-but outside the triangle specified by `t`.
-
 #### Solve multiple triangular linear systems [linalg.alg.blas3.trsm]
 
 <i>[Note:</i> These functions correspond to the BLAS function `xTRSM`.
@@ -9923,17 +9833,10 @@ to all functions in this section.
       nor `A.static_extent(1)` equals `dynamic_extent`,
       then `A.static_extent(0)` equals `A.static_extent(1)`.
 
-[5]{.pnum} *Remarks:*
-
-  * [5.1]{.pnum} The functions will only access
-      the triangle of `A` specified by
-      the `Triangle` argument `t`.
-
-  * [5.2]{.pnum} If the `DiagonalStorage` template argument
-      has type `implicit_unit_diagonal_t`,
-      then the functions will not access the diagonal of `A`,
-      and will interpret `A` as if each of its diagonal elements
-      behaves as a two-sided multiplicative identity.
+[5]{.pnum} *Remarks:* If the `DiagonalStorage` template argument has type
+`implicit_unit_diagonal_t`, then the functions will not access the diagonal of
+`A`, and will interpret `A` as if each of its diagonal elements behaves as a
+two-sided multiplicative identity.
 
 ##### Solve multiple triangular linear systems with triangular matrix on the left [linalg.alg.blas3.trsm.left]
 

--- a/D1673/P1673.md
+++ b/D1673/P1673.md
@@ -5106,6 +5106,23 @@ void triangular_matrix_matrix_right_solve(
 }
 ```
 
+## General [linalg.general]
+
+[1]{.pnum} For the effects of all functions in this clause, when the effects
+are described as "Computes $R = EXPR$" or "compute $R = EXPR$" (for some $R$
+and mathematical expression $EXPR$), the following apply:
+
+  * [1.1]{.pnum} $EXPR$ has the conventional mathematical meaning as written.
+
+  * [1.2]{.pnum} The pattern $x^T$ should be read as "the transpose of $x$".
+
+  * [1.3]{.pnum} The pattern $x^H$ should be read as "the conjugate transpose of $x$".
+
+  * [1.4]{.pnum} When $R$ is the same name as a function parameter whose
+    type is a template parameter with `Out` in its name, the intent is that
+    the result of the computation is written to the elements of the function
+    parameter `R`.
+
 ## Requirements [linalg.reqs]
 
 ### Value and reference requirements [linalg.reqs.val]
@@ -7692,7 +7709,7 @@ void matrix_vector_product(ExecutionPolicy&& exec,
                            OutVec y);
 ```
 
-[1]{.pnum} *Effects:* Computes $y$ such that $y = A x$.
+[1]{.pnum} *Effects:* Computes $y = A x$.
 
 [*Example:*
 ```c++
@@ -7752,7 +7769,7 @@ void matrix_vector_product(ExecutionPolicy&& exec,
                            OutVec z);
 ```
 
-[1]{.pnum} *Effects:* Computes $z$ such that $z = y + A x$.
+[1]{.pnum} *Effects:* Computes $z = y + A x$.
 
 [2]{.pnum} *Remarks:* `y` and `z` may refer to the same vector.
 
@@ -7831,7 +7848,7 @@ void symmetric_matrix_vector_product(ExecutionPolicy&& exec,
                                      OutVec y);
 ```
 
-[1]{.pnum} *Effects:* Computes $y$ such that $y = A x$.
+[1]{.pnum} *Effects:* Computes $y = A x$.
 
 ##### Updating symmetric matrix-vector product
 
@@ -7863,7 +7880,7 @@ void symmetric_matrix_vector_product(
   OutVec z);
 ```
 
-[1]{.pnum} *Effects:* Computes $z$ such that $z = y + A x$.
+[1]{.pnum} *Effects:* Computes $z = y + A x$.
 
 [2]{.pnum} *Remarks:* `y` and `z` may refer to the same vector.
 
@@ -7943,7 +7960,7 @@ void hermitian_matrix_vector_product(ExecutionPolicy&& exec,
                                      OutVec y);
 ```
 
-[1]{.pnum} *Effects:* Computes $y$ such that $y = A x$.
+[1]{.pnum} *Effects:* Computes $y = A x$.
 
 ##### Updating Hermitian matrix-vector product
 
@@ -7973,7 +7990,7 @@ void hermitian_matrix_vector_product(ExecutionPolicy&& exec,
                                      OutVec z);
 ```
 
-[1]{.pnum} *Effects:* Computes $z$ such that $z = y + A x$.
+[1]{.pnum} *Effects:* Computes $z = y + A x$.
 
 [2]{.pnum} *Remarks:* `y` and `z` may refer to the same vector.
 
@@ -8060,7 +8077,7 @@ void triangular_matrix_vector_product(
   OutVec y);
 ```
 
-[1]{.pnum} *Effects:* Computes $y$ such that $y = A x$.
+[1]{.pnum} *Effects:* Computes $y = A x$.
 
 ##### In-place triangular matrix-vector product [linalg.algs.blas2.trmv.in-place]
 
@@ -8098,7 +8115,7 @@ This is why the `ExecutionPolicy` overload exists. <i>-- end note]</i>
 nor `y.static_extent(0)` equals `dynamic_extent`,
 then `A.static_extent(1)` equals `y.static_extent(0)`.
 
-[3]{.pnum} *Effects:* Computes $y$ such that $y = A x$.
+[3]{.pnum} *Effects:* Computes $y = A x$.
 
 ##### Updating triangular matrix-vector product [linalg.algs.blas2.trmv.up]
 
@@ -8132,7 +8149,7 @@ void triangular_matrix_vector_product(ExecutionPolicy&& exec,
                                       OutVec z);
 ```
 
-[1]{.pnum} *Effects:* Computes $z$ such that $z = y + A x$.
+[1]{.pnum} *Effects:* Computes $z = y + A x$.
 
 [2]{.pnum} *Remarks:* `y` and `z` may refer to the same vector.
 
@@ -8217,9 +8234,9 @@ void triangular_matrix_vector_solve(
 nor `x.static_extent(0)` equals `dynamic_extent`,
 then `A.static_extent(0)` equals `x.static_extent(0)`.
 
-[3]{.pnum} *Effects:* Computes $x$ such that $b = A x$.
-If no such $x$ exists,
-then the elements of $x$ are valid but unspecified.
+[3]{.pnum} *Effects:* Computes $x'$ such that $b = A x'$, and assigns each
+element of $x'$ to the corresponding element of `x`.  If no such $x'$ exists,
+then the elements of `x` are valid but unspecified.
 
 ```c++
 template<@_in-matrix_@ InMat,
@@ -8305,10 +8322,9 @@ This is why the `ExecutionPolicy` overload exists. <i>-- end note]</i>
 nor `b.static_extent(0)` equals `dynamic_extent`,
 then `A.static_extent(0)` equals `b.static_extent(0)`.
 
-[3]{.pnum} *Effects:* Overwrites $b$ with $x$ such that
-$b = A x$.
-If no such $x$ exists,
-then the elements of $b$ are valid but unspecified.
+[3]{.pnum} *Effects:* Computes $x'$ such that $b = A x'$, and assigns each
+element of $x'$ to the corresponding element of `b`.  If no such $x'$ exists,
+then the elements of `b` are valid but unspecified.
 
 ```c++
 template<@_in-matrix_@ InMat,
@@ -8393,8 +8409,7 @@ void matrix_rank_1_update(
       nor `y.static_extent(0)` equals `dynamic_extent`,
       then `A.static_extent(1)` equals `y.static_extent(0)`.
 
-[3]{.pnum} *Effects:* Overwrites $A$ with $A'$ such that $A' = x y^T$,
-where $y^T$ denotes the transpose of the column vector $y$.
+[3]{.pnum} *Effects:* Computes $A = x y^T$.
 
 [4]{.pnum} *Complexity:* The count of `mdspan` array accesses and arithmetic operations is linear in `x.extent(0)` times `y.extent(0)`.
 
@@ -8503,14 +8518,9 @@ the function's `Triangle` template argument.
 
 [4]{.pnum} *Effects:*
 
-  * [4.1]{.pnum} Overloads without an `alpha` parameter overwrite $A$
-      with $A'$ such that $A' = A + x x^T$,
-      where $x^T$ denotes the transpose of the column vector $x$.
+  * [4.1]{.pnum} Overloads without an `alpha` parameter compute $A = A + x x^T$.
 
-  * [4.2]{.pnum} Overloads with an `alpha` parameter overwrite $A$
-      with $A'$ such that $A' = A + \alpha x x^T$,
-      where the scalar $\alpha$ is `alpha`
-      and $x^T$ denotes the transpose of the column vector $x$.
+  * [4.2]{.pnum} Overloads with an `alpha` parameter compute $A = A + \alpha x x^T$.
 
 [5]{.pnum} *Complexity:* The count of `mdspan` array accesses
 and arithmetic operations is linear in
@@ -8594,15 +8604,10 @@ the function's `Triangle` template argument.
 [4]{.pnum} *Effects:*
 
   * [4.1]{.pnum} Overloads without an `alpha` parameter
-      overwrite $A$ with $A'$ such that $A' = A + x x^H$,
-      where $x^H$ denotes the conjugate transpose
-      of the column vector $x$.
+      compute $A = A + x x^H$.
 
   * [4.2]{.pnum} Overloads with an `alpha` parameter
-      overwrite $A$ with $A'$ such that $A' = A + \alpha x x^H$,
-      where the scalar $\alpha$ is `alpha`
-      and $x^H$ denotes the conjugate transpose
-      of the column vector $x$.
+      compute $A = A + \alpha x x^H$.
 
 [5]{.pnum} *Complexity:* The count of `mdspan` array accesses
 and arithmetic operations is linear in
@@ -8676,10 +8681,7 @@ the function's `Triangle` template argument.
       or `y.static_extent(0)` equals `dynamic_extent`,
       then `A.static_extent(0)` equals `y.static_extent(0)`.
 
-[4]{.pnum} *Effects:* Overwrites $A$ with $A'$ such that
-$A' = A + x y^T + y x^T$,
-where $x^T$ denotes the transpose of the column vector $x$,
-and $y^T$ denotes the transpose of the column vector $y$.
+[4]{.pnum} *Effects:* Computes $A = A + x y^T + y x^T$.
 
 [5]{.pnum} *Complexity:* The count of `mdspan` array accesses
 and arithmetic operations is linear in
@@ -8747,10 +8749,7 @@ the function's `Triangle` template argument.
       nor `y.static_extent(0)` equals `dynamic_extent`,
       then `A.static_extent(0)` equals `y.static_extent(0)`.
 
-[4]{.pnum} *Effects:* Overwrites $A$ with $A'$ such that
-$A' = A + x y^H + y x^H$,
-where $x^H$ denotes the conjugate transpose of the column vector $x$,
-and $y^H$ denotes the conjugate transpose of the column vector $y$.
+[4]{.pnum} *Effects:* Computes $A = A + x y^H + y x^H$.
 
 [5]{.pnum} *Complexity:* The count of `mdspan` array accesses
 and arithmetic operations is linear in
@@ -8827,7 +8826,7 @@ void matrix_product(ExecutionPolicy&& exec,
                     OutMat C);
 ```
 
-[1]{.pnum} *Effects:* Computes $C$ such that $C = A B$.
+[1]{.pnum} *Effects:* Computes $C = A B$.
 
 ##### Updating general matrix-matrix product
 
@@ -8853,7 +8852,7 @@ void matrix_product(ExecutionPolicy&& exec,
                     OutMat C);
 ```
 
-[1]{.pnum} *Effects:* Computes $C$ such that $C = E + A B$.
+[1]{.pnum} *Effects:* Computes $C = E + A B$.
 
 [2]{.pnum} *Remarks:* `C` and `E` may refer to the same matrix.
 
@@ -8986,7 +8985,7 @@ void symmetric_matrix_left_product(
   OutMat C);
 ```
 
-[1]{.pnum} *Effects:* Computes $C$ such that $C = A B$.
+[1]{.pnum} *Effects:* Computes $C = A B$.
 
 ##### Overwriting symmetric matrix-matrix right product [linalg.algs.blas3.symm.ov.right]
 
@@ -9013,7 +9012,7 @@ void symmetric_matrix_right_product(
   OutMat C);
 ```
 
-[1]{.pnum} *Effects:* Computes $C$ such that $C = B A$.
+[1]{.pnum} *Effects:* Computes $C = B A$.
 
 ##### Updating symmetric matrix-matrix left product [linalg.algs.blas3.symm.up.left]
 
@@ -9044,7 +9043,7 @@ void symmetric_matrix_left_product(
   OutMat C);
 ```
 
-[1]{.pnum} *Effects:* Computes $C$ such that $C = E + A B$.
+[1]{.pnum} *Effects:* Computes $C = E + A B$.
 
 ##### Updating symmetric matrix-matrix right product [linalg.algs.blas3.symm.up.right]
 
@@ -9075,7 +9074,7 @@ void symmetric_matrix_right_product(
   OutMat C);
 ```
 
-[1]{.pnum} *Effects:* Computes $C$ such that $C = E + B A$.
+[1]{.pnum} *Effects:* Computes $C = E + B A$.
 
 #### Hermitian matrix-matrix product [linalg.algs.blas3.hemm]
 
@@ -9210,7 +9209,7 @@ void hermitian_matrix_left_product(
   OutMat C);
 ```
 
-[1]{.pnum} *Effects:* Computes $C$ such that $C = A B$.
+[1]{.pnum} *Effects:* Computes $C = A B$.
 
 ##### Overwriting Hermitian matrix-matrix right product [linalg.algs.blas3.hemm.ov.right]
 
@@ -9237,7 +9236,7 @@ void hermitian_matrix_right_product(
   OutMat C);
 ```
 
-[1]{.pnum} *Effects:* Computes $C$ such that $C = B A$.
+[1]{.pnum} *Effects:* Computes $C = B A$.
 
 ##### Updating Hermitian matrix-matrix left product [linalg.algs.blas3.hemm.up.left]
 
@@ -9268,7 +9267,7 @@ void hermitian_matrix_left_product(
   OutMat C);
 ```
 
-[1]{.pnum} *Effects:* Computes $C$ such that $C = E + A B$.
+[1]{.pnum} *Effects:* Computes $C = E + A B$.
 
 ##### Updating Hermitian matrix-matrix right product [linalg.algs.blas3.hemm.up.right]
 
@@ -9299,7 +9298,7 @@ void hermitian_matrix_right_product(
   OutMat C);
 ```
 
-[1]{.pnum} *Effects:* Computes $C$ such that $C = E + B A$.
+[1]{.pnum} *Effects:* Computes $C = E + B A$.
 
 #### Triangular matrix-matrix product [linalg.algs.blas3.trmm]
 
@@ -9443,7 +9442,7 @@ void triangular_matrix_left_product(
   OutMat C);
 ```
 
-[2]{.pnum} *Effects:* Computes $C$ such that $C = A B$.
+[2]{.pnum} *Effects:* Computes $C = A B$.
 
 [3]{.pnum} In-place overwriting triangular matrix-matrix left product
 
@@ -9477,7 +9476,7 @@ If neither `A.static_extent(1)` nor `C.static_extent(0)`
 equals `dynamic_extent`,
 then `A.static_extent(1)` equals `C.static_extent(0)`.
 
-[6]{.pnum} *Effects:* Overwrites $C$ with $C'$ such that $C' = A C$.
+[6]{.pnum} *Effects:* Computes $C = A C$.
 
 ##### Overwriting triangular matrix-matrix right product [linalg.algs.blas3.trmm.ov.right]
 
@@ -9510,7 +9509,7 @@ void triangular_matrix_right_product(
   OutMat C);
 ```
 
-[2]{.pnum} *Effects:* Computes $C$ such that $C = B A$.
+[2]{.pnum} *Effects:* Computes $C = B A$.
 
 [3]{.pnum} In-place overwriting triangular matrix-matrix right product
 
@@ -9544,7 +9543,7 @@ If neither `C.static_extent(1)` nor `A.static_extent(0)`
 equals `dynamic_extent`, then `C.static_extent(1)` equals
 `A.static_extent(0)`.
 
-[6]{.pnum} *Effects:* Overwrites $C$ with $C'$ such that $C' = C A$.
+[6]{.pnum} *Effects:* Computes $C = C A$.
 
 ##### Updating triangular matrix-matrix left product [linalg.algs.blas3.trmm.up.left]
 
@@ -9579,7 +9578,7 @@ void triangular_matrix_left_product(
   OutMat C);
 ```
 
-[1]{.pnum} *Effects:* Computes $C$ such that $C = E + A B$.
+[1]{.pnum} *Effects:* Computes $C = E + A B$.
 
 ##### Updating triangular matrix-matrix right product [linalg.algs.blas3.trmm.up.right]
 
@@ -9614,7 +9613,7 @@ void triangular_matrix_right_product(
   OutMat C);
 ```
 
-[1]{.pnum} *Effects:* Computes $C$ such that $C = E + B A$.
+[1]{.pnum} *Effects:* Computes $C = E + B A$.
 
 #### Rank-k update of a symmetric or Hermitian matrix [linalg.alg.blas3.rank-k]
 
@@ -9681,10 +9680,7 @@ If `C` has `layout_blas_packed` layout, then the layout's
       nor `C.static_extent(1)` equals `dynamic_extent`,
       then `C.static_extent(0)` equals `C.static_extent(1)`.
 
-[4]{.pnum} *Effects:* Overwrites $C$ with $C'$ such that
-$C' = C + \alpha A A^T$,
-where the scalar $\alpha$ is `alpha`
-and $A^T$ denotes the transpose of the matrix $A$.
+[4]{.pnum} *Effects:* Computes $C = C + \alpha A A^T$.
 
 [5]{.pnum} *Remarks:* The functions will only access
 the triangle of `C` specified by the `Triangle` argument `t`,
@@ -9747,10 +9743,7 @@ If `C` has `layout_blas_packed` layout, then the layout's
       nor `C.static_extent(1)` equals `dynamic_extent`,
       then `C.static_extent(0)` equals `C.static_extent(1)`.
 
-[4]{.pnum} *Effects:* Overwrites $C$ with $C'$ such that
-$C' = C + \alpha A A^H$,
-where the scalar $\alpha$ is `alpha`
-and $A^H$ denotes the conjugate transpose of the matrix $A$.
+[4]{.pnum} *Effects:* Computes $C = C + \alpha A A^H$.
 
 [5]{.pnum} *Remarks:* The functions will only access
 the triangle of `C` specified by the `Triangle` argument `t`,
@@ -9828,10 +9821,7 @@ the function's `Triangle` template argument.
       nor `C.static_extent(0)` equals `dynamic_extent`,
       then `A.static_extent(0)` equals `C.static_extent(0)`.
 
-[4]{.pnum} *Effects:* Overwrites $C$ with $C'$ such that
-$C' = C + A B^T + B A^T$,
-where $A^T$ denotes the transpose of the matrix $A$
-and $B^T$ denotes the transpose of the matrix $B$.
+[4]{.pnum} *Effects:* Computes $C = C + A B^T + B A^T$.
 
 [5]{.pnum} *Remarks:* The functions will only access
 the triangle of `C` specified by the `Triangle` argument `t`,
@@ -9895,10 +9885,7 @@ If `C` has `layout_blas_packed` layout, then the layout's
       nor `C.static_extent(0)` equals `dynamic_extent`,
       then `A.static_extent(0)` equals `C.static_extent(0)`.
 
-[4]{.pnum} *Effects:* Overwrites $C$ with $C'$ such that
-$C' = C + A B^H + B A^H$,
-where $A^H$ denotes the conjugate transpose of the matrix $A$
-and $B^H$ denotes the conjugate transpose of the matrix $B$.
+[4]{.pnum} *Effects:* Computes $C = C + A B^H + B A^H$.
 
 [5]{.pnum} *Remarks:* The functions will only access
 the triangle of `C` specified by the `Triangle` argument `t`,
@@ -10028,9 +10015,9 @@ nor `B.static_extent(0)`
 equals `dynamic_extent`, then
 `A.static_extent(1)` equals `B.static_extent(0)`.
 
-[5]{.pnum} *Effects:* Computes $X$ such that $AX = B$.
-If so such $X$ exists,
-then the elements of $X$ are valid but unspecified.
+[5]{.pnum} *Effects:* Computes $X'$ such that $AX' = B$, and assigns each
+element of $X'$ to the corresponding element of `X`.  If no such $X'$ exists,
+then the elements of `X` are valid but unspecified.
 
 <i>[Note:</i> Since the triangular matrix is on the left,
 the desired `divide` implementation
@@ -10105,9 +10092,9 @@ nor `B.static_extent(0)`
 equals `dynamic_extent`, then
 `A.static_extent(1)` equals `B.static_extent(0)`.
 
-[9]{.pnum} *Effects:* Overwrites $B$ with $X$ such that $AX = B$.
-If no such $X$ exists,
-then the elements of $X$ are valid but unspecified.
+[9]{.pnum} *Effects:* Computes $X$ such that $AX = B$, and assigns each
+element of $X$ to the corresponding element of `B`.  If no such $X$ exists,
+then the elements of `B` are valid but unspecified.
 
 <i>[Note:</i> Since the triangular matrix is on the left,
 the desired `divide` implementation
@@ -10201,9 +10188,9 @@ nor `B.static_extent(1)`
 equals `dynamic_extent`, then
 `A.static_extent(1)` equals `B.static_extent(1)`.
 
-[5]{.pnum} *Effects:* Computes $X$ such that $XA = B$.
-If so such $X$ exists,
-then the elements of $X$ are valid but unspecified.
+[5]{.pnum} *Effects:* Computes $X'$ such that $X'A = B$, and assigns each
+element of $X'$ to the corresponding element of `X`.  If no such $X'$ exists,
+then the elements of `X` are valid but unspecified.
 
 <i>[Note:</i> Since the triangular matrix is on the right,
 the desired `divide` implementation
@@ -10280,9 +10267,9 @@ nor `B.static_extent(1)`
 equals `dynamic_extent`, then
 `A.static_extent(1)` equals `B.static_extent(1)`.
 
-[9]{.pnum} *Effects:* Overwrites $B$ with $X$ such that $XA = B$.
-If no such $X$ exists,
-then the elements of $X$ are valid but unspecified.
+[9]{.pnum} *Effects:* Computes $X$ such that $XA = B$, assigning each element
+of $X$ to the corresponding element of `B`.  If no such $X$ exists, then the
+elements of `B` are valid but unspecified.
 
 <i>[Note:</i> Since the triangular matrix is on the right,
 the desired `divide` implementation

--- a/D1673/P1673.md
+++ b/D1673/P1673.md
@@ -7051,8 +7051,7 @@ if neither `x.static_extent(r)` nor `y.static_extent(r)` equals
 `dynamic_extent`, then `x.static_extent(r)` equals
 `y.static_extent(r)`.
 
-[4]{.pnum} *Effects:* Overwrites the elements of $y$
-with the corresponding elements of $x$.
+[4]{.pnum} *Effects:* Assigns each element of $x$ to the corresponding element of $y$.
 
 #### Add vectors or matrices elementwise [linalg.algs.blas1.add]
 
@@ -7137,9 +7136,10 @@ T dot(ExecutionPolicy&& exec,
 `v2.static_extent(0)` equals `dynamic_extent`, then
 `v1.static_extent(0)` equals `v2.static_extent(0)`.
 
-[4]{.pnum} *Effects:* Let `N` be `v1.extent(0)`.
-If `N` is zero, returns `init`, else returns
-*GENERALIZED_SUM*(`plus<>()`, `init`, `v1[0]*v2[0]`, ..., `v1[N-1]*v2[N-1]`).
+[4]{.pnum} *Returns:*
+
+  * [4.1]{.pnum} `init` if `v1.extent(0) == 0`.
+  * [4.2]{.pnum} Otherwise, *GENERALIZED_SUM*(`plus<>()`, `init`, `v1[0]*v2[0]`, ..., `v1[N-1]*v2[N-1]`).
 
 [5]{.pnum} *Remarks:* If `InVec1::value_type`, `InVec2::value_type`, and `T` are all
 floating-point types or complex versions thereof, and if `T` has
@@ -7380,17 +7380,17 @@ one-norm for many linear algebra algorithms in practice. <i>-- end note]</i>
 and `decltype(init + abs(declval<typename InVec::value_type>()))`
 are both convertible to `T`.
 
-[2]{.pnum} *Effects:* Let `N` be `v.extent(0)`:
+[2]{.pnum} *Returns:*
 
-  * [2.1]{.pnum} If `N` is zero, returns `init`;
+  * [2.1]{.pnum} `init` if `v.extent(0) == 0`.
 
-  * [2.2]{.pnum} else, if `typename InVec::value_type`
-      is `complex<R>` for some `R`, then returns
-      *GENERALIZED_SUM*(`plus<>()`, `init`,
+  * [2.2]{.pnum} Otherwise, *GENERALIZED_SUM*(`plus<>()`, `init`,
       `abs(real(v[0])) + abs(imag(v[0]))`, ...,
-      `abs(real(v[N-1])) + abs(imag(v[N-1]))`).
+      `abs(real(v[N-1])) + abs(imag(v[N-1]))`)
+      if `typename InVec::value_type`
+      is a specialization of `complex<R>`.
 
-  * [2.3]{.pnum} else, returns
+  * [2.3]{.pnum} Otherwise,
       *GENERALIZED_SUM*(`plus<>()`, `init`,
       `abs(v[0])`, ..., `abs(v[N-1])`).
 
@@ -7439,10 +7439,10 @@ typename InVec::size_type idx_abs_max(
 let `abs_value_type` be `decltype(v[i])`;
 then, `abs_value_type` shall be *Cpp17LessThanComparable*.
 
-[2]{.pnum} *Effects:* Returns the index (in the domain of `v`)
+[2]{.pnum} *Returns:* The index (in the domain of `v`)
 of the first element of `v` having largest absolute value.
-If `v` has zero elements, then returns
-`numeric_limits<typename InVec::size_type>::max()`.
+Returns `numeric_limits<typename InVec::size_type>::max()` if
+`v` has zero elements.
 
 <i>[Note:</i> The `abs` function is invoked
 via unqualified lookup. <i>-- end note]</i>
@@ -7470,7 +7470,7 @@ T matrix_frob_norm(
 `init + abs(declval<InMat::value_type>())*abs(declval<InMat::value_type>())`
 shall be convertible to `T`.
 
-[2]{.pnum} *Effects:* Returns the square root of the sum of squares
+[2]{.pnum} *Returns:* The square root of the sum of squares
 of `init` and the absolute values of the elements of `A`.
 <i>[Note:</i> For `init` equal to zero,
 this is the Frobenius norm of the matrix `A`.
@@ -7535,11 +7535,11 @@ T matrix_one_norm(
 [1]{.pnum} *Constraints:* `abs(declval<typename InMat::value_type>())`
 is convertible to `T`.
 
-[2]{.pnum} *Effects:*
+[2]{.pnum} *Returns:*
 
-  * [2.1]{.pnum} If `A.extent(1)` is zero, returns `init`;
+  * [2.1]{.pnum} `init` if `A.extent(1)` is zero.
 
-  * [2.2]{.pnum} else, returns the sum of `init`
+  * [2.2]{.pnum} Otherwise, the sum of `init`
       and the one norm of the matrix $A$.
 
 <i>[Note:</i> The one norm of the matrix `A`
@@ -7598,11 +7598,11 @@ T matrix_inf_norm(
 
 [1]{.pnum} *Preconditions:* `abs(A[0,0])` shall be convertible to `T`.
 
-[2]{.pnum} *Effects:*
+[2]{.pnum} *Returns:*
 
-  * [2.1]{.pnum} If `A.extent(0)` is zero, returns `init`;
+  * [2.1]{.pnum} `init` if `A.extent(0)` is zero.
 
-  * [2.2]{.pnum} else, returns the sum of `init`
+  * [2.2]{.pnum} Otherwise, the sum of `init`
       and the infinity norm of the matrix `A`.
       The infinity norm of the matrix `A`
       is the maximum over all rows of `A`,

--- a/D1673/P1673.md
+++ b/D1673/P1673.md
@@ -8516,11 +8516,8 @@ the function's `Triangle` template argument.
       nor `x.static_extent(0)` equals `dynamic_extent`,
       then `A.static_extent(0)` equals `x.static_extent(0)`.
 
-[4]{.pnum} *Effects:*
-
-  * [4.1]{.pnum} Overloads without an `alpha` parameter compute $A = A + x x^T$.
-
-  * [4.2]{.pnum} Overloads with an `alpha` parameter compute $A = A + \alpha x x^T$.
+[4]{.pnum} *Effects:* Let $\alpha$ be $1$ for overloads without an `alpha`
+parameter, and `alpha` otherwise.  Computes $A = A + \alpha x x^T$.
 
 [5]{.pnum} *Complexity:* The count of `mdspan` array accesses
 and arithmetic operations is linear in
@@ -8601,13 +8598,8 @@ the function's `Triangle` template argument.
       nor `x.static_extent(0)` equals `dynamic_extent`,
       then `A.static_extent(0)` equals `x.static_extent(0)`.
 
-[4]{.pnum} *Effects:*
-
-  * [4.1]{.pnum} Overloads without an `alpha` parameter
-      compute $A = A + x x^H$.
-
-  * [4.2]{.pnum} Overloads with an `alpha` parameter
-      compute $A = A + \alpha x x^H$.
+[4]{.pnum} *Effects:* Let $\alpha$ be $1$ for overloads without an `alpha`
+parameter, and `alpha` otherwise.  Computes $A = A + \alpha x x^H$.
 
 [5]{.pnum} *Complexity:* The count of `mdspan` array accesses
 and arithmetic operations is linear in

--- a/D1673/P1673.md
+++ b/D1673/P1673.md
@@ -6514,8 +6514,7 @@ template<class OtherExtents>
 
   * [22.2]{.pnum} `OtherExtents::rank()` equals `rank()`.
 
-[23]{.pnum} *Effects:* Equivalent to
-_`nested-mapping`_ ` == m.` _`nested-mapping`_ `;`.
+[23]{.pnum} *Returns:* _`nested-mapping`_ ` == m.` _`nested-mapping`_
 
 ### `transposed` [linalg.transp.transposed]
 

--- a/D1673/P1673.md
+++ b/D1673/P1673.md
@@ -5835,7 +5835,7 @@ by value-initializing `value_type`). <i>-- end note]</i>
 constexpr friend auto conj(const derived_type& x);
 ```
 
-[6]{.pnum} *Effects:* Equivalent to `return` _`conj-if-needed`_`(x);`.
+[6]{.pnum} *Returns:*  _`conj-if-needed`_`(x)`
 
 ### Exposition-only class template _`scaled-scalar`_
 
@@ -5905,8 +5905,7 @@ explicit scaled_scalar(const ScalingFactor& scaling_factor, const Reference& ref
 value_type to_value(Reference reference) const;
 ```
 
-[6]{.pnum} *Effects:* Equivalent to
-`return` _`scaling-factor`_ ` * ReferenceValue(reference);`.
+[6]{.pnum} *Returns:* _`scaling-factor`_ ` * ReferenceValue(reference)`
 
 ### Class template `accessor_scaled` [linalg.scaled.accessor_scaled]
 
@@ -5966,27 +5965,26 @@ constexpr accessor_scaled(const ScalingFactor& s, const Accessor& a);
 constexpr reference access(data_handle_type p, size_t i) const noexcept;
 ```
 
-[4]{.pnum} *Effects:* Equivalent to
-`return reference(`_`scaling-factor`_`,` _`nested-accessor`_`.access(p, i));`.
+[4]{.pnum} *Returns:* `reference(`_`scaling-factor`_`,` _`nested-accessor`_`.access(p, i))`
 
 ```c++
 constexpr offset_policy::data_handle_type
 offset(data_handle_type p, size_t i) const noexcept;
 ```
 
-[5]{.pnum} *Effects:* Equivalent to `return` _`nested-accessor`_`.offset(p, i);`.
+[5]{.pnum} *Returns:* _`nested-accessor`_`.offset(p, i)`
 
 ```c++
 constexpr ScalingFactor scaling_factor() const;
 ```
 
-[6]{.pnum} *Effects:* Equivalent to `return` _`scaling-factor`_`;`.
+[6]{.pnum} *Returns:* _`scaling-factor`_
 
 ```c++
 constexpr Accessor nested_accessor() const;
 ```
 
-[7]{.pnum} *Effects:* Equivalent to `return` _`nested-accessor`_`;`.
+[7]{.pnum} *Returns:* _`nested-accessor`_
 
 ### `scaled` [linalg.scaled.scaled]
 
@@ -6009,8 +6007,7 @@ constexpr auto scaled(
   ScalingFactor scaling_factor,
   const mdspan<ElementType, Extents, Layout, Accessor>& x);
 ```
-[2]{.pnum} *Effects:* Equivalent to
-`return mdspan{x.data(), x.mapping(), accessor_scaled{alpha, x.accessor()}};`.
+[2]{.pnum} *Returns:* `mdspan{x.data(), x.mapping(), accessor_scaled{alpha, x.accessor()}}`
 
 <i>[Note:</i> The elements of the returned `mdspan` are read only.
 
@@ -6106,8 +6103,7 @@ constexpr static auto to_value(Reference value_type);
 
 [5]{.pnum} *Preconditions:* This function may be invoked arbitrarily many times.
 
-[6]{.pnum} *Effects:* Equivalent to
-`return `_`conj-if-needed`_`(ReferenceValue(reference));`.
+[6]{.pnum} *Returns:* _`conj-if-needed`_`(ReferenceValue(reference))`
 
 ### Class template `accessor_conjugate` [linalg.conj.accessor_conjugate]
 
@@ -6196,8 +6192,7 @@ constexpr reference access(data_handle_type p, size_t i) const
   noexcept(noexcept(reference(@_nested-accessor_@.access(p, i))));
 ```
 
-[8]{.pnum} *Effects:* Equivalent to
-`return reference(`_`nested-accessor`_`.access(p, i));`.
+[8]{.pnum} *Returns:* `reference(`_`nested-accessor`_`.access(p, i))`
 
 ```c++
 constexpr typename offset_policy::data_handle_type
@@ -6205,14 +6200,13 @@ constexpr typename offset_policy::data_handle_type
     noexcept(noexcept(@_nested-accessor_@.offset(p, i)));
 ```
 
-[9]{.pnum} *Effects:* Equivalent to
-`return` _`nested-accessor`_`.offset(p, i);`.
+[9]{.pnum} *Returns:* _`nested-accessor`_`.offset(p, i)`
 
 ```c++
 constexpr Accessor nested_accessor() const;
 ```
 
-[10]{.pnum} *Effects:* Equivalent to `return` _`nested-accessor`_`;`.
+[10]{.pnum} *Returns:* _`nested-accessor`_
 
 ### `conjugated` [linalg.conj.conjugated]
 
@@ -6256,18 +6250,13 @@ where
 
     * [1.2.3]{.pnum} else `accessor_conjugate<Accessor>`.
 
-[2]{.pnum} *Effects:*
+[2]{.pnum} *Returns:*
 
-  * [2.1]{.pnum} If `Accessor` is `accessor_conjugate<NestedAccessor>`,
-      then equivalent to
-      `return R(a.data(), a.mapping(), a.nested_accessor());`;
+  * [2.1]{.pnum} `R(a.data(), a.mapping(), a.nested_accessor())` if `Accessor` is `accessor_conjugate<NestedAccessor>`.
 
-  * [2.2]{.pnum} else if `remove_cv_t<ElementType>` is an arithmetic type,
-      then equivalent to
-      `return R(a.data(), a.mapping(), a.accessor());`;
+  * [2.2]{.pnum} Otherwise, `R(a.data(), a.mapping(), a.accessor())` if `remove_cv_t<ElementType>` is an arithmetic type.
 
-  * [2.3]{.pnum} else, equivalent to
-      `return R(a.data(), a.mapping(), ReturnAccessor(a.accessor()));`;
+  * [2.3]{.pnum} Otherwise, `R(a.data(), a.mapping(), ReturnAccessor(a.accessor()))`.
 
 <i>[Note:</i> The elements of the returned `mdspan`
 are read only. <i>-- end note]</i>;
@@ -6434,16 +6423,14 @@ constexpr extents_type extents() const
   noexcept(noexcept(@_nested-mapping_@.extents()));
 ```
 
-[10]{.pnum} *Effects:* Equivalent to
-`return` _`transpose-extents`_ `(` _`nested_mapping`_ `.extents());`.
+[10]{.pnum} *Returns:* _`transpose-extents`_ `(` _`nested_mapping`_ `.extents())`
 
 ```c++
 constexpr size_type required_span_size() const
   noexcept(noexcept(@_nested-mapping_@.required_span_size()));
 ```
 
-[11]{.pnum} *Effects:* Equivalent to
-`return ` _`nested-mapping`_ `.required_span_size();`.
+[11]{.pnum} *Returns:* _`nested-mapping`_ `.required_span_size()`
 
 ```c++
 template<class... Indices>
@@ -6451,8 +6438,7 @@ template<class... Indices>
     noexcept(noexcept(@_nested-mapping_@(indices...)));
 ```
 
-[12]{.pnum} *Effects:* Equivalent to
-`return ` _`nested-mapping`_ `(last_2_indices_reversed);`,
+[12]{.pnum} *Returns:* _`nested-mapping`_ `(last_2_indices_reversed)`
 where `last_2_indices_reversed` is the result of
 reversing the last two elements of `indices`.
 
@@ -6460,53 +6446,46 @@ reversing the last two elements of `indices`.
 constexpr @_nested-mapping-type_@ nested_mapping() const;
 ```
 
-[13]{.pnum} *Effects:* Equivalent to
-`return ` _`nested-mapping`_ `;`.
+[13]{.pnum} *Returns:* _`nested-mapping`_
 
 ```c++
 static constexpr bool is_always_unique();
 ```
 
-[14]{.pnum} *Effects:* Equivalent to
-`return ` _`nested-mapping-type`_ `::is_always_unique();`.
+[14]{.pnum} *Returns:* _`nested-mapping-type`_ `::is_always_unique()`
 
 ```c++
 static constexpr bool is_always_contiguous();
 ```
 
-[15]{.pnum} *Effects:* Equivalent to
-`return ` _`nested-mapping-type`_ `::is_always_contiguous();`.
+[15]{.pnum} *Returns:* _`nested-mapping-type`_ `::is_always_contiguous()`
 
 ```c++
 static constexpr bool is_always_strided();
 ```
 
-[16]{.pnum} *Effects:* Equivalent to
-`return ` _`nested-mapping-type`_ `::is_always_strided();`.
+[16]{.pnum} *Returns:* _`nested-mapping-type`_ `::is_always_strided()`
 
 ```c++
 constexpr bool is_unique() const
   noexcept(noexcept(@_nested-mapping_@.is_unique()));
 ```
 
-[17]{.pnum} *Effects:* Equivalent to
-`return ` _`nested-mapping`_ `.is_unique();`.
+[17]{.pnum} *Returns:* _`nested-mapping`_ `.is_unique()`
 
 ```c++
 constexpr bool is_contiguous() const
   noexcept(noexcept(@_nested-mapping_@.is_contiguous()));
 ```
 
-[18]{.pnum} *Effects:* Equivalent to
-`return ` _`nested-mapping`_ `.is_contiguous();`.
+[18]{.pnum} *Returns:* _`nested-mapping`_ `.is_contiguous()`
 
 ```c++
 constexpr bool is_strided() const
   noexcept(noexcept(@_nested-mapping_@.is_strided()));
 ```
 
-[19]{.pnum} *Effects:* Equivalent to
-`return ` _`nested-mapping`_ `.is_strided();`.
+[19]{.pnum} *Returns:* _`nested-mapping`_ `.is_strided()`
 
 ```c++
 constexpr size_type stride(size_t r) const
@@ -6515,14 +6494,13 @@ constexpr size_type stride(size_t r) const
 
 [20]{.pnum} *Constraints:* `is_always_strided()` is `true`.
 
-[21]{.pnum} *Effects:* Equivalent to
-`return ` _`nested-mapping`_ `.stride(s);`, where
+[21]{.pnum} *Returns:*
 
-  * [21.1]{.pnum} `s` is `rank()` - 2 if `r` equals `rank()` - 1,
+  * [21.1]{.pnum} _`nested-mapping`_ `.stride(rank() - 2)` if `r` equals `rank()` - 1.
 
-  * [21.2]{.pnum} `s` is `rank()` - 1 if `r` equals `rank()` - 2, and
+  * [21.2]{.pnum} Otherwise, _`nested-mapping`_ `.stride(rank() - 1)` if `r` equals `rank()` - 2.
 
-  * [21.3]{.pnum} `s` is `r` for 0 ≤ `r` < `in.rank()-2`.
+  * [21.3]{.pnum} Otherwise, _`nested-mapping`_ `.stride(r)_`.
 
 ```c++
 template<class OtherExtents>
@@ -6614,65 +6592,27 @@ where
 
     * else, `Accessor`.
 
-[3]{.pnum} *Effects:*
+[3]{.pnum} *Returns:*
 
-  * [3.1]{.pnum} If `Layout` is `layout_left`, `layout_right`, or
-      `layout_blas_packed<Triangle, StorageOrder>`
-      for some `Triangle` and `StorageOrder`,
-      then equivalent to
-```c++
-return R(a.data(),
-  ReturnMapping(@_transpose-extents_@(a.mapping().extents())),
-  a.accessor());
-```
+  * [3.1]{.pnum} `R(a.data(), ReturnMapping(@_transpose-extents_@(a.mapping().extents())),
+      a.accessor())` if `Layout` is `layout_left`, `layout_right`, or a specialization of
+      `layout_blas_packed`.
 
-  * [3.2]{.pnum} else, if `Layout` is
-      `layout_left_padded<padding_stride>`
-      for some `padding_stride`, then equivalent to
-```c++
-return R(a.data(),
-  ReturnMapping(
-    @_transpose-extents_@(a.mapping().extents()),
-    a.mapping().stride(1)),
-  a.accessor());
-```
+  * [3.2]{.pnum} Otherwise, `R(a.data(), ReturnMapping(
+       @_transpose-extents_@(a.mapping().extents()), a.mapping().stride(1)), a.accessor())`
+       if `Layout` is a specialization of `layout_left_padded`.
 
-  * [3.3]{.pnum} else,
-      if `Layout` is `layout_right_padded<padding_stride>`
-      for some `padding_stride`, then equivalent to
-```c++
-return R(a.data(),
-  ReturnMapping(
-    @_transpose-extents_@(a.mapping().extents()),
-    a.mapping().stride(0)),
-  a.accessor());
-```
+  * [3.3]{.pnum} Otherwise, `R(a.data(), ReturnMapping(@_transpose-extents_@(a.mapping().extents()), a.mapping().stride(0)), a.accessor())`
+      if `Layout` is a specialization of `layout_right_padded`.
 
-  * [3.4]{.pnum} else, if `Layout` is `layout_stride`,
-      then equivalent to
-      <i>[Note:</i> this reverses the strides as well as
-      the extents <i>-- end note]</i>
-```c++
-return R(a.data(),
-  ReturnMapping(
-    @_transpose-extents_@(a.mapping().extents()),
-    array<decltype(), a.mapping().rank()>{
-      a.mapping().stride(1),
-      a.mapping().stride(0)}),
-    a.accessor());
-```
+  * [3.4]{.pnum} Otherwise, `R(a.data(), ReturnMapping(@_transpose-extents_@(a.mapping().extents()), array<decltype(), a.mapping().rank()>{a.mapping().stride(1), a.mapping().stride(0)}), a.accessor())` if `Layout` is `layout_stride`. (TZL) TODO: You have a nullary "decltype()"!
 
-  * [3.5]{.pnum} else, if `Layout` is `layout_transpose<NestedLayout>`
-      for some `NestedLayout`, then equivalent to
-      <i>[Note:</i> getting the nested mapping
-      untransposes the extents <i>-- end note]</i>
-```c++        
-return R(a.data(), a.mapping().nested_mapping(), a.accessor());
-```
+  * [3.5]{.pnum} Otherwise, `R(a.data(), a.mapping().nested_mapping(), a.accessor())`
+      if `Layout` is a specialization of `layout_transpose`.
 
-  * [3.6]{.pnum} else, equivalent to
-      `return R(a.data(), ReturnMapping(a.mapping()), a.accessor());`,
-      where `ReturnMapping` names the type
+  * [3.6]{.pnum} Otherwise,
+      `R(a.data(), ReturnMapping(a.mapping()), a.accessor())`,
+      where `ReturnMapping` is
       `typename layout_transpose<Layout>::template mapping<ReturnExtents>`.
 
 [4]{.pnum} *Remarks:* The elements of the returned `mdspan` are read only.
@@ -6726,8 +6666,7 @@ constexpr auto conjugate_transposed(
   mdspan<ElementType, Extents, Layout, Accessor> a);
 ```
 
-[2]{.pnum} *Effects:* Equivalent to
-`return conjugated(transposed(a));`.
+[2]{.pnum} *Returns:* `conjugated(transposed(a))`
 
 [*Example:*
 ```c++

--- a/D1673/P1673.md
+++ b/D1673/P1673.md
@@ -5131,6 +5131,9 @@ outside the triangle specified by `t`, `F` will interpret the value `M[i, j]`
 as equal to _`conj-if-needed`_`(M[j, i])` if the name of `F` starts with
 `hermitian`, and `M[j, i]` otherwise.
 
+[3]{.pnum} Within all the functions in **[linalg]**, any calls to `abs`,
+`conj`, `imag`, and `real` are unqualified.
+
 ## Requirements [linalg.reqs]
 
 ### Value and reference requirements [linalg.reqs.val]


### PR DESCRIPTION
…ibrary

implementation mut write exactly `X` as the implementation of this function."

Also, "Effects: Equivalent to: `return X;`" is better writen as "Returns: X".

Finally, when listing multiple cases of what a function returns, it should look like this: https://eel.is/c++draft/containers#mdspan.layout.stride.obs .

IMPORTANT NOTE: This same pattern should be repeated for listing out the multiple cases of what a type might be.  For example, in 16.6.3, the part that says "Let `R` name the type ...", you wnat to do it like the return-cases example.  Something like:

Let `R` be `mdspan<ReturnElementType, Extents, Layout, ReturnAccessor>`, where:

  - `T` if some-condition.
  - Otherwise, `U` if some-other-condition.
  - ...
  - Otherwise, `Z`.

Also, as you can see there, you don't need to be so verbose as "names the type"; you can just say "is".