### PR TITLE
Added alternate constructor design to mdarray

### DIFF
--- a/P1684-mdarray/D1684R5a.html
+++ b/P1684-mdarray/D1684R5a.html
@@ -1,0 +1,3104 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang xml:lang>
+<head>
+  <meta charset="utf-8" />
+  <meta name="generator" content="mpark/wg21" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+  <meta name="dcterms.date" content="2023-05-04" />
+  <title>`mdarray`: An Owning Multidimensional Array Analog of
+`mdspan`</title>
+  <style>
+      code{white-space: pre-wrap;}
+      span.smallcaps{font-variant: small-caps;}
+      span.underline{text-decoration: underline;}
+      div.column{display: inline-block; vertical-align: top; width: 50%;}
+      div.csl-block{margin-left: 1.5em;}
+      ul.task-list{list-style: none;}
+      pre > code.sourceCode { white-space: pre; position: relative; }
+      pre > code.sourceCode > span { display: inline-block; line-height: 1.25; }
+      pre > code.sourceCode > span:empty { height: 1.2em; }
+      .sourceCode { overflow: visible; }
+      code.sourceCode > span { color: inherit; text-decoration: inherit; }
+      div.sourceCode { margin: 1em 0; }
+      pre.sourceCode { margin: 0; }
+      @media screen {
+      div.sourceCode { overflow: auto; }
+      }
+      @media print {
+      pre > code.sourceCode { white-space: pre-wrap; }
+      pre > code.sourceCode > span { text-indent: -5em; padding-left: 5em; }
+      }
+      pre.numberSource code
+        { counter-reset: source-line 0; }
+      pre.numberSource code > span
+        { position: relative; left: -4em; counter-increment: source-line; }
+      pre.numberSource code > span > a:first-child::before
+        { content: counter(source-line);
+          position: relative; left: -1em; text-align: right; vertical-align: baseline;
+          border: none; display: inline-block;
+          -webkit-touch-callout: none; -webkit-user-select: none;
+          -khtml-user-select: none; -moz-user-select: none;
+          -ms-user-select: none; user-select: none;
+          padding: 0 4px; width: 4em;
+          color: #aaaaaa;
+        }
+      pre.numberSource { margin-left: 3em; border-left: 1px solid #aaaaaa;  padding-left: 4px; }
+      div.sourceCode
+        {  background-color: #f6f8fa; }
+      @media screen {
+      pre > code.sourceCode > span > a:first-child::before { text-decoration: underline; }
+      }
+      code span { } /* Normal */
+      code span.al { color: #ff0000; } /* Alert */
+      code span.an { } /* Annotation */
+      code span.at { } /* Attribute */
+      code span.bn { color: #9f6807; } /* BaseN */
+      code span.bu { color: #9f6807; } /* BuiltIn */
+      code span.cf { color: #00607c; } /* ControlFlow */
+      code span.ch { color: #9f6807; } /* Char */
+      code span.cn { } /* Constant */
+      code span.co { color: #008000; font-style: italic; } /* Comment */
+      code span.cv { color: #008000; font-style: italic; } /* CommentVar */
+      code span.do { color: #008000; } /* Documentation */
+      code span.dt { color: #00607c; } /* DataType */
+      code span.dv { color: #9f6807; } /* DecVal */
+      code span.er { color: #ff0000; font-weight: bold; } /* Error */
+      code span.ex { } /* Extension */
+      code span.fl { color: #9f6807; } /* Float */
+      code span.fu { } /* Function */
+      code span.im { } /* Import */
+      code span.in { color: #008000; } /* Information */
+      code span.kw { color: #00607c; } /* Keyword */
+      code span.op { color: #af1915; } /* Operator */
+      code span.ot { } /* Other */
+      code span.pp { color: #6f4e37; } /* Preprocessor */
+      code span.re { } /* RegionMarker */
+      code span.sc { color: #9f6807; } /* SpecialChar */
+      code span.ss { color: #9f6807; } /* SpecialString */
+      code span.st { color: #9f6807; } /* String */
+      code span.va { } /* Variable */
+      code span.vs { color: #9f6807; } /* VerbatimString */
+      code span.wa { color: #008000; font-weight: bold; } /* Warning */
+      code.diff {color: #898887}
+      code.diff span.va {color: #006e28}
+      code.diff span.st {color: #bf0303}
+  </style>
+  <style type="text/css">
+body {
+margin: 5em;
+font-family: serif;
+
+hyphens: auto;
+line-height: 1.35;
+text-align: justify;
+}
+@media screen and (max-width: 30em) {
+body {
+margin: 1.5em;
+}
+}
+div.wrapper {
+max-width: 60em;
+margin: auto;
+}
+ul {
+list-style-type: none;
+padding-left: 2em;
+margin-top: -0.2em;
+margin-bottom: -0.2em;
+}
+a {
+text-decoration: none;
+color: #4183C4;
+}
+a.hidden_link {
+text-decoration: none;
+color: inherit;
+}
+li {
+margin-top: 0.6em;
+margin-bottom: 0.6em;
+}
+h1, h2, h3, h4 {
+position: relative;
+line-height: 1;
+}
+a.self-link {
+position: absolute;
+top: 0;
+left: calc(-1 * (3.5rem - 26px));
+width: calc(3.5rem - 26px);
+height: 2em;
+text-align: center;
+border: none;
+transition: opacity .2s;
+opacity: .5;
+font-family: sans-serif;
+font-weight: normal;
+font-size: 83%;
+}
+a.self-link:hover { opacity: 1; }
+a.self-link::before { content: "§"; }
+ul > li:before {
+content: "\2014";
+position: absolute;
+margin-left: -1.5em;
+}
+:target { background-color: #C9FBC9; }
+:target .codeblock { background-color: #C9FBC9; }
+:target ul { background-color: #C9FBC9; }
+.abbr_ref { float: right; }
+.folded_abbr_ref { float: right; }
+:target .folded_abbr_ref { display: none; }
+:target .unfolded_abbr_ref { float: right; display: inherit; }
+.unfolded_abbr_ref { display: none; }
+.secnum { display: inline-block; min-width: 35pt; }
+.header-section-number { display: inline-block; min-width: 35pt; }
+.annexnum { display: block; }
+div.sourceLinkParent {
+float: right;
+}
+a.sourceLink {
+position: absolute;
+opacity: 0;
+margin-left: 10pt;
+}
+a.sourceLink:hover {
+opacity: 1;
+}
+a.itemDeclLink {
+position: absolute;
+font-size: 75%;
+text-align: right;
+width: 5em;
+opacity: 0;
+}
+a.itemDeclLink:hover { opacity: 1; }
+span.marginalizedparent {
+position: relative;
+left: -5em;
+}
+li span.marginalizedparent { left: -7em; }
+li ul > li span.marginalizedparent { left: -9em; }
+li ul > li ul > li span.marginalizedparent { left: -11em; }
+li ul > li ul > li ul > li span.marginalizedparent { left: -13em; }
+div.footnoteNumberParent {
+position: relative;
+left: -4.7em;
+}
+a.marginalized {
+position: absolute;
+font-size: 75%;
+text-align: right;
+width: 5em;
+}
+a.enumerated_item_num {
+position: relative;
+left: -3.5em;
+display: inline-block;
+margin-right: -3em;
+text-align: right;
+width: 3em;
+}
+div.para { margin-bottom: 0.6em; margin-top: 0.6em; text-align: justify; }
+div.section { text-align: justify; }
+div.sentence { display: inline; }
+span.indexparent {
+display: inline;
+position: relative;
+float: right;
+right: -1em;
+}
+a.index {
+position: absolute;
+display: none;
+}
+a.index:before { content: "⟵"; }
+
+a.index:target {
+display: inline;
+}
+.indexitems {
+margin-left: 2em;
+text-indent: -2em;
+}
+div.itemdescr {
+margin-left: 3em;
+}
+.bnf {
+font-family: serif;
+margin-left: 40pt;
+margin-top: 0.5em;
+margin-bottom: 0.5em;
+}
+.ncbnf {
+font-family: serif;
+margin-top: 0.5em;
+margin-bottom: 0.5em;
+margin-left: 40pt;
+}
+.ncsimplebnf {
+font-family: serif;
+font-style: italic;
+margin-top: 0.5em;
+margin-bottom: 0.5em;
+margin-left: 40pt;
+background: inherit; 
+}
+span.textnormal {
+font-style: normal;
+font-family: serif;
+white-space: normal;
+display: inline-block;
+}
+span.rlap {
+display: inline-block;
+width: 0px;
+}
+span.descr { font-style: normal; font-family: serif; }
+span.grammarterm { font-style: italic; }
+span.term { font-style: italic; }
+span.terminal { font-family: monospace; font-style: normal; }
+span.nonterminal { font-style: italic; }
+span.tcode { font-family: monospace; font-style: normal; }
+span.textbf { font-weight: bold; }
+span.textsc { font-variant: small-caps; }
+a.nontermdef { font-style: italic; font-family: serif; }
+span.emph { font-style: italic; }
+span.techterm { font-style: italic; }
+span.mathit { font-style: italic; }
+span.mathsf { font-family: sans-serif; }
+span.mathrm { font-family: serif; font-style: normal; }
+span.textrm { font-family: serif; }
+span.textsl { font-style: italic; }
+span.mathtt { font-family: monospace; font-style: normal; }
+span.mbox { font-family: serif; font-style: normal; }
+span.ungap { display: inline-block; width: 2pt; }
+span.textit { font-style: italic; }
+span.texttt { font-family: monospace; }
+span.tcode_in_codeblock { font-family: monospace; font-style: normal; }
+span.phantom { color: white; }
+
+span.math { font-style: normal; }
+span.mathblock {
+display: block;
+margin-left: auto;
+margin-right: auto;
+margin-top: 1.2em;
+margin-bottom: 1.2em;
+text-align: center;
+}
+span.mathalpha {
+font-style: italic;
+}
+span.synopsis {
+font-weight: bold;
+margin-top: 0.5em;
+display: block;
+}
+span.definition {
+font-weight: bold;
+display: block;
+}
+.codeblock {
+margin-left: 1.2em;
+line-height: 127%;
+}
+.outputblock {
+margin-left: 1.2em;
+line-height: 127%;
+}
+div.itemdecl {
+margin-top: 2ex;
+}
+code.itemdeclcode {
+white-space: pre;
+display: block;
+}
+span.textsuperscript {
+vertical-align: super;
+font-size: smaller;
+line-height: 0;
+}
+.footnotenum { vertical-align: super; font-size: smaller; line-height: 0; }
+.footnote {
+font-size: small;
+margin-left: 2em;
+margin-right: 2em;
+margin-top: 0.6em;
+margin-bottom: 0.6em;
+}
+div.minipage {
+display: inline-block;
+margin-right: 3em;
+}
+div.numberedTable {
+text-align: center;
+margin: 2em;
+}
+div.figure {
+text-align: center;
+margin: 2em;
+}
+table {
+border: 1px solid black;
+border-collapse: collapse;
+margin-left: auto;
+margin-right: auto;
+margin-top: 0.8em;
+text-align: left;
+hyphens: none; 
+}
+td, th {
+padding-left: 1em;
+padding-right: 1em;
+vertical-align: top;
+}
+td.empty {
+padding: 0px;
+padding-left: 1px;
+}
+td.left {
+text-align: left;
+}
+td.right {
+text-align: right;
+}
+td.center {
+text-align: center;
+}
+td.justify {
+text-align: justify;
+}
+td.border {
+border-left: 1px solid black;
+}
+tr.rowsep, td.cline {
+border-top: 1px solid black;
+}
+tr.even, tr.odd {
+border-bottom: 1px solid black;
+}
+tr.capsep {
+border-top: 3px solid black;
+border-top-style: double;
+}
+tr.header {
+border-bottom: 3px solid black;
+border-bottom-style: double;
+}
+th {
+border-bottom: 1px solid black;
+}
+span.centry {
+font-weight: bold;
+}
+div.table {
+display: block;
+margin-left: auto;
+margin-right: auto;
+text-align: center;
+width: 90%;
+}
+span.indented {
+display: block;
+margin-left: 2em;
+margin-bottom: 1em;
+margin-top: 1em;
+}
+ol.enumeratea { list-style-type: none; background: inherit; }
+ol.enumerate { list-style-type: none; background: inherit; }
+
+code.sourceCode > span { display: inline; }
+</style>
+  <link href="data:image/x-icon;base64,AAABAAIAEBAAAAEAIABoBAAAJgAAACAgAAABACAAqBAAAI4EAAAoAAAAEAAAACAAAAABACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA////AIJEAACCRAAAgkQAAIJEAACCRAAAgkQAVoJEAN6CRADegkQAWIJEAACCRAAAgkQAAIJEAACCRAAA////AP///wCCRAAAgkQAAIJEAACCRAAsgkQAvoJEAP+CRAD/gkQA/4JEAP+CRADAgkQALoJEAACCRAAAgkQAAP///wD///8AgkQAAIJEABSCRACSgkQA/IJEAP99PQD/dzMA/3czAP99PQD/gkQA/4JEAPyCRACUgkQAFIJEAAD///8A////AHw+AFiBQwDqgkQA/4BBAP9/PxP/uZd6/9rJtf/bybX/upd7/39AFP+AQQD/gkQA/4FDAOqAQgBc////AP///wDKklv4jlEa/3o7AP+PWC//8+3o///////////////////////z7un/kFox/35AAP+GRwD/mVYA+v///wD///8A0Zpk+NmibP+0d0T/8evj///////+/fv/1sKz/9bCs//9/fr//////+/m2/+NRwL/nloA/5xYAPj///8A////ANKaZPjRmGH/5cKh////////////k149/3UwAP91MQD/lmQ//86rhv+USg3/m1YA/5hSAP+bVgD4////AP///wDSmmT4zpJY/+/bx///////8+TV/8mLT/+TVx//gkIA/5lVAP+VTAD/x6B//7aEVv/JpH7/s39J+P///wD///8A0ppk+M6SWP/u2sf///////Pj1f/Nj1T/2KFs/8mOUv+eWhD/lEsA/8aee/+0glT/x6F7/7J8Rvj///8A////ANKaZPjRmGH/48Cf///////+/v7/2qt//82PVP/OkFX/37KJ/86siv+USg7/mVQA/5hRAP+bVgD4////AP///wDSmmT40ppk/9CVXP/69O////////7+/v/x4M//8d/P//7+/f//////9u7n/6tnJf+XUgD/nFgA+P///wD///8A0ppk+NKaZP/RmWL/1qNy//r07///////////////////////+vXw/9akdP/Wnmn/y5FY/6JfFvj///8A////ANKaZFTSmmTo0ppk/9GYYv/Ql1//5cWm//Hg0P/x4ND/5cWm/9GXYP/RmGH/0ppk/9KaZOjVnmpY////AP///wDSmmQA0ppkEtKaZI7SmmT60ppk/9CWX//OkVb/zpFW/9CWX//SmmT/0ppk/NKaZJDSmmQS0ppkAP///wD///8A0ppkANKaZADSmmQA0ppkKtKaZLrSmmT/0ppk/9KaZP/SmmT/0ppkvNKaZCrSmmQA0ppkANKaZAD///8A////ANKaZADSmmQA0ppkANKaZADSmmQA0ppkUtKaZNzSmmTc0ppkVNKaZADSmmQA0ppkANKaZADSmmQA////AP5/AAD4HwAA4AcAAMADAACAAQAAgAEAAIABAACAAQAAgAEAAIABAACAAQAAgAEAAMADAADgBwAA+B8AAP5/AAAoAAAAIAAAAEAAAAABACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA////AP///wCCRAAAgkQAAIJEAACCRAAAgkQAAIJEAACCRAAAgkQAAIJEAACCRAAAgkQAAIJEAAyCRACMgkQA6oJEAOqCRACQgkQAEIJEAACCRAAAgkQAAIJEAACCRAAAgkQAAIJEAACCRAAAgkQAAIJEAACCRAAA////AP///wD///8A////AIJEAACCRAAAgkQAAIJEAACCRAAAgkQAAIJEAACCRAAAgkQAAIJEAACCRABigkQA5oJEAP+CRAD/gkQA/4JEAP+CRADqgkQAZoJEAACCRAAAgkQAAIJEAACCRAAAgkQAAIJEAACCRAAAgkQAAIJEAAD///8A////AP///wD///8AgkQAAIJEAACCRAAAgkQAAIJEAACCRAAAgkQAAIJEAACCRAA4gkQAwoJEAP+CRAD/gkQA/4JEAP+CRAD/gkQA/4JEAP+CRAD/gkQAxIJEADyCRAAAgkQAAIJEAACCRAAAgkQAAIJEAACCRAAAgkQAAP///wD///8A////AP///wCCRAAAgkQAAIJEAACCRAAAgkQAAIJEAACCRAAWgkQAmIJEAP+CRAD/gkQA/4JEAP+CRAD/gkQA/4JEAP+CRAD/gkQA/4JEAP+CRAD/gkQA/4JEAJyCRAAYgkQAAIJEAACCRAAAgkQAAIJEAACCRAAA////AP///wD///8A////AIJEAACCRAAAgkQAAIJEAACCRAAAgkQAdIJEAPCCRAD/gkQA/4JEAP+CRAD/gkQA/4JEAP+CRAD/gkQA/4JEAP+CRAD/gkQA/4JEAP+CRAD/gkQA/4JEAPSCRAB4gkQAAIJEAACCRAAAgkQAAIJEAAD///8A////AP///wD///8AgkQAAIJEAACCRAAAgkQASoJEANKCRAD/gkQA/4JEAP+CRAD/g0YA/39AAP9zLgD/bSQA/2shAP9rIQD/bSQA/3MuAP9/PwD/g0YA/4JEAP+CRAD/gkQA/4JEAP+CRADUgkQAToJEAACCRAAAgkQAAP///wD///8A////AP///wB+PwAAgkUAIoJEAKiCRAD/gkQA/4JEAP+CRAD/hEcA/4BBAP9sIwD/dTAA/5RfKv+viF7/vp56/76ee/+wiF7/lWAr/3YxAP9sIwD/f0AA/4RHAP+CRAD/gkQA/4JEAP+CRAD/gkQArIJEACaBQwAA////AP///wD///8A////AIBCAEBzNAD6f0EA/4NFAP+CRAD/gkQA/4VIAP92MwD/bSUA/6N1Tv/ezsL/////////////////////////////////38/D/6V3Uv9uJgD/dTEA/4VJAP+CRAD/gkQA/4JEAP+BQwD/fUAA/4FDAEj///8A////AP///wD///8AzJRd5qBlKf91NgD/dDUA/4JEAP+FSQD/cy4A/3YyAP/PuKP//////////////////////////////////////////////////////9K7qP94NQD/ciwA/4VJAP+CRAD/fkEA/35BAP+LSwD/mlYA6v///wD///8A////AP///wDdpnL/4qx3/8KJUv+PUhf/cTMA/3AsAP90LgD/4dK+/////////////////////////////////////////////////////////////////+TYxf91MAD/dTIA/31CAP+GRwD/llQA/6FcAP+gWwD8////AP///wD///8A////ANGZY/LSm2X/4ap3/92mcP+wdT3/byQA/8mwj////////////////////////////////////////////////////////////////////////////+LYxv9zLgP/jUoA/59bAP+hXAD/nFgA/5xYAPL///8A////AP///wD///8A0ppk8tKaZP/RmWL/1p9q/9ubXv/XqXj////////////////////////////7+fD/vZyG/6BxS/+gcUr/vJuE//r37f//////////////////////3MOr/5dQBf+dVQD/nVkA/5xYAP+cWAD/nFgA8v///wD///8A////AP///wDSmmTy0ppk/9KaZP/SmWP/yohJ//jo2P//////////////////////4NTG/4JDFf9lGAD/bSQA/20kAP9kGAD/fz8S/+Xb0f//////5NG9/6txN/+LOgD/m1QA/51aAP+cWAD/m1cA/5xYAP+cWADy////AP///wD///8A////ANKaZPLSmmT/0ppk/8+TWf/Unmv//v37//////////////////////+TWRr/VwsA/35AAP+ERgD/g0UA/4JGAP9lHgD/kFga/8KXX/+TRwD/jT4A/49CAP+VTQD/n10A/5xYAP+OQQD/lk4A/55cAPL///8A////AP///wD///8A0ppk8tKaZP/SmmT/y4tO/92yiP//////////////////////8NnE/8eCQP+rcTT/ez0A/3IyAP98PgD/gEMA/5FSAP+USwD/jj8A/5lUAP+JNwD/yqV2/694Mf+HNQD/jkAA/82rf/+laBj/jT4A8v///wD///8A////AP///wDSmmTy0ppk/9KaZP/LiUr/4byY///////////////////////gupX/0I5P/+Wuev/Lklz/l1sj/308AP+QSwD/ol0A/59aAP+aVQD/k0oA/8yoh///////+fXv/6pwO//Lp3v///////Pr4f+oay7y////AP///wD///8A////ANKaZPLSmmT/0ppk/8uJSv/hvJj//////////////////////+G7l//Jhkb/0ppk/96nc//fqXX/x4xO/6dkFP+QSQD/llEA/5xXAP+USgD/yaOA///////38uv/qG05/8ijdv//////8efb/6ZpLPL///8A////AP///wD///8A0ppk8tKaZP/SmmT/zIxO/9yxh///////////////////////7dbA/8iEQf/Sm2X/0Zlj/9ScZv/eqHf/2KJv/7yAQf+XTgD/iToA/5lSAP+JNgD/yKFv/611LP+HNQD/jT8A/8qmeP+kZRT/jT4A8v///wD///8A////AP///wDSmmTy0ppk/9KaZP/Pk1n/1J5q//78+//////////////////+/fv/1aFv/8iEQv/Tm2b/0ppl/9GZY//Wn2z/1pZc/9eldf/Bl2b/kUcA/4w9AP+OQAD/lUwA/59eAP+cWQD/jT8A/5ZOAP+eXADy////AP///wD///8A////ANKaZPLSmmT/0ppk/9KZY//KiEn/8d/P///////////////////////47+f/05tm/8iCP//KiEj/yohJ/8eCP//RmGH//vfy///////n1sP/rXQ7/4k4AP+TTAD/nVoA/5xYAP+cVwD/nFgA/5xYAPL///8A////AP///wD///8A0ppk8tKaZP/SmmT/0ptl/8uLTf/aq37////////////////////////////+/fz/6c2y/961jv/etY7/6Myx//78+v//////////////////////3MWv/5xXD/+ORAD/mFQA/51ZAP+cWAD/nFgA8v///wD///8A////AP///wDSmmTy0ppk/9KaZP/SmmT/0ppk/8mFRP/s1b//////////////////////////////////////////////////////////////////////////////+PD/0JFU/7NzMv+WUQD/kUsA/5tXAP+dWQDy////AP///wD///8A////ANKaZP/SmmT/0ppk/9KaZP/Sm2X/z5NZ/8yMT//z5NX/////////////////////////////////////////////////////////////////9Ofa/8yNUP/UmGH/36p5/8yTWv+qaSD/kksA/5ROAPz///8A////AP///wD///8A0ppk5NKaZP/SmmT/0ppk/9KaZP/TnGf/zY9T/82OUv/t1sD//////////////////////////////////////////////////////+7Yw//OkFX/zI5R/9OcZ//SmmP/26V0/9ymdf/BhUf/ol8R6P///wD///8A////AP///wDSmmQ80ppk9tKaZP/SmmT/0ppk/9KaZP/TnGj/zpFW/8qJSv/dson/8uHS//////////////////////////////////Lj0//etIv/y4lL/86QVf/TnGj/0ppk/9KaZP/RmWP/05xn/9ymdfjUnWdC////AP///wD///8A////ANKaZADSmmQc0ppkotKaZP/SmmT/0ppk/9KaZP/Tm2b/0Zli/8qJSf/NjlH/16Z3/+G8mP/myKr/5siq/+G8mP/Xp3f/zY5S/8qISf/RmGH/05tm/9KaZP/SmmT/0ppk/9KaZP/SmmSm0pljINWdaQD///8A////AP///wD///8A0ppkANKaZADSmmQA0ppkQtKaZMrSmmT/0ppk/9KaZP/SmmT/0ptl/9GYYf/Nj1P/y4lL/8qISP/KiEj/y4lK/82PU//RmGH/0ptl/9KaZP/SmmT/0ppk/9KaZP/SmmTO0ppkRtKaZADSmmQA0ppkAP///wD///8A////AP///wDSmmQA0ppkANKaZADSmmQA0ppkANKaZGzSmmTu0ppk/9KaZP/SmmT/0ppk/9KaZP/SmmT/0ppk/9KaZP/SmmT/0ppk/9KaZP/SmmT/0ppk/9KaZP/SmmTw0ppkcNKaZADSmmQA0ppkANKaZADSmmQA////AP///wD///8A////ANKaZADSmmQA0ppkANKaZADSmmQA0ppkANKaZBLSmmSQ0ppk/9KaZP/SmmT/0ppk/9KaZP/SmmT/0ppk/9KaZP/SmmT/0ppk/9KaZP/SmmT/0ppklNKaZBTSmmQA0ppkANKaZADSmmQA0ppkANKaZAD///8A////AP///wD///8A0ppkANKaZADSmmQA0ppkANKaZADSmmQA0ppkANKaZADSmmQy0ppkutKaZP/SmmT/0ppk/9KaZP/SmmT/0ppk/9KaZP/SmmT/0ppkvtKaZDbSmmQA0ppkANKaZADSmmQA0ppkANKaZADSmmQA0ppkAP///wD///8A////AP///wDSmmQA0ppkANKaZADSmmQA0ppkANKaZADSmmQA0ppkANKaZADSmmQA0ppkXNKaZODSmmT/0ppk/9KaZP/SmmT/0ppk5NKaZGDSmmQA0ppkANKaZADSmmQA0ppkANKaZADSmmQA0ppkANKaZADSmmQA////AP///wD///8A////ANKaZADSmmQA0ppkANKaZADSmmQA0ppkANKaZADSmmQA0ppkANKaZADSmmQA0ppkBtKaZIbSmmTo0ppk6tKaZIrSmmQK0ppkANKaZADSmmQA0ppkANKaZADSmmQA0ppkANKaZADSmmQA0ppkANKaZAD///8A////AP/8P///+B///+AH//+AAf//AAD//AAAP/AAAA/gAAAHwAAAA8AAAAPAAAADwAAAA8AAAAPAAAADwAAAA8AAAAPAAAADwAAAA8AAAAPAAAADwAAAA8AAAAPAAAADwAAAA+AAAAfwAAAP/AAAP/8AAP//gAH//+AH///4H////D//" rel="icon" />
+  
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
+</head>
+<body>
+<div class="wrapper">
+<header id="title-block-header">
+<h1 class="title" style="text-align:center"><code class="sourceCode default">mdarray</code>:
+An Owning Multidimensional Array Analog of
+<code class="sourceCode default">mdspan</code></h1>
+<table style="border:none;float:right">
+  <tr>
+    <td>Document #:</td>
+    <td>D1684R5a</td>
+  </tr>
+  <tr>
+    <td>Date:</td>
+    <td>2023-05-04</td>
+  </tr>
+  <tr>
+    <td style="vertical-align:top">Project:</td>
+    <td>Programming Language C++</td>
+  </tr>
+  <tr>
+    <td style="vertical-align:top">Audience:</td>
+    <td>
+      Library Evolution<br>
+    </td>
+  </tr>
+  <tr>
+    <td style="vertical-align:top">Reply-to:</td>
+    <td>
+      Christian Trott<br>&lt;<a href="mailto:crtrott@sandia.gov" class="email">crtrott@sandia.gov</a>&gt;<br>
+      Daisy Hollman<br>&lt;<a href="mailto:me@dsh.fyi" class="email">me@dsh.fyi</a>&gt;<br>
+      Mark Hoemmen<br>&lt;<a href="mailto:mark.hoemmen@gmail.com" class="email">mark.hoemmen@gmail.com</a>&gt;<br>
+      Daniel Sunderland<br>&lt;<a href="mailto:dansunderland@gmail.com" class="email">dansunderland@gmail.com</a>&gt;<br>
+      Damien Lebrun-Grandie<br>&lt;<a href="mailto:lebrungrandt@ornl.gov" class="email">lebrungrandt@ornl.gov</a>&gt;<br>
+      Nevin Liber<br>&lt;<a href="mailto:nliber@anl.gov" class="email">nliber@anl.gov</a>&gt;<br>
+    </td>
+  </tr>
+</table>
+</header>
+<div style="clear:both">
+<div id="TOC" role="doc-toc">
+<h1 id="toctitle">Contents</h1>
+<ul>
+<li><a href="#revision-history" id="toc-revision-history"><span class="toc-section-number">1</span> Revision History<span></span></a>
+<ul>
+<li><a href="#p1684r4-pre-varna-mailing-2023-05" id="toc-p1684r4-pre-varna-mailing-2023-05"><span class="toc-section-number">1.1</span> P1684R4: pre-Varna mailing
+(2023-05)<span></span></a></li>
+<li><a href="#p1684r3-2022-07-mailing" id="toc-p1684r3-2022-07-mailing"><span class="toc-section-number">1.2</span> P1684R3: 2022-07
+Mailing<span></span></a></li>
+<li><a href="#p1684r2-2022-04-mailing" id="toc-p1684r2-2022-04-mailing"><span class="toc-section-number">1.3</span> P1684r2: 2022-04
+Mailing<span></span></a></li>
+<li><a href="#p1684r1-2022-03-mailing" id="toc-p1684r1-2022-03-mailing"><span class="toc-section-number">1.4</span> P1684r1: 2022-03
+Mailing<span></span></a></li>
+</ul></li>
+<li><a href="#motivation" id="toc-motivation"><span class="toc-section-number">2</span> Motivation<span></span></a></li>
+<li><a href="#design" id="toc-design"><span class="toc-section-number">3</span> Design<span></span></a>
+<ul>
+<li><a href="#design-overview" id="toc-design-overview"><span class="toc-section-number">3.1</span> Design
+overview<span></span></a></li>
+<li><a href="#differences-between-mdarray-and-mdspan" id="toc-differences-between-mdarray-and-mdspan"><span class="toc-section-number">3.2</span> Differences between
+<code class="sourceCode default">mdarray</code> and
+<code class="sourceCode default">mdspan</code><span></span></a>
+<ul>
+<li><a href="#deep-constness" id="toc-deep-constness"><span class="toc-section-number">3.2.1</span> Deep
+<code class="sourceCode default">const</code>ness<span></span></a></li>
+<li><a href="#interoperability-between-mdarray-and-mdspan" id="toc-interoperability-between-mdarray-and-mdspan"><span class="toc-section-number">3.2.2</span> Interoperability between
+<code class="sourceCode default">mdarray</code> and
+<code class="sourceCode default">mdspan</code><span></span></a></li>
+<li><a href="#container-instead-of-accessorpolicy" id="toc-container-instead-of-accessorpolicy"><span class="toc-section-number">3.2.3</span>
+<code class="sourceCode default">Container</code> instead of
+<code class="sourceCode default">AccessorPolicy</code><span></span></a></li>
+<li><a href="#constructors-and-assignment-operators" id="toc-constructors-and-assignment-operators"><span class="toc-section-number">3.2.4</span> Constructors and assignment
+operators<span></span></a></li>
+<li><a href="#alternative-constructor-design" id="toc-alternative-constructor-design"><span class="toc-section-number">3.2.5</span> Alternative constructor
+design<span></span></a></li>
+</ul></li>
+<li><a href="#extents-design-reused" id="toc-extents-design-reused"><span class="toc-section-number">3.3</span>
+<code class="sourceCode default">Extents</code> design
+reused<span></span></a></li>
+<li><a href="#layoutpolicy-design-reused" id="toc-layoutpolicy-design-reused"><span class="toc-section-number">3.4</span>
+<code class="sourceCode default">LayoutPolicy</code> design
+reused<span></span></a></li>
+<li><a href="#accessorpolicy-replaced-by-container" id="toc-accessorpolicy-replaced-by-container"><span class="toc-section-number">3.5</span>
+<code class="sourceCode default">AccessorPolicy</code> replaced by
+<code class="sourceCode default">Container</code><span></span></a>
+<ul>
+<li><a href="#expected-behavior-of-motivating-use-cases" id="toc-expected-behavior-of-motivating-use-cases"><span class="toc-section-number">3.5.1</span> Expected behavior of motivating
+use cases<span></span></a></li>
+<li><a href="#analogs-in-the-standard-library-container-adapters" id="toc-analogs-in-the-standard-library-container-adapters"><span class="toc-section-number">3.5.2</span> Analogs in the standard library:
+Container adapters<span></span></a></li>
+<li><a href="#not-proposed-alternative-a-dedicated-containerpolicy-concept" id="toc-not-proposed-alternative-a-dedicated-containerpolicy-concept"><span class="toc-section-number">3.5.3</span> (Not proposed) alternative: A
+dedicated <code class="sourceCode default">ContainerPolicy</code>
+concept<span></span></a></li>
+<li><a href="#not-proposed-alternative-containerpolicy-subsumes-accessorpolicy" id="toc-not-proposed-alternative-containerpolicy-subsumes-accessorpolicy"><span class="toc-section-number">3.5.4</span> (Not proposed) alternative:
+<code class="sourceCode default">ContainerPolicy</code> subsumes
+<code class="sourceCode default">AccessorPolicy</code><span></span></a></li>
+<li><a href="#extension-for-accessor-policy-from-container" id="toc-extension-for-accessor-policy-from-container"><span class="toc-section-number">3.5.5</span> Extension for accessor policy
+from container<span></span></a></li>
+<li><a href="#safety-and-other-issues-with-containers" id="toc-safety-and-other-issues-with-containers"><span class="toc-section-number">3.5.6</span> Safety and other issues with
+containers<span></span></a></li>
+</ul></li>
+</ul></li>
+<li><a href="#wording" id="toc-wording"><span class="toc-section-number">4</span> Wording<span></span></a></li>
+<li><a href="#bibliography" id="toc-bibliography"><span class="toc-section-number">5</span> References<span></span></a></li>
+</ul>
+</div>
+<h1 data-number="1" id="revision-history"><span class="header-section-number">1</span> Revision History<a href="#revision-history" class="self-link"></a></h1>
+<h2 data-number="1.1" id="p1684r4-pre-varna-mailing-2023-05"><span class="header-section-number">1.1</span> P1684R4: pre-Varna mailing
+(2023-05)<a href="#p1684r4-pre-varna-mailing-2023-05" class="self-link"></a></h2>
+<h4 data-number="1.1.0.1" id="changes-from-r4"><span class="header-section-number">1.1.0.1</span> Changes from R4<a href="#changes-from-r4" class="self-link"></a></h4>
+<ul>
+<li>Propose alternate constructor design design</li>
+</ul>
+<h2 data-number="1.2" id="p1684r3-2022-07-mailing"><span class="header-section-number">1.2</span> P1684R3: 2022-07 Mailing<a href="#p1684r3-2022-07-mailing" class="self-link"></a></h2>
+<h4 data-number="1.2.0.1" id="changes-from-r3"><span class="header-section-number">1.2.0.1</span> Changes from R3<a href="#changes-from-r3" class="self-link"></a></h4>
+<ul>
+<li>drop the “size constructible container” requirements and simply use
+preconditions on relevant constructors</li>
+</ul>
+<h4 data-number="1.2.0.2" id="changes-from-r2"><span class="header-section-number">1.2.0.2</span> Changes from R2<a href="#changes-from-r2" class="self-link"></a></h4>
+<ul>
+<li>bring in line with P0009 and follow up papers P2554, P2553, P2599
+and P2406</li>
+<li>add new container requirements: <em>size constructible
+containers</em> (bikeshedding needed)</li>
+<li>add deduction guide for
+<code class="sourceCode default">mdspan</code> from
+<code class="sourceCode default">mdarray</code></li>
+<li>remove constructors from
+<code class="sourceCode default">ranges</code>/<code class="sourceCode default">initializer_list</code>
+etc. (can be done via moving container in)
+<ul>
+<li>waiting for feedback from other sgs to see which convenience
+constructors we should have</li>
+</ul></li>
+<li>add deduction guides</li>
+<li>update explanatory wording</li>
+</ul>
+<h2 data-number="1.3" id="p1684r2-2022-04-mailing"><span class="header-section-number">1.3</span> P1684r2: 2022-04 Mailing<a href="#p1684r2-2022-04-mailing" class="self-link"></a></h2>
+<h4 data-number="1.3.0.1" id="changes-from-r1"><span class="header-section-number">1.3.0.1</span> Changes from R1<a href="#changes-from-r1" class="self-link"></a></h4>
+<ul>
+<li>update and reword non-wording text to harmonize with P0009R16</li>
+<li>fix synopsis missing Alloc argument in some places</li>
+<li>fix constraints on some constructors to allow
+<code class="sourceCode default">std::array</code> as container</li>
+<li>add missing wording for constructors from
+<code class="sourceCode default">std::initializer_list</code></li>
+<li>add constructors from ranges</li>
+<li>always use <code class="sourceCode default">std::vector</code> as
+the default container type, based on LEWG guidance</li>
+<li>remove container accessor function
+<ul>
+<li>it’s a bad idea to allow someone to resize the container owned by an
+<code class="sourceCode default">mdarray</code> …</li>
+</ul></li>
+<li>add new <code class="sourceCode default">mdarray</code> constructors
+from <code class="sourceCode default">mdspan</code></li>
+<li>add <code class="sourceCode default">view</code> member function; it
+returns an <code class="sourceCode default">mdspan</code> that views the
+<code class="sourceCode default">mdarray</code>’s elements</li>
+</ul>
+<h2 data-number="1.4" id="p1684r1-2022-03-mailing"><span class="header-section-number">1.4</span> P1684r1: 2022-03 Mailing<a href="#p1684r1-2022-03-mailing" class="self-link"></a></h2>
+<h4 data-number="1.4.0.1" id="changes-from-r0"><span class="header-section-number">1.4.0.1</span> Changes from R0<a href="#changes-from-r0" class="self-link"></a></h4>
+<ul>
+<li>harmonize with P0009R15</li>
+<li>don’t use ContainerPolicy, simply use Container as fourth template
+argument</li>
+<li>added wording</li>
+</ul>
+<h1 data-number="2" id="motivation"><span class="header-section-number">2</span> Motivation<a href="#motivation" class="self-link"></a></h1>
+<p><span class="citation" data-cites="P0009R18">[<a href="#ref-P0009R18" role="doc-biblioref">P0009R18</a>]</span> proposed
+<code class="sourceCode default">mdspan</code>, a nonowning
+multidimensional array abstraction. It was voted into the C++23 draft.
+This proposal builds on <code class="sourceCode default">mdspan</code>
+by introducing <code class="sourceCode default">mdarray</code>, an
+<em>owning</em> multidimensional array that interoperates with
+<code class="sourceCode default">mdspan</code>. The
+<code class="sourceCode default">mdarray</code> class is to
+<code class="sourceCode default">vector</code> as
+<code class="sourceCode default">mdspan</code> is to
+<code class="sourceCode default">span</code>. Owning semantics can make
+it easier for users to express common cases, like returning an array
+from a function. It also makes it much easier to create a multi
+dimensional array for use:</p>
+<p><strong>C++23:</strong></p>
+<div class="sourceCode" id="cb1"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Create a mapping so one knows how many </span></span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="co">// elements the buffer needs to have</span></span>
+<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a>layout_right<span class="op">::</span>mapping<span class="op">&lt;</span>dextents<span class="op">&lt;</span><span class="dv">2</span><span class="op">&gt;&gt;</span> map<span class="op">(</span>N,M<span class="op">)</span>;</span>
+<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb1-5"><a href="#cb1-5" aria-hidden="true" tabindex="-1"></a><span class="co">// Create the underlying data object</span></span>
+<span id="cb1-6"><a href="#cb1-6" aria-hidden="true" tabindex="-1"></a>vector<span class="op">&lt;</span><span class="dt">double</span><span class="op">&gt;</span> buffer<span class="op">(</span>map<span class="op">.</span>required_span_size<span class="op">())</span>;</span>
+<span id="cb1-7"><a href="#cb1-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb1-8"><a href="#cb1-8" aria-hidden="true" tabindex="-1"></a><span class="co">// Create the mdspan</span></span>
+<span id="cb1-9"><a href="#cb1-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb1-10"><a href="#cb1-10" aria-hidden="true" tabindex="-1"></a>mdspan matrix<span class="op">(</span>buffer<span class="op">.</span>data<span class="op">()</span>, N, M<span class="op">)</span>;</span></code></pre></div>
+<p><strong>This Work:</strong></p>
+<div class="sourceCode" id="cb2"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a>mdarray<span class="op">&lt;</span><span class="dt">double</span>, dextents<span class="op">&lt;</span><span class="dv">3</span>,<span class="dv">3</span><span class="op">&gt;&gt;</span> matrix<span class="op">(</span>N,M<span class="op">)</span>;</span></code></pre></div>
+<p>In addition, especially for arrays with small, compile-time extents,
+<code class="sourceCode default">mdarray</code>’s owning semantics make
+fewer demands on interprocedural analysis for optimization. In
+particular, the lack of indirection due to
+<code class="sourceCode default">mdarray</code> owning its data makes it
+easier for compilers to deduce that the data could be stored in
+registers.</p>
+<h1 data-number="3" id="design"><span class="header-section-number">3</span> Design<a href="#design" class="self-link"></a></h1>
+<p>One major goal of the design for
+<code class="sourceCode default">mdarray</code> is to parallel the
+design of <code class="sourceCode default">mdspan</code> as much as
+possible, with the goals of reducing cognitive load for users already
+familiar with <code class="sourceCode default">mdspan</code> and of
+incorporating the lessons learned from over a decade of experience with
+<span class="citation" data-cites="P0009R18">[<a href="#ref-P0009R18" role="doc-biblioref">P0009R18</a>]</span> and libraries of similar
+design. This paper assumes the reader has read and is already familiar
+with <span class="citation" data-cites="P0009R18">[<a href="#ref-P0009R18" role="doc-biblioref">P0009R18</a>]</span>.</p>
+<h2 data-number="3.1" id="design-overview"><span class="header-section-number">3.1</span> Design overview<a href="#design-overview" class="self-link"></a></h2>
+<p>The analogy to <code class="sourceCode default">mdspan</code> can be
+seen in the declaration of the proposed design for
+<code class="sourceCode default">mdarray</code>.</p>
+<div class="sourceCode" id="cb3"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ElementType,</span>
+<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Extents,</span>
+<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> LayoutPolicy <span class="op">=</span> layout_right,</span>
+<span id="cb3-4"><a href="#cb3-4" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Container <span class="op">=</span> <em>see-below</em><span class="op">&gt;</span></span>
+<span id="cb3-5"><a href="#cb3-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">class</span> mdarray;</span></code></pre></div>
+<p>This intentionally parallels the design of
+<code class="sourceCode default">mdspan</code> in <span class="citation" data-cites="P0009R18">[<a href="#ref-P0009R18" role="doc-biblioref">P0009R18</a>]</span>, which has the following
+signature.</p>
+<div class="sourceCode" id="cb4"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ElementType,</span>
+<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Extents,</span>
+<span id="cb4-3"><a href="#cb4-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> LayoutPolicy <span class="op">=</span> layout_right,</span>
+<span id="cb4-4"><a href="#cb4-4" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> AccessorPolicy <span class="op">=</span> default_accessor<span class="op">&lt;</span>ElementType<span class="op">&gt;&gt;</span></span>
+<span id="cb4-5"><a href="#cb4-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">class</span> mdspan;</span></code></pre></div>
+<p>Our original <code class="sourceCode default">mdarray</code> proposal
+<span class="citation" data-cites="P1684R0">[<a href="#ref-P1684R0" role="doc-biblioref">P1684R0</a>]</span> had a
+<code class="sourceCode default">ContainerPolicy</code> instead of a
+<code class="sourceCode default">Container</code> template parameter.
+The <code class="sourceCode default">ContainerPolicy</code> provided
+functionality like that of
+<code class="sourceCode default">mdspan</code>’s
+<code class="sourceCode default">AccessorPolicy</code>, and would also
+select the actual container type used to store the
+<code class="sourceCode default">mdarray</code>’s data.</p>
+<p>For the current revision of this proposal, we have decided that the
+complexity of a <code class="sourceCode default">ContainerPolicy</code>
+is not actually required for
+<code class="sourceCode default">mdarray</code>. The vast majority of
+cases where customization of the
+<code class="sourceCode default">AccessorPolicy</code> is required to
+modify the access behavior, are local contextual requirements that are
+better served by <code class="sourceCode default">mdspan</code>. For
+example, one might have code that creates and uses an
+<code class="sourceCode default">mdarray</code> in several different
+ways. One loop over the array might have write conflicts that an atomic
+accessor would resolve. Changing how one views data in a way limited to
+a particular context is the job of a view. That is, in this case, it
+would make the most sense to create a temporary
+<code class="sourceCode default">mdspan</code> with an atomic accessor
+that views the original <code class="sourceCode default">mdarray</code>,
+for use in the particular loop that needs atomic access.</p>
+<h2 data-number="3.2" id="differences-between-mdarray-and-mdspan"><span class="header-section-number">3.2</span> Differences between
+<code class="sourceCode default">mdarray</code> and
+<code class="sourceCode default">mdspan</code><a href="#differences-between-mdarray-and-mdspan" class="self-link"></a></h2>
+<p>By design, <code class="sourceCode default">mdarray</code> is as
+similar as possible to <code class="sourceCode default">mdspan</code>,
+except with container semantics instead of reference semantics. However,
+the use of container semantics calls for a few differences.</p>
+<h3 data-number="3.2.1" id="deep-constness"><span class="header-section-number">3.2.1</span> Deep
+<code class="sourceCode default">const</code>ness<a href="#deep-constness" class="self-link"></a></h3>
+<p>The most notable difference from
+<code class="sourceCode default">mdspan</code> is deep
+<code class="sourceCode default">const</code>ness. Like all reference
+semantic types in the standard,
+<code class="sourceCode default">mdspan</code> has shallow
+<code class="sourceCode default">const</code>ness, but container types
+in the standard library propagate
+<code class="sourceCode default">const</code> through their access
+functions. Thus, <code class="sourceCode default">mdarray</code> needs
+<code class="sourceCode default">const</code> and
+non-<code class="sourceCode default">const</code> versions of every
+analogous operation in <code class="sourceCode default">mdspan</code>
+that interacts with the underlying data.</p>
+<div class="sourceCode" id="cb5"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ElementType, <span class="kw">class</span> Extents, <span class="kw">class</span> LayoutPolicy, <span class="kw">class</span> Container<span class="op">&gt;</span></span>
+<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a><span class="kw">class</span> mdarray <span class="op">{</span></span>
+<span id="cb5-3"><a href="#cb5-3" aria-hidden="true" tabindex="-1"></a>  <span class="co">/* ... */</span></span>
+<span id="cb5-4"><a href="#cb5-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-5"><a href="#cb5-5" aria-hidden="true" tabindex="-1"></a>  <span class="co">// also in mdspan:</span></span>
+<span id="cb5-6"><a href="#cb5-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> pointer <span class="op">=</span> <span class="co">/* ... */</span>;</span>
+<span id="cb5-7"><a href="#cb5-7" aria-hidden="true" tabindex="-1"></a>  <span class="co">// only in mdarray:</span></span>
+<span id="cb5-8"><a href="#cb5-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> const_pointer <span class="op">=</span> <span class="co">/* ... */</span>;</span>
+<span id="cb5-9"><a href="#cb5-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-10"><a href="#cb5-10" aria-hidden="true" tabindex="-1"></a>  <span class="co">// also in mdspan:</span></span>
+<span id="cb5-11"><a href="#cb5-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> reference <span class="op">=</span> <span class="co">/* ... */</span>;</span>
+<span id="cb5-12"><a href="#cb5-12" aria-hidden="true" tabindex="-1"></a>  <span class="co">// only in mdarray:</span></span>
+<span id="cb5-13"><a href="#cb5-13" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> const_reference <span class="op">=</span> <span class="co">/* ... */</span>;</span>
+<span id="cb5-14"><a href="#cb5-14" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-15"><a href="#cb5-15" aria-hidden="true" tabindex="-1"></a>  <span class="co">// analogous to mdspan, except with const_reference return type:</span></span>
+<span id="cb5-16"><a href="#cb5-16" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span><span class="op">...</span> IndexType<span class="op">&gt;</span></span>
+<span id="cb5-17"><a href="#cb5-17" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> const_reference <span class="kw">operator</span><span class="op">[](</span>IndexType<span class="op">...)</span> <span class="kw">const</span>;</span>
+<span id="cb5-18"><a href="#cb5-18" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> IndexType, <span class="dt">size_t</span> N<span class="op">&gt;</span></span>
+<span id="cb5-19"><a href="#cb5-19" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> const_reference <span class="kw">operator</span><span class="op">[](</span><span class="kw">const</span> array<span class="op">&lt;</span>IndexType, N<span class="op">&gt;&amp;)</span> <span class="kw">const</span>;</span>
+<span id="cb5-20"><a href="#cb5-20" aria-hidden="true" tabindex="-1"></a>  <span class="co">// non-const overloads only in mdarray:</span></span>
+<span id="cb5-21"><a href="#cb5-21" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span><span class="op">...</span> IndexType<span class="op">&gt;</span></span>
+<span id="cb5-22"><a href="#cb5-22" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> reference <span class="kw">operator</span><span class="op">[](</span>IndexType<span class="op">...)</span>;</span>
+<span id="cb5-23"><a href="#cb5-23" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> IndexType, <span class="dt">size_t</span> N<span class="op">&gt;</span></span>
+<span id="cb5-24"><a href="#cb5-24" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> reference <span class="kw">operator</span><span class="op">[](</span><span class="kw">const</span> array<span class="op">&lt;</span>IndexType, N<span class="op">&gt;&amp;)</span>;</span>
+<span id="cb5-25"><a href="#cb5-25" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-26"><a href="#cb5-26" aria-hidden="true" tabindex="-1"></a>  <span class="co">// also in mdspan, except with const_pointer return type:</span></span>
+<span id="cb5-27"><a href="#cb5-27" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> const_pointer data<span class="op">()</span> <span class="kw">const</span> <span class="kw">noexcept</span>;</span>
+<span id="cb5-28"><a href="#cb5-28" aria-hidden="true" tabindex="-1"></a>  <span class="co">// non-const overload only in mdarray:</span></span>
+<span id="cb5-29"><a href="#cb5-29" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> pointer data<span class="op">()</span> <span class="kw">noexcept</span>;</span>
+<span id="cb5-30"><a href="#cb5-30" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-31"><a href="#cb5-31" aria-hidden="true" tabindex="-1"></a>  <span class="co">/* ... */</span></span>
+<span id="cb5-32"><a href="#cb5-32" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
+<h3 data-number="3.2.2" id="interoperability-between-mdarray-and-mdspan"><span class="header-section-number">3.2.2</span> Interoperability between
+<code class="sourceCode default">mdarray</code> and
+<code class="sourceCode default">mdspan</code><a href="#interoperability-between-mdarray-and-mdspan" class="self-link"></a></h3>
+<p>The <code class="sourceCode default">mdarray</code> class needs a
+means of interoperating with
+<code class="sourceCode default">mdspan</code> in roughly the same way
+as contiguous containers interact with
+<code class="sourceCode default">span</code>, or as
+<code class="sourceCode default">string</code> interacts with
+<code class="sourceCode default">string_view</code>. One way we could do
+this would be by adding a constructor to
+<code class="sourceCode default">mdspan</code>. This which would be more
+consistent with the analogous features in
+<code class="sourceCode default">span</code> and
+<code class="sourceCode default">string_view</code>. However, in the
+interest of avoiding modifications to an in-flight proposal, we instead
+propose using a member function of
+<code class="sourceCode default">mdarray</code> for this functionality
+for now. This member function is tentatively named
+<code class="sourceCode default">to_mdspan()</code>, but we welcome
+suggestions for other names.</p>
+<p>One advantage of this member function is that it could serve as a
+starting point for a general customization point in C++ for obtaining an
+<code class="sourceCode default">mdspan</code> generically.
+<code class="sourceCode default">to_mdspan</code> would effectively work
+like <code class="sourceCode default">begin</code> and other such
+customization points, which allow C++ facilities to interact with user
+provided classes.</p>
+<p>We would be happy to change this based on design direction from
+LEWG.</p>
+<div class="sourceCode" id="cb6"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ElementType, <span class="kw">class</span> Extents, <span class="kw">class</span> LayoutPolicy, <span class="kw">class</span> Container<span class="op">&gt;</span></span>
+<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a><span class="kw">class</span> mdarray <span class="op">{</span></span>
+<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a>  <span class="co">/* ... */</span></span>
+<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a>  </span>
+<span id="cb6-5"><a href="#cb6-5" aria-hidden="true" tabindex="-1"></a>  <span class="co">// only in mdarray:</span></span>
+<span id="cb6-6"><a href="#cb6-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> mdspan_type <span class="op">=</span> <span class="co">/* ... */</span>;</span>
+<span id="cb6-7"><a href="#cb6-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> const_mdspan_type <span class="op">=</span> <span class="co">/* ... */</span>;</span>
+<span id="cb6-8"><a href="#cb6-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-9"><a href="#cb6-9" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OT, <span class="kw">class</span> OE, <span class="kw">class</span> OL, <span class="kw">class</span> OA<span class="op">&gt;</span></span>
+<span id="cb6-10"><a href="#cb6-10" aria-hidden="true" tabindex="-1"></a>    <span class="kw">operator</span> mdspan<span class="op">()</span> <span class="kw">const</span>;</span>
+<span id="cb6-11"><a href="#cb6-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-12"><a href="#cb6-12" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherAccessorType <span class="op">=</span> default_accessor<span class="op">&lt;</span>element_type<span class="op">&gt;&gt;</span></span>
+<span id="cb6-13"><a href="#cb6-13" aria-hidden="true" tabindex="-1"></a>    <span class="kw">auto</span> to_mdspan<span class="op">(</span><span class="kw">const</span> OtherAccessorType<span class="op">&amp;</span> a <span class="op">=</span> </span>
+<span id="cb6-14"><a href="#cb6-14" aria-hidden="true" tabindex="-1"></a>                     default_accessor<span class="op">&lt;</span>element_type<span class="op">&gt;())</span> <span class="kw">const</span> <span class="kw">noexcept</span>;</span>
+<span id="cb6-15"><a href="#cb6-15" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherAccessorType <span class="op">=</span> default_accessor<span class="op">&lt;</span><span class="kw">const</span> element_type<span class="op">&gt;&gt;</span></span>
+<span id="cb6-16"><a href="#cb6-16" aria-hidden="true" tabindex="-1"></a>    <span class="kw">auto</span> to_mdspan<span class="op">(</span><span class="kw">const</span> OtherAccessorType<span class="op">&amp;</span> a <span class="op">=</span> </span>
+<span id="cb6-17"><a href="#cb6-17" aria-hidden="true" tabindex="-1"></a>                     default_accessor<span class="op">&lt;</span><span class="kw">const</span> element_type<span class="op">&gt;())</span> <span class="kw">const</span> <span class="kw">noexcept</span>;</span>
+<span id="cb6-18"><a href="#cb6-18" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-19"><a href="#cb6-19" aria-hidden="true" tabindex="-1"></a>  <span class="co">/* ... */</span></span>
+<span id="cb6-20"><a href="#cb6-20" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
+<h3 data-number="3.2.3" id="container-instead-of-accessorpolicy"><span class="header-section-number">3.2.3</span>
+<code class="sourceCode default">Container</code> instead of
+<code class="sourceCode default">AccessorPolicy</code><a href="#container-instead-of-accessorpolicy" class="self-link"></a></h3>
+<p>As we discuss elsewhere, the
+<code class="sourceCode default">mdspan</code> class has an
+<code class="sourceCode default">AccessorPolicy</code> template
+parameter, while <code class="sourceCode default">mdarray</code> has a
+<code class="sourceCode default">Container</code> template
+parameter.</p>
+<div class="sourceCode" id="cb7"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ElementType, <span class="kw">class</span> Extents, <span class="kw">class</span> LayoutPolicy, <span class="kw">class</span> Container<span class="op">&gt;</span></span>
+<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a><span class="kw">class</span> mdarray <span class="op">{</span></span>
+<span id="cb7-3"><a href="#cb7-3" aria-hidden="true" tabindex="-1"></a>  <span class="co">/* ... */</span></span>
+<span id="cb7-4"><a href="#cb7-4" aria-hidden="true" tabindex="-1"></a>  </span>
+<span id="cb7-5"><a href="#cb7-5" aria-hidden="true" tabindex="-1"></a>  <span class="co">// only in mdarray</span></span>
+<span id="cb7-6"><a href="#cb7-6" aria-hidden="true" tabindex="-1"></a> <span class="kw">using</span> container_type <span class="op">=</span> Container;</span>
+<span id="cb7-7"><a href="#cb7-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-8"><a href="#cb7-8" aria-hidden="true" tabindex="-1"></a>  <span class="co">/* ... */</span></span>
+<span id="cb7-9"><a href="#cb7-9" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
+<h3 data-number="3.2.4" id="constructors-and-assignment-operators"><span class="header-section-number">3.2.4</span> Constructors and assignment
+operators<a href="#constructors-and-assignment-operators" class="self-link"></a></h3>
+<p>The constructors and assignment operators of
+<code class="sourceCode default">mdspan</code> and
+<code class="sourceCode default">mdarray</code> have a few differences.
+The <code class="sourceCode default">mdspan</code> class provides a
+compatible <code class="sourceCode default">mdspan</code> copy-like
+constructor and copy-like assignment operator, with proper constraints
+and expectations to enforce compatibility of shape, layout, and size.
+Since <code class="sourceCode default">mdarray</code> has owning
+semantics, we also need move-like versions of these:</p>
+<div class="sourceCode" id="cb8"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ElementType, <span class="kw">class</span> Extents, <span class="kw">class</span> LayoutPolicy, <span class="kw">class</span> ContainerPolicy<span class="op">&gt;</span></span>
+<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a><span class="kw">class</span> mdarray <span class="op">{</span></span>
+<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a>  <span class="co">/* ... */</span></span>
+<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a>  </span>
+<span id="cb8-5"><a href="#cb8-5" aria-hidden="true" tabindex="-1"></a>  <span class="co">// analogous to mdspan:</span></span>
+<span id="cb8-6"><a href="#cb8-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ET, <span class="kw">class</span> Exts, <span class="kw">class</span> LP, <span class="kw">class</span> CP<span class="op">&gt;</span></span>
+<span id="cb8-7"><a href="#cb8-7" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> mdarray<span class="op">&lt;</span>ET, Exts, LP, CP<span class="op">&gt;&amp;)</span>;</span>
+<span id="cb8-8"><a href="#cb8-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ET, <span class="kw">class</span> Exts, <span class="kw">class</span> LP, <span class="kw">class</span> CP<span class="op">&gt;</span></span>
+<span id="cb8-9"><a href="#cb8-9" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">&amp;</span> <span class="kw">operator</span><span class="op">=(</span><span class="kw">const</span> mdarray<span class="op">&lt;</span>ET, Exts, LP, CP<span class="op">&gt;&amp;)</span>;</span>
+<span id="cb8-10"><a href="#cb8-10" aria-hidden="true" tabindex="-1"></a>  <span class="co">// only in mdarray:</span></span>
+<span id="cb8-11"><a href="#cb8-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ET, <span class="kw">class</span> Exts, <span class="kw">class</span> LP, <span class="kw">class</span> CP<span class="op">&gt;</span></span>
+<span id="cb8-12"><a href="#cb8-12" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span>mdarray<span class="op">&lt;</span>ET, Exts, LP, CP<span class="op">&gt;&amp;&amp;)</span> <span class="kw">noexcept</span><span class="op">(</span><em>see-below</em><span class="op">)</span>;</span>
+<span id="cb8-13"><a href="#cb8-13" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ET, <span class="kw">class</span> Exts, <span class="kw">class</span> LP, <span class="kw">class</span> CP<span class="op">&gt;</span></span>
+<span id="cb8-14"><a href="#cb8-14" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">&amp;</span> <span class="kw">operator</span><span class="op">=(</span>mdarray<span class="op">&lt;</span>ET, Exts, LP, CP<span class="op">&gt;&amp;&amp;)</span> <span class="kw">noexcept</span>;</span>
+<span id="cb8-15"><a href="#cb8-15" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb8-16"><a href="#cb8-16" aria-hidden="true" tabindex="-1"></a>  <span class="co">/* ... */</span></span>
+<span id="cb8-17"><a href="#cb8-17" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
+<p>(The <code class="sourceCode default">noexcept</code> clauses on
+these constructors and operators should probably actually derive from
+<code class="sourceCode default">noexcept</code> clauses on the
+analogous functionality for the element type and policy types.)</p>
+<p>Additionally, the analog of the
+<code class="sourceCode default">mdspan(pointer, IndexType...)</code>
+constructor for <code class="sourceCode default">mdarray</code> does not
+need a <code class="sourceCode default">pointer</code> argument, since
+the <code class="sourceCode default">mdarray</code> owns the data and
+thus should be able to construct it from sizes:</p>
+<div class="sourceCode" id="cb9"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ElementType, <span class="kw">class</span> Extents, <span class="kw">class</span> LayoutPolicy, <span class="kw">class</span> ContainerPolicy<span class="op">&gt;</span></span>
+<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a><span class="kw">class</span> mdarray <span class="op">{</span></span>
+<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a>  <span class="co">/* ... */</span></span>
+<span id="cb9-4"><a href="#cb9-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb9-5"><a href="#cb9-5" aria-hidden="true" tabindex="-1"></a>  <span class="co">// only in mdarray</span></span>
+<span id="cb9-6"><a href="#cb9-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span><span class="op">...</span> IndexType<span class="op">&gt;</span></span>
+<span id="cb9-7"><a href="#cb9-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">explicit</span> <span class="kw">constexpr</span> mdarray<span class="op">(</span>IndexType<span class="op">...)</span>;</span>
+<span id="cb9-8"><a href="#cb9-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb9-9"><a href="#cb9-9" aria-hidden="true" tabindex="-1"></a>  <span class="co">/* ... */</span></span>
+<span id="cb9-10"><a href="#cb9-10" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
+<p>Note that in the completely static extents case, this is ambiguous
+with the default constructor. For consistency in generic code, the
+semantics of this constructor should be preferred over those of the
+default constructor in that case.</p>
+<p>By this same logic, we arrive at the
+<code class="sourceCode default">mapping_type</code> constructor
+analogs:</p>
+<div class="sourceCode" id="cb10"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ElementType, <span class="kw">class</span> Extents, <span class="kw">class</span> LayoutPolicy, <span class="kw">class</span> Container<span class="op">&gt;</span></span>
+<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a><span class="kw">class</span> mdarray <span class="op">{</span></span>
+<span id="cb10-3"><a href="#cb10-3" aria-hidden="true" tabindex="-1"></a>  <span class="co">/* ... */</span></span>
+<span id="cb10-4"><a href="#cb10-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb10-5"><a href="#cb10-5" aria-hidden="true" tabindex="-1"></a>  <span class="co">// only in mdarray</span></span>
+<span id="cb10-6"><a href="#cb10-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">explicit</span> <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> mapping_type<span class="op">&amp;)</span>;</span>
+<span id="cb10-7"><a href="#cb10-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb10-8"><a href="#cb10-8" aria-hidden="true" tabindex="-1"></a>  <span class="co">/* ... */</span></span>
+<span id="cb10-9"><a href="#cb10-9" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
+<p>There is some question as to whether we should also have constructors
+that take <code class="sourceCode default">container_type</code>
+instances in addition to indices. Consistency with standard container
+adapters like
+<code class="sourceCode default">std::priority_queue</code> would
+dictate that we should. Note that these constructors would deep-copy the
+input container.</p>
+<div class="sourceCode" id="cb11"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ElementType, <span class="kw">class</span> Extents, <span class="kw">class</span> LayoutPolicy, <span class="kw">class</span> Container<span class="op">&gt;</span></span>
+<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a><span class="kw">class</span> mdarray <span class="op">{</span></span>
+<span id="cb11-3"><a href="#cb11-3" aria-hidden="true" tabindex="-1"></a>  <span class="co">/* ... */</span></span>
+<span id="cb11-4"><a href="#cb11-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb11-5"><a href="#cb11-5" aria-hidden="true" tabindex="-1"></a>  <span class="co">// only in mdarray</span></span>
+<span id="cb11-6"><a href="#cb11-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">explicit</span> <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> mapping_type<span class="op">&amp;)</span>;</span>
+<span id="cb11-7"><a href="#cb11-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> container_type<span class="op">&amp;</span>, <span class="kw">const</span> mapping_type<span class="op">&amp;)</span>;</span>
+<span id="cb11-8"><a href="#cb11-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb11-9"><a href="#cb11-9" aria-hidden="true" tabindex="-1"></a>  <span class="co">/* ... */</span></span>
+<span id="cb11-10"><a href="#cb11-10" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
+<p>Moreover, containers such as
+<code class="sourceCode default">vector</code> and container adapters
+like <code class="sourceCode default">queue</code> have a significant
+number of other constructors which copy the data on input, such as
+constructors taking ranges, input iterator pairs, and initializer lists.
+The R2 version of this paper had a number of those, but in combination
+with allocator arguments it lead to an explosion of constructors. A
+draft version seen by LEWG on 2022-07-12 sported 41 constructors.
+However almost all these constructors would simply forward arguments to
+the constructor of the container owned by
+<code class="sourceCode default">mdarray</code>. LEWG provided feedback
+that we should consider reducing the amount of constructors, since at a
+minimum one could inline construct the
+<code class="sourceCode default">container</code> itself, and move it
+into the <code class="sourceCode default">mdarray</code> upon
+construction.</p>
+<div class="sourceCode" id="cb12"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="co">// with convenience constructors:</span></span>
+<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a>mdarray a<span class="op">(</span>first, last, N, M<span class="op">)</span>;</span>
+<span id="cb12-3"><a href="#cb12-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb12-4"><a href="#cb12-4" aria-hidden="true" tabindex="-1"></a><span class="co">// without</span></span>
+<span id="cb12-5"><a href="#cb12-5" aria-hidden="true" tabindex="-1"></a>mdarray a<span class="op">(</span>std<span class="op">::</span>move<span class="op">(</span>vector<span class="op">(</span>first, last<span class="op">))</span>, N, M<span class="op">)</span>;</span></code></pre></div>
+<p>In R3 we decided to radically cut back on constructors and simply
+leave those out.</p>
+<p>Finally, <code class="sourceCode default">mdarray</code> does not
+have the analog of <code class="sourceCode default">mdspan</code>’s
+constructor that takes an
+<code class="sourceCode default">array&lt;IndexType, N&gt;</code> of
+dynamic extents. This avoids any ambiguity or confusion with a
+constructor that takes a container instance, in the case where the
+<code class="sourceCode default">container</code> happens to be an
+<code class="sourceCode default">array&lt;IndexType, N&gt;</code>.</p>
+<h3 data-number="3.2.5" id="alternative-constructor-design"><span class="header-section-number">3.2.5</span> Alternative constructor
+design<a href="#alternative-constructor-design" class="self-link"></a></h3>
+<p>We can both significantly reduce the number of constructors
+<em>and</em> gain the ability to emplace the container. This requires a
+bit of shuffling of the arguments, adding a tag and adding a parameter
+pack.</p>
+<ul>
+<li>Whenever <code class="sourceCode default">extents_type</code> or
+<code class="sourceCode default">mapping_type</code> is provided, it
+must come first.</li>
+<li>Whenever an <code class="sourceCode default">mdarray</code> is
+constructed with <code class="sourceCode default">val</code>, it must be
+preceded by a tag.</li>
+<li>Add a parameter pack <code class="sourceCode default">Args...</code>
+that essentially emplace constructs the container.</li>
+</ul>
+<p>The original adaptors couldn’t do this, because variadics didn’t
+exist in C++98. We can and should do better now that we have better
+language facilities.</p>
+<p>In the original design, the unconstrained
+<code class="sourceCode default">Alloc</code> parameter is in a weird
+spot in the constructors by not being next to the container it is being
+passed to. This alternate design addresses that but introduces a
+different weirdness between “take an integer pack” and “take
+extents/mapping” constructors in terms of position of the container
+argument. This is teachable with these simple rules:</p>
+<ul>
+<li>If you have an extents/mapping object, it comes first.</li>
+<li>Otherwise, if you have a container object, it comes first.</li>
+<li>For constructors that take a parameter pack of extents (as opposed
+to an extents/mapping object), they come last.</li>
+</ul>
+<p>The deduction guides have been reworked for the new constructors.
+Because we need to deduce the container type, a
+<code class="sourceCode default">Container</code> parameter is provided
+for all the guides which are not using the default container, and that
+container is then copied or moved into the
+<code class="sourceCode default">mdarray</code> on construction. This
+works because providing a container as the only parameter to the
+<code class="sourceCode default">Args...</code> parameter pack in any of
+the constructors effectively implements this.</p>
+<table>
+<thead>
+<tr class="header">
+<th><div style="text-align:center">
+<strong>Original (26 <code class="sourceCode default">mdarray</code>
+constructors)</strong>
+</div></th>
+<th><div style="text-align:center">
+<strong>Alternative (12 <code class="sourceCode default">mdarray</code>
+constructors)</strong>
+</div></th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td><div>
+
+<div class="sourceCode" id="cb13"><pre class="sourceCode cpp"><code class="sourceCode cpp"></code></pre></div>
+
+</div></td>
+<td><div>
+
+<div class="sourceCode" id="cb14"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="kw">namespace</span> std <span class="op">{</span></span>
+<span id="cb14-2"><a href="#cb14-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">struct</span> fill_t <span class="op">{</span></span>
+<span id="cb14-3"><a href="#cb14-3" aria-hidden="true" tabindex="-1"></a>    <span class="kw">explicit</span> fill_t<span class="op">()</span> <span class="op">=</span> <span class="cf">default</span>;</span>
+<span id="cb14-4"><a href="#cb14-4" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span>;</span>
+<span id="cb14-5"><a href="#cb14-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">inline</span> <span class="kw">constexpr</span> fill_t fill<span class="op">()</span>;</span>
+<span id="cb14-6"><a href="#cb14-6" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+
+</div></td>
+</tr>
+<tr class="even">
+<td><div>
+
+<div class="sourceCode" id="cb15"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> mdarray<span class="op">()</span></span>
+<span id="cb15-2"><a href="#cb15-2" aria-hidden="true" tabindex="-1"></a>    <span class="kw">requires</span><span class="op">(</span>rank_dynamic<span class="op">()</span> <span class="op">!=</span> <span class="dv">0</span><span class="op">)</span></span>
+<span id="cb15-3"><a href="#cb15-3" aria-hidden="true" tabindex="-1"></a>    <span class="op">=</span> <span class="cf">default</span>;</span>
+<span id="cb15-4"><a href="#cb15-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> mdarray<span class="op">&amp;</span> rhs<span class="op">)</span> <span class="op">=</span> <span class="cf">default</span>;</span>
+<span id="cb15-5"><a href="#cb15-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> mdarray<span class="op">(</span>mdarray<span class="op">&amp;&amp;</span> rhs<span class="op">)</span> <span class="op">=</span> <span class="cf">default</span>;</span>
+<span id="cb15-6"><a href="#cb15-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb15-7"><a href="#cb15-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span><span class="op">...</span> OtherIndexTypes<span class="op">&gt;</span></span>
+<span id="cb15-8"><a href="#cb15-8" aria-hidden="true" tabindex="-1"></a>    <span class="kw">explicit</span> <span class="kw">constexpr</span> mdarray<span class="op">(</span>OtherIndexTypes<span class="op">...</span> exts<span class="op">)</span>;</span>
+<span id="cb15-9"><a href="#cb15-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb15-10"><a href="#cb15-10" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span><span class="op">...</span> OtherIndexTypes<span class="op">&gt;</span></span>
+<span id="cb15-11"><a href="#cb15-11" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> container_type<span class="op">&amp;</span> c,</span>
+<span id="cb15-12"><a href="#cb15-12" aria-hidden="true" tabindex="-1"></a>                      OtherIndexTypes<span class="op">...</span> exts<span class="op">)</span>;</span>
+<span id="cb15-13"><a href="#cb15-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb15-14"><a href="#cb15-14" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span><span class="op">...</span> OtherIndexTypes<span class="op">&gt;</span></span>
+<span id="cb15-15"><a href="#cb15-15" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span>container_type<span class="op">&amp;&amp;</span> c,</span>
+<span id="cb15-16"><a href="#cb15-16" aria-hidden="true" tabindex="-1"></a>                      OtherIndexTypes<span class="op">...</span> exts<span class="op">)</span>;</span></code></pre></div>
+
+</div></td>
+<td><div>
+
+<div class="sourceCode" id="cb16"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> mdarray<span class="op">()</span></span>
+<span id="cb16-2"><a href="#cb16-2" aria-hidden="true" tabindex="-1"></a>    <span class="kw">requires</span><span class="op">(</span>rank_dynamic<span class="op">()</span> <span class="op">!=</span> <span class="dv">0</span><span class="op">)</span></span>
+<span id="cb16-3"><a href="#cb16-3" aria-hidden="true" tabindex="-1"></a>    <span class="op">=</span> <span class="cf">default</span>;</span>
+<span id="cb16-4"><a href="#cb16-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> mdarray<span class="op">&amp;</span> rhs<span class="op">)</span> <span class="op">=</span> <span class="cf">default</span>;</span>
+<span id="cb16-5"><a href="#cb16-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> mdarray<span class="op">(</span>mdarray<span class="op">&amp;&amp;</span> rhs<span class="op">)</span> <span class="op">=</span> <span class="cf">default</span>;</span>
+<span id="cb16-6"><a href="#cb16-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb16-7"><a href="#cb16-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span><span class="op">...</span> OtherIndexTypes<span class="op">&gt;</span></span>
+<span id="cb16-8"><a href="#cb16-8" aria-hidden="true" tabindex="-1"></a>    <span class="kw">explicit</span> <span class="kw">constexpr</span> mdarray<span class="op">(</span>OtherIndexTypes<span class="op">...</span> exts<span class="op">)</span>;</span>
+<span id="cb16-9"><a href="#cb16-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb16-10"><a href="#cb16-10" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span><span class="op">...</span> OtherIndexTypes<span class="op">&gt;</span></span>
+<span id="cb16-11"><a href="#cb16-11" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> container_type<span class="op">&amp;</span> c,</span>
+<span id="cb16-12"><a href="#cb16-12" aria-hidden="true" tabindex="-1"></a>                      OtherIndexTypes<span class="op">...</span> exts<span class="op">)</span>;</span>
+<span id="cb16-13"><a href="#cb16-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb16-14"><a href="#cb16-14" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span><span class="op">...</span> OtherIndexTypes<span class="op">&gt;</span></span>
+<span id="cb16-15"><a href="#cb16-15" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span>container_type<span class="op">&amp;&amp;</span> c,</span>
+<span id="cb16-16"><a href="#cb16-16" aria-hidden="true" tabindex="-1"></a>                      OtherIndexTypes<span class="op">...</span> exts<span class="op">)</span>;</span></code></pre></div>
+
+</div></td>
+</tr>
+<tr class="odd">
+<td><div>
+
+<div class="sourceCode" id="cb17"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb17-1"><a href="#cb17-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">explicit</span> <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> extents_type<span class="op">&amp;</span> ext<span class="op">)</span>;</span>
+<span id="cb17-2"><a href="#cb17-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">explicit</span> <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> mapping_type<span class="op">&amp;</span> m<span class="op">)</span>;</span>
+<span id="cb17-3"><a href="#cb17-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb17-4"><a href="#cb17-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> container_type<span class="op">&amp;</span> c,</span>
+<span id="cb17-5"><a href="#cb17-5" aria-hidden="true" tabindex="-1"></a>                    <span class="kw">const</span> extents_type<span class="op">&amp;</span> ext<span class="op">)</span>;</span>
+<span id="cb17-6"><a href="#cb17-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> container_type<span class="op">&amp;</span> c,</span>
+<span id="cb17-7"><a href="#cb17-7" aria-hidden="true" tabindex="-1"></a>                    <span class="kw">const</span> mapping_type<span class="op">&amp;</span> m<span class="op">)</span>;</span>
+<span id="cb17-8"><a href="#cb17-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb17-9"><a href="#cb17-9" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
+<span id="cb17-10"><a href="#cb17-10" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> extents_type<span class="op">&amp;</span> ext,</span>
+<span id="cb17-11"><a href="#cb17-11" aria-hidden="true" tabindex="-1"></a>                      <span class="kw">const</span> Alloc<span class="op">&amp;</span> a<span class="op">)</span>;</span>
+<span id="cb17-12"><a href="#cb17-12" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
+<span id="cb17-13"><a href="#cb17-13" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> mapping_type<span class="op">&amp;</span> m,</span>
+<span id="cb17-14"><a href="#cb17-14" aria-hidden="true" tabindex="-1"></a>                      <span class="kw">const</span> Alloc<span class="op">&amp;</span> a<span class="op">)</span>;</span>
+<span id="cb17-15"><a href="#cb17-15" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb17-16"><a href="#cb17-16" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> mdarray<span class="op">(</span>container_type<span class="op">&amp;&amp;</span> c,</span>
+<span id="cb17-17"><a href="#cb17-17" aria-hidden="true" tabindex="-1"></a>                    <span class="kw">const</span> extents_type<span class="op">&amp;</span> ext<span class="op">)</span>;</span>
+<span id="cb17-18"><a href="#cb17-18" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> mdarray<span class="op">(</span>container_type<span class="op">&amp;&amp;</span> c,</span>
+<span id="cb17-19"><a href="#cb17-19" aria-hidden="true" tabindex="-1"></a>                    <span class="kw">const</span> mapping_type<span class="op">&amp;</span> m<span class="op">)</span>;</span>
+<span id="cb17-20"><a href="#cb17-20" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb17-21"><a href="#cb17-21" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
+<span id="cb17-22"><a href="#cb17-22" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> container_type<span class="op">&amp;</span> c,</span>
+<span id="cb17-23"><a href="#cb17-23" aria-hidden="true" tabindex="-1"></a>                      <span class="kw">const</span> extents_type<span class="op">&amp;</span> ext,</span>
+<span id="cb17-24"><a href="#cb17-24" aria-hidden="true" tabindex="-1"></a>                      <span class="kw">const</span> Alloc<span class="op">&amp;</span> a<span class="op">)</span>;</span>
+<span id="cb17-25"><a href="#cb17-25" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
+<span id="cb17-26"><a href="#cb17-26" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> container_type<span class="op">&amp;</span> c,</span>
+<span id="cb17-27"><a href="#cb17-27" aria-hidden="true" tabindex="-1"></a>                      <span class="kw">const</span> mapping_type<span class="op">&amp;</span> m,</span>
+<span id="cb17-28"><a href="#cb17-28" aria-hidden="true" tabindex="-1"></a>                      <span class="kw">const</span> Alloc<span class="op">&amp;</span> a<span class="op">)</span>;</span>
+<span id="cb17-29"><a href="#cb17-29" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb17-30"><a href="#cb17-30" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
+<span id="cb17-31"><a href="#cb17-31" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span>container_type<span class="op">&amp;&amp;</span> c,</span>
+<span id="cb17-32"><a href="#cb17-32" aria-hidden="true" tabindex="-1"></a>                      <span class="kw">const</span> extents_type<span class="op">&amp;</span> ext,</span>
+<span id="cb17-33"><a href="#cb17-33" aria-hidden="true" tabindex="-1"></a>                      <span class="kw">const</span> Alloc<span class="op">&amp;</span> a<span class="op">)</span>;</span>
+<span id="cb17-34"><a href="#cb17-34" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
+<span id="cb17-35"><a href="#cb17-35" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span>container_type<span class="op">&amp;&amp;</span> c,</span>
+<span id="cb17-36"><a href="#cb17-36" aria-hidden="true" tabindex="-1"></a>                      <span class="kw">const</span> mapping_type<span class="op">&amp;</span> m,</span>
+<span id="cb17-37"><a href="#cb17-37" aria-hidden="true" tabindex="-1"></a>                      <span class="kw">const</span> Alloc<span class="op">&amp;</span> a<span class="op">)</span>;</span></code></pre></div>
+
+</div></td>
+<td><div>
+
+<div class="sourceCode" id="cb18"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span><span class="op">...</span> Args<span class="op">&gt;</span></span>
+<span id="cb18-2"><a href="#cb18-2" aria-hidden="true" tabindex="-1"></a>    <span class="kw">explicit</span><span class="op">(</span><span class="kw">sizeof</span><span class="op">...(</span>Args<span class="op">)</span> <span class="op">==</span> <span class="dv">0</span><span class="op">)</span></span>
+<span id="cb18-3"><a href="#cb18-3" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> extents_type<span class="op">&amp;</span> ext,</span>
+<span id="cb18-4"><a href="#cb18-4" aria-hidden="true" tabindex="-1"></a>                      Args<span class="op">&amp;&amp;...</span> args<span class="op">)</span>;</span>
+<span id="cb18-5"><a href="#cb18-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb18-6"><a href="#cb18-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span><span class="op">...</span> Args<span class="op">&gt;</span></span>
+<span id="cb18-7"><a href="#cb18-7" aria-hidden="true" tabindex="-1"></a>    <span class="kw">explicit</span><span class="op">(</span><span class="kw">sizeof</span><span class="op">...(</span>Args<span class="op">)</span> <span class="op">==</span> <span class="dv">0</span><span class="op">)</span></span>
+<span id="cb18-8"><a href="#cb18-8" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> mapping_type<span class="op">&amp;</span> m,</span>
+<span id="cb18-9"><a href="#cb18-9" aria-hidden="true" tabindex="-1"></a>                      Args<span class="op">&amp;&amp;...</span> args<span class="op">)</span>;</span></code></pre></div>
+
+</div></td>
+</tr>
+<tr class="even">
+<td><div>
+
+<div class="sourceCode" id="cb19"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb19-1"><a href="#cb19-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> extents_type<span class="op">&amp;</span> ext,</span>
+<span id="cb19-2"><a href="#cb19-2" aria-hidden="true" tabindex="-1"></a>                    <span class="kw">const</span> value_type<span class="op">&amp;</span> val<span class="op">)</span>;</span>
+<span id="cb19-3"><a href="#cb19-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> mapping_type<span class="op">&amp;</span> m,</span>
+<span id="cb19-4"><a href="#cb19-4" aria-hidden="true" tabindex="-1"></a>                    <span class="kw">const</span> value_type<span class="op">&amp;</span> val<span class="op">)</span>;</span>
+<span id="cb19-5"><a href="#cb19-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb19-6"><a href="#cb19-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
+<span id="cb19-7"><a href="#cb19-7" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> extents_type<span class="op">&amp;</span> ext,</span>
+<span id="cb19-8"><a href="#cb19-8" aria-hidden="true" tabindex="-1"></a>                      <span class="kw">const</span> value_type<span class="op">&amp;</span> val,</span>
+<span id="cb19-9"><a href="#cb19-9" aria-hidden="true" tabindex="-1"></a>                      <span class="kw">const</span> Alloc<span class="op">&amp;</span> a<span class="op">)</span>;</span>
+<span id="cb19-10"><a href="#cb19-10" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
+<span id="cb19-11"><a href="#cb19-11" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> mapping_type<span class="op">&amp;</span> m,</span>
+<span id="cb19-12"><a href="#cb19-12" aria-hidden="true" tabindex="-1"></a>                      <span class="kw">const</span> value_type<span class="op">&amp;</span> val,</span>
+<span id="cb19-13"><a href="#cb19-13" aria-hidden="true" tabindex="-1"></a>                      <span class="kw">const</span> Alloc<span class="op">&amp;</span> a<span class="op">)</span>;</span></code></pre></div>
+
+</div></td>
+<td><div>
+
+<div class="sourceCode" id="cb20"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb20-1"><a href="#cb20-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span><span class="op">...</span> Args<span class="op">&gt;</span></span>
+<span id="cb20-2"><a href="#cb20-2" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> extents_type<span class="op">&amp;</span> ext,</span>
+<span id="cb20-3"><a href="#cb20-3" aria-hidden="true" tabindex="-1"></a>                      fill_t,</span>
+<span id="cb20-4"><a href="#cb20-4" aria-hidden="true" tabindex="-1"></a>                      <span class="kw">const</span> value_type<span class="op">&amp;</span> val,</span>
+<span id="cb20-5"><a href="#cb20-5" aria-hidden="true" tabindex="-1"></a>                      Args<span class="op">&amp;&amp;...</span> args<span class="op">)</span>;</span>
+<span id="cb20-6"><a href="#cb20-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb20-7"><a href="#cb20-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span><span class="op">...</span> Args<span class="op">&gt;</span></span>
+<span id="cb20-8"><a href="#cb20-8" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> mapping_type<span class="op">&amp;</span> m,</span>
+<span id="cb20-9"><a href="#cb20-9" aria-hidden="true" tabindex="-1"></a>                      fill_t,</span>
+<span id="cb20-10"><a href="#cb20-10" aria-hidden="true" tabindex="-1"></a>                      <span class="kw">const</span> value_type<span class="op">&amp;</span> val,</span>
+<span id="cb20-11"><a href="#cb20-11" aria-hidden="true" tabindex="-1"></a>                      Args<span class="op">&amp;&amp;...</span> args<span class="op">)</span>;</span></code></pre></div>
+
+</div></td>
+</tr>
+<tr class="odd">
+<td><div>
+
+<div class="sourceCode" id="cb21"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb21-1"><a href="#cb21-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherElementType, <span class="kw">class</span> OtherExtents, </span>
+<span id="cb21-2"><a href="#cb21-2" aria-hidden="true" tabindex="-1"></a>           <span class="kw">class</span> OtherLayoutPolicy, <span class="kw">class</span> OtherContainer<span class="op">&gt;</span></span>
+<span id="cb21-3"><a href="#cb21-3" aria-hidden="true" tabindex="-1"></a>    <span class="kw">explicit</span><span class="op">(</span><em>see below</em><span class="op">)</span></span>
+<span id="cb21-4"><a href="#cb21-4" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> mdarray<span class="op">&lt;</span>OtherElementType,</span>
+<span id="cb21-5"><a href="#cb21-5" aria-hidden="true" tabindex="-1"></a>                    OtherExtents,</span>
+<span id="cb21-6"><a href="#cb21-6" aria-hidden="true" tabindex="-1"></a>                    OtherLayoutPolicy,</span>
+<span id="cb21-7"><a href="#cb21-7" aria-hidden="true" tabindex="-1"></a>                    OtherContainer<span class="op">&gt;&amp;</span> other<span class="op">)</span>;</span>
+<span id="cb21-8"><a href="#cb21-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb21-9"><a href="#cb21-9" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherElementType, <span class="kw">class</span> OtherExtents,</span>
+<span id="cb21-10"><a href="#cb21-10" aria-hidden="true" tabindex="-1"></a>           <span class="kw">class</span> OtherLayoutPolicy, <span class="kw">class</span> Accessor<span class="op">&gt;</span></span>
+<span id="cb21-11"><a href="#cb21-11" aria-hidden="true" tabindex="-1"></a>    <span class="kw">explicit</span><span class="op">(</span><em>see below</em><span class="op">)</span></span>
+<span id="cb21-12"><a href="#cb21-12" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> mdspan<span class="op">&lt;</span>OtherElementType,</span>
+<span id="cb21-13"><a href="#cb21-13" aria-hidden="true" tabindex="-1"></a>                                   OtherExtents,</span>
+<span id="cb21-14"><a href="#cb21-14" aria-hidden="true" tabindex="-1"></a>                                   OtherLayoutPolicy,</span>
+<span id="cb21-15"><a href="#cb21-15" aria-hidden="true" tabindex="-1"></a>                                   Accessor<span class="op">&gt;&amp;</span> other<span class="op">)</span>;</span>
+<span id="cb21-16"><a href="#cb21-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb21-17"><a href="#cb21-17" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherElementType, <span class="kw">class</span> OtherExtents, </span>
+<span id="cb21-18"><a href="#cb21-18" aria-hidden="true" tabindex="-1"></a>           <span class="kw">class</span> OtherLayoutPolicy, <span class="kw">class</span> OtherContainer, </span>
+<span id="cb21-19"><a href="#cb21-19" aria-hidden="true" tabindex="-1"></a>           <span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
+<span id="cb21-20"><a href="#cb21-20" aria-hidden="true" tabindex="-1"></a>    <span class="kw">explicit</span><span class="op">(</span><em>see below</em><span class="op">)</span></span>
+<span id="cb21-21"><a href="#cb21-21" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> mdarray<span class="op">&lt;</span>OtherElementType,</span>
+<span id="cb21-22"><a href="#cb21-22" aria-hidden="true" tabindex="-1"></a>                                    OtherExtents, </span>
+<span id="cb21-23"><a href="#cb21-23" aria-hidden="true" tabindex="-1"></a>                                    OtherLayoutPolicy,</span>
+<span id="cb21-24"><a href="#cb21-24" aria-hidden="true" tabindex="-1"></a>                                    OtherContainer<span class="op">&gt;&amp;</span> other,</span>
+<span id="cb21-25"><a href="#cb21-25" aria-hidden="true" tabindex="-1"></a>                      <span class="kw">const</span> Alloc<span class="op">&amp;</span> a<span class="op">)</span>;</span>
+<span id="cb21-26"><a href="#cb21-26" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb21-27"><a href="#cb21-27" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherElementType, <span class="kw">class</span> OtherExtents,</span>
+<span id="cb21-28"><a href="#cb21-28" aria-hidden="true" tabindex="-1"></a>           <span class="kw">class</span> OtherLayoutPolicy, <span class="kw">class</span> Accessor,</span>
+<span id="cb21-29"><a href="#cb21-29" aria-hidden="true" tabindex="-1"></a>           <span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
+<span id="cb21-30"><a href="#cb21-30" aria-hidden="true" tabindex="-1"></a>    <span class="kw">explicit</span><span class="op">(</span><em>see below</em><span class="op">)</span></span>
+<span id="cb21-31"><a href="#cb21-31" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> mdspan<span class="op">&lt;</span>OtherElementType,</span>
+<span id="cb21-32"><a href="#cb21-32" aria-hidden="true" tabindex="-1"></a>                                   OtherExtents,</span>
+<span id="cb21-33"><a href="#cb21-33" aria-hidden="true" tabindex="-1"></a>                                   OtherLayoutPolicy,</span>
+<span id="cb21-34"><a href="#cb21-34" aria-hidden="true" tabindex="-1"></a>                                   Accessor<span class="op">&gt;&amp;</span> other,</span>
+<span id="cb21-35"><a href="#cb21-35" aria-hidden="true" tabindex="-1"></a>                      <span class="kw">const</span> Alloc<span class="op">&amp;</span> a<span class="op">)</span>;</span></code></pre></div>
+
+</div></td>
+<td><div>
+
+<div class="sourceCode" id="cb22"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb22-1"><a href="#cb22-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherElementType, <span class="kw">class</span> OtherExtents, </span>
+<span id="cb22-2"><a href="#cb22-2" aria-hidden="true" tabindex="-1"></a>           <span class="kw">class</span> OtherLayoutPolicy, <span class="kw">class</span> OtherContainer, </span>
+<span id="cb22-3"><a href="#cb22-3" aria-hidden="true" tabindex="-1"></a>           <span class="kw">class</span><span class="op">...</span> Args<span class="op">&gt;</span></span>
+<span id="cb22-4"><a href="#cb22-4" aria-hidden="true" tabindex="-1"></a>    <span class="kw">explicit</span><span class="op">(</span><em>see below</em><span class="op">)</span></span>
+<span id="cb22-5"><a href="#cb22-5" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> mdarray<span class="op">&lt;</span>OtherElementType,</span>
+<span id="cb22-6"><a href="#cb22-6" aria-hidden="true" tabindex="-1"></a>                                    OtherExtents, </span>
+<span id="cb22-7"><a href="#cb22-7" aria-hidden="true" tabindex="-1"></a>                                    OtherLayoutPolicy,</span>
+<span id="cb22-8"><a href="#cb22-8" aria-hidden="true" tabindex="-1"></a>                                    OtherContainer<span class="op">&gt;&amp;</span> other,</span>
+<span id="cb22-9"><a href="#cb22-9" aria-hidden="true" tabindex="-1"></a>                      Args<span class="op">&amp;&amp;...</span> args<span class="op">)</span>;</span>
+<span id="cb22-10"><a href="#cb22-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb22-11"><a href="#cb22-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherElementType, <span class="kw">class</span> OtherExtents,</span>
+<span id="cb22-12"><a href="#cb22-12" aria-hidden="true" tabindex="-1"></a>           <span class="kw">class</span> OtherLayoutPolicy, <span class="kw">class</span> Accessor,</span>
+<span id="cb22-13"><a href="#cb22-13" aria-hidden="true" tabindex="-1"></a>           <span class="kw">class</span><span class="op">...</span> Args<span class="op">&gt;</span></span>
+<span id="cb22-14"><a href="#cb22-14" aria-hidden="true" tabindex="-1"></a>    <span class="kw">explicit</span><span class="op">(</span><em>see below</em><span class="op">)</span></span>
+<span id="cb22-15"><a href="#cb22-15" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> mdspan<span class="op">&lt;</span>OtherElementType,</span>
+<span id="cb22-16"><a href="#cb22-16" aria-hidden="true" tabindex="-1"></a>                                   OtherExtents,</span>
+<span id="cb22-17"><a href="#cb22-17" aria-hidden="true" tabindex="-1"></a>                                   OtherLayoutPolicy,</span>
+<span id="cb22-18"><a href="#cb22-18" aria-hidden="true" tabindex="-1"></a>                                   Accessor<span class="op">&gt;&amp;</span> other,</span>
+<span id="cb22-19"><a href="#cb22-19" aria-hidden="true" tabindex="-1"></a>                      Args<span class="op">&amp;&amp;...</span> args<span class="op">)</span>;</span></code></pre></div>
+
+</div></td>
+</tr>
+<tr class="even">
+<td><div>
+
+<div class="sourceCode" id="cb23"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb23-1"><a href="#cb23-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> Container, <span class="kw">class</span><span class="op">...</span> Integrals<span class="op">&gt;</span></span>
+<span id="cb23-2"><a href="#cb23-2" aria-hidden="true" tabindex="-1"></a><span class="kw">requires</span><span class="op">((</span>is_convertible_v<span class="op">&lt;</span>Integrals, <span class="dt">size_t</span><span class="op">&gt;</span> <span class="op">&amp;&amp;</span> <span class="op">...)</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb23-3"><a href="#cb23-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">sizeof</span><span class="op">...(</span>Integrals<span class="op">)</span> <span class="op">&gt;</span> <span class="dv">0</span><span class="op">)</span></span>
+<span id="cb23-4"><a href="#cb23-4" aria-hidden="true" tabindex="-1"></a><span class="kw">explicit</span> mdarray<span class="op">(</span><span class="kw">const</span> Container<span class="op">&amp;</span>, Integrals<span class="op">...)</span></span>
+<span id="cb23-5"><a href="#cb23-5" aria-hidden="true" tabindex="-1"></a>  <span class="op">-&gt;</span> mdarray<span class="op">&lt;</span><span class="kw">typename</span> Container<span class="op">::</span>value_type,</span>
+<span id="cb23-6"><a href="#cb23-6" aria-hidden="true" tabindex="-1"></a>             dextents<span class="op">&lt;</span><span class="dt">size_t</span>, <span class="kw">sizeof</span><span class="op">...(</span>Integrals<span class="op">)&gt;</span>,</span>
+<span id="cb23-7"><a href="#cb23-7" aria-hidden="true" tabindex="-1"></a>             layout_right,</span>
+<span id="cb23-8"><a href="#cb23-8" aria-hidden="true" tabindex="-1"></a>             Container<span class="op">&gt;</span>;</span>
+<span id="cb23-9"><a href="#cb23-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb23-10"><a href="#cb23-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Container, <span class="kw">class</span> Extents<span class="op">&gt;</span></span>
+<span id="cb23-11"><a href="#cb23-11" aria-hidden="true" tabindex="-1"></a>mdarray<span class="op">(</span><span class="kw">const</span> Container<span class="op">&amp;</span>, <span class="kw">const</span> Extents<span class="op">&amp;)</span></span>
+<span id="cb23-12"><a href="#cb23-12" aria-hidden="true" tabindex="-1"></a>  <span class="op">-&gt;</span> mdarray<span class="op">&lt;</span><span class="kw">typename</span> Container<span class="op">::</span>value_type,</span>
+<span id="cb23-13"><a href="#cb23-13" aria-hidden="true" tabindex="-1"></a>             Extents,</span>
+<span id="cb23-14"><a href="#cb23-14" aria-hidden="true" tabindex="-1"></a>             layout_right,</span>
+<span id="cb23-15"><a href="#cb23-15" aria-hidden="true" tabindex="-1"></a>             Container<span class="op">&gt;</span>;</span>
+<span id="cb23-16"><a href="#cb23-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb23-17"><a href="#cb23-17" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Container, <span class="kw">class</span> Mapping<span class="op">&gt;</span></span>
+<span id="cb23-18"><a href="#cb23-18" aria-hidden="true" tabindex="-1"></a>mdarray<span class="op">(</span><span class="kw">const</span> Container<span class="op">&amp;</span>, <span class="kw">const</span> Mapping<span class="op">&amp;)</span></span>
+<span id="cb23-19"><a href="#cb23-19" aria-hidden="true" tabindex="-1"></a>  <span class="op">-&gt;</span> mdarray<span class="op">&lt;</span><span class="kw">typename</span> Container<span class="op">::</span>value_type,</span>
+<span id="cb23-20"><a href="#cb23-20" aria-hidden="true" tabindex="-1"></a>             <span class="kw">typename</span> Mapping<span class="op">::</span>extents_type,</span>
+<span id="cb23-21"><a href="#cb23-21" aria-hidden="true" tabindex="-1"></a>             layout_right,</span>
+<span id="cb23-22"><a href="#cb23-22" aria-hidden="true" tabindex="-1"></a>             Container<span class="op">&gt;</span>;</span>
+<span id="cb23-23"><a href="#cb23-23" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb23-24"><a href="#cb23-24" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> Container, <span class="kw">class</span><span class="op">...</span> Integrals<span class="op">&gt;</span></span>
+<span id="cb23-25"><a href="#cb23-25" aria-hidden="true" tabindex="-1"></a><span class="kw">requires</span><span class="op">((</span>is_convertible_v<span class="op">&lt;</span>Integrals, <span class="dt">size_t</span><span class="op">&gt;</span> <span class="op">&amp;&amp;</span> <span class="op">...)</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb23-26"><a href="#cb23-26" aria-hidden="true" tabindex="-1"></a>         <span class="kw">sizeof</span><span class="op">...(</span>Integrals<span class="op">)</span> <span class="op">&gt;</span> <span class="dv">0</span><span class="op">)</span></span>
+<span id="cb23-27"><a href="#cb23-27" aria-hidden="true" tabindex="-1"></a><span class="kw">explicit</span> mdarray<span class="op">(</span>Container<span class="op">&amp;&amp;</span>, Integrals<span class="op">...)</span></span>
+<span id="cb23-28"><a href="#cb23-28" aria-hidden="true" tabindex="-1"></a>  <span class="op">-&gt;</span> mdarray<span class="op">&lt;</span><span class="kw">typename</span> Container<span class="op">::</span>value_type,</span>
+<span id="cb23-29"><a href="#cb23-29" aria-hidden="true" tabindex="-1"></a>             dextents<span class="op">&lt;</span><span class="dt">size_t</span>, <span class="kw">sizeof</span><span class="op">...(</span>Integrals<span class="op">)&gt;</span>,</span>
+<span id="cb23-30"><a href="#cb23-30" aria-hidden="true" tabindex="-1"></a>             layout_right,</span>
+<span id="cb23-31"><a href="#cb23-31" aria-hidden="true" tabindex="-1"></a>             Container<span class="op">&gt;</span>;</span>
+<span id="cb23-32"><a href="#cb23-32" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb23-33"><a href="#cb23-33" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Container, <span class="kw">class</span> Extents<span class="op">&gt;</span></span>
+<span id="cb23-34"><a href="#cb23-34" aria-hidden="true" tabindex="-1"></a>mdarray<span class="op">(</span>Container<span class="op">&amp;&amp;</span>, <span class="kw">const</span> Extents<span class="op">&amp;)</span></span>
+<span id="cb23-35"><a href="#cb23-35" aria-hidden="true" tabindex="-1"></a>  <span class="op">-&gt;</span> mdarray<span class="op">&lt;</span><span class="kw">typename</span> Container<span class="op">::</span>value_type,</span>
+<span id="cb23-36"><a href="#cb23-36" aria-hidden="true" tabindex="-1"></a>             Extents,</span>
+<span id="cb23-37"><a href="#cb23-37" aria-hidden="true" tabindex="-1"></a>             layout_right,</span>
+<span id="cb23-38"><a href="#cb23-38" aria-hidden="true" tabindex="-1"></a>             Container<span class="op">&gt;</span>;</span>
+<span id="cb23-39"><a href="#cb23-39" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb23-40"><a href="#cb23-40" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Container, <span class="kw">class</span> Mapping<span class="op">&gt;</span></span>
+<span id="cb23-41"><a href="#cb23-41" aria-hidden="true" tabindex="-1"></a>mdarray<span class="op">(</span>Container<span class="op">&amp;&amp;</span>, <span class="kw">const</span> Mapping<span class="op">&amp;)</span></span>
+<span id="cb23-42"><a href="#cb23-42" aria-hidden="true" tabindex="-1"></a>  <span class="op">-&gt;</span> mdarray<span class="op">&lt;</span><span class="kw">typename</span> Container<span class="op">::</span>value_type,</span>
+<span id="cb23-43"><a href="#cb23-43" aria-hidden="true" tabindex="-1"></a>             <span class="kw">typename</span> Mapping<span class="op">::</span>extents_type,</span>
+<span id="cb23-44"><a href="#cb23-44" aria-hidden="true" tabindex="-1"></a>             layout_right,</span>
+<span id="cb23-45"><a href="#cb23-45" aria-hidden="true" tabindex="-1"></a>             Container<span class="op">&gt;</span>;</span>
+<span id="cb23-46"><a href="#cb23-46" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb23-47"><a href="#cb23-47" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ElementType, <span class="kw">class</span> Extents,</span>
+<span id="cb23-48"><a href="#cb23-48" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Layout, <span class="kw">class</span> Accessor<span class="op">&gt;</span></span>
+<span id="cb23-49"><a href="#cb23-49" aria-hidden="true" tabindex="-1"></a>mdarray<span class="op">(</span><span class="kw">const</span> mdspan<span class="op">&lt;</span>ElementType, Extents, Layout, Accessor<span class="op">&gt;&amp;)</span></span>
+<span id="cb23-50"><a href="#cb23-50" aria-hidden="true" tabindex="-1"></a>  <span class="op">-&gt;</span> mdarray<span class="op">&lt;</span>ElementType,</span>
+<span id="cb23-51"><a href="#cb23-51" aria-hidden="true" tabindex="-1"></a>             Extents,</span>
+<span id="cb23-52"><a href="#cb23-52" aria-hidden="true" tabindex="-1"></a>             Layout<span class="op">&gt;</span>;</span>
+<span id="cb23-53"><a href="#cb23-53" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb23-54"><a href="#cb23-54" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Container, <span class="kw">class</span> Extents, <span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
+<span id="cb23-55"><a href="#cb23-55" aria-hidden="true" tabindex="-1"></a>mdarray<span class="op">(</span><span class="kw">const</span> Container<span class="op">&amp;</span>, <span class="kw">const</span> Extents<span class="op">&amp;</span>, <span class="kw">const</span> Alloc<span class="op">&amp;)</span></span>
+<span id="cb23-56"><a href="#cb23-56" aria-hidden="true" tabindex="-1"></a>  <span class="op">-&gt;</span> mdarray<span class="op">&lt;</span><span class="kw">typename</span> Container<span class="op">::</span>value_type,</span>
+<span id="cb23-57"><a href="#cb23-57" aria-hidden="true" tabindex="-1"></a>             Extents,</span>
+<span id="cb23-58"><a href="#cb23-58" aria-hidden="true" tabindex="-1"></a>             layout_right,</span>
+<span id="cb23-59"><a href="#cb23-59" aria-hidden="true" tabindex="-1"></a>             Container<span class="op">&gt;</span>;</span>
+<span id="cb23-60"><a href="#cb23-60" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb23-61"><a href="#cb23-61" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Container, <span class="kw">class</span> Mapping, <span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
+<span id="cb23-62"><a href="#cb23-62" aria-hidden="true" tabindex="-1"></a>mdarray<span class="op">(</span><span class="kw">const</span> Container<span class="op">&amp;</span>, <span class="kw">const</span> Mapping<span class="op">&amp;</span>, <span class="kw">const</span> Alloc<span class="op">&amp;)</span></span>
+<span id="cb23-63"><a href="#cb23-63" aria-hidden="true" tabindex="-1"></a>  <span class="op">-&gt;</span> mdarray<span class="op">&lt;</span><span class="kw">typename</span> Container<span class="op">::</span>value_type,</span>
+<span id="cb23-64"><a href="#cb23-64" aria-hidden="true" tabindex="-1"></a>             <span class="kw">typename</span> Mapping<span class="op">::</span>extents_type,</span>
+<span id="cb23-65"><a href="#cb23-65" aria-hidden="true" tabindex="-1"></a>             layout_right,</span>
+<span id="cb23-66"><a href="#cb23-66" aria-hidden="true" tabindex="-1"></a>             Container<span class="op">&gt;</span>;</span>
+<span id="cb23-67"><a href="#cb23-67" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb23-68"><a href="#cb23-68" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Container, <span class="kw">class</span> Extents, <span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
+<span id="cb23-69"><a href="#cb23-69" aria-hidden="true" tabindex="-1"></a>mdarray<span class="op">(</span>Container<span class="op">&amp;&amp;</span>, <span class="kw">const</span> Extents<span class="op">&amp;</span>, <span class="kw">const</span> Alloc<span class="op">&amp;)</span></span>
+<span id="cb23-70"><a href="#cb23-70" aria-hidden="true" tabindex="-1"></a>  <span class="op">-&gt;</span> mdarray<span class="op">&lt;</span><span class="kw">typename</span> Container<span class="op">::</span>value_type,</span>
+<span id="cb23-71"><a href="#cb23-71" aria-hidden="true" tabindex="-1"></a>             Extents,</span>
+<span id="cb23-72"><a href="#cb23-72" aria-hidden="true" tabindex="-1"></a>             layout_right,</span>
+<span id="cb23-73"><a href="#cb23-73" aria-hidden="true" tabindex="-1"></a>             Container<span class="op">&gt;</span>;</span>
+<span id="cb23-74"><a href="#cb23-74" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb23-75"><a href="#cb23-75" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Container, <span class="kw">class</span> Mapping, <span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
+<span id="cb23-76"><a href="#cb23-76" aria-hidden="true" tabindex="-1"></a>mdarray<span class="op">(</span>Container<span class="op">&amp;&amp;</span>, <span class="kw">const</span> Mapping<span class="op">&amp;</span>, <span class="kw">const</span> Alloc<span class="op">&amp;)</span></span>
+<span id="cb23-77"><a href="#cb23-77" aria-hidden="true" tabindex="-1"></a>  <span class="op">-&gt;</span> mdarray<span class="op">&lt;</span><span class="kw">typename</span> Container<span class="op">::</span>value_type,</span>
+<span id="cb23-78"><a href="#cb23-78" aria-hidden="true" tabindex="-1"></a>             <span class="kw">typename</span> Mapping<span class="op">::</span>extents_type,</span>
+<span id="cb23-79"><a href="#cb23-79" aria-hidden="true" tabindex="-1"></a>             layout_right,</span>
+<span id="cb23-80"><a href="#cb23-80" aria-hidden="true" tabindex="-1"></a>             Container<span class="op">&gt;</span>;</span>
+<span id="cb23-81"><a href="#cb23-81" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb23-82"><a href="#cb23-82" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ElementType, <span class="kw">class</span> Extents,</span>
+<span id="cb23-83"><a href="#cb23-83" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Layout, <span class="kw">class</span> Accessor, <span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
+<span id="cb23-84"><a href="#cb23-84" aria-hidden="true" tabindex="-1"></a>mdarray<span class="op">(</span><span class="kw">const</span> mdspan<span class="op">&lt;</span>ElementType, Extents, Layout, Accessor<span class="op">&gt;&amp;</span>,</span>
+<span id="cb23-85"><a href="#cb23-85" aria-hidden="true" tabindex="-1"></a>        <span class="kw">const</span> Alloc<span class="op">&amp;)</span></span>
+<span id="cb23-86"><a href="#cb23-86" aria-hidden="true" tabindex="-1"></a>  <span class="op">-&gt;</span> mdarray<span class="op">&lt;</span>ElementType,</span>
+<span id="cb23-87"><a href="#cb23-87" aria-hidden="true" tabindex="-1"></a>             Extents,</span>
+<span id="cb23-88"><a href="#cb23-88" aria-hidden="true" tabindex="-1"></a>             Layout<span class="op">&gt;</span>;</span></code></pre></div>
+
+</div></td>
+<td><div>
+
+<div class="sourceCode" id="cb24"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb24-1"><a href="#cb24-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Container, <span class="kw">class</span><span class="op">...</span> Integrals<span class="op">&gt;</span></span>
+<span id="cb24-2"><a href="#cb24-2" aria-hidden="true" tabindex="-1"></a><span class="kw">requires</span><span class="op">((</span>is_convertible_v<span class="op">&lt;</span>Integrals, <span class="dt">size_t</span><span class="op">&gt;</span> <span class="op">&amp;&amp;</span> <span class="op">...)</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb24-3"><a href="#cb24-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">sizeof</span><span class="op">...(</span>Integrals<span class="op">)</span> <span class="op">&gt;</span> <span class="dv">0</span><span class="op">)</span></span>
+<span id="cb24-4"><a href="#cb24-4" aria-hidden="true" tabindex="-1"></a>mdarray<span class="op">(</span>Container<span class="op">&amp;&amp;</span>,</span>
+<span id="cb24-5"><a href="#cb24-5" aria-hidden="true" tabindex="-1"></a>        Integrals<span class="op">...)</span></span>
+<span id="cb24-6"><a href="#cb24-6" aria-hidden="true" tabindex="-1"></a>  <span class="op">-&gt;</span> mdarray<span class="op">&lt;</span><span class="kw">typename</span> Container<span class="op">::</span>value_type,</span>
+<span id="cb24-7"><a href="#cb24-7" aria-hidden="true" tabindex="-1"></a>             dextents<span class="op">&lt;</span><span class="dt">size_t</span>, <span class="kw">sizeof</span><span class="op">...(</span>Integrals<span class="op">)&gt;</span>,</span>
+<span id="cb24-8"><a href="#cb24-8" aria-hidden="true" tabindex="-1"></a>             layout_right,</span>
+<span id="cb24-9"><a href="#cb24-9" aria-hidden="true" tabindex="-1"></a>             remove_const_t<span class="op">&lt;</span>remove_reference_t<span class="op">&lt;</span>Container<span class="op">&gt;&gt;&gt;</span>;</span>
+<span id="cb24-10"><a href="#cb24-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb24-11"><a href="#cb24-11" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Container, <span class="kw">class</span> IndexType, <span class="dt">size_t</span><span class="op">...</span> Extents<span class="op">&gt;</span></span>
+<span id="cb24-12"><a href="#cb24-12" aria-hidden="true" tabindex="-1"></a>mdarray<span class="op">(</span><span class="kw">const</span> extents<span class="op">&lt;</span>IndexType, Extents<span class="op">...&gt;&amp;</span>,</span>
+<span id="cb24-13"><a href="#cb24-13" aria-hidden="true" tabindex="-1"></a>        Container<span class="op">&amp;&amp;)</span></span>
+<span id="cb24-14"><a href="#cb24-14" aria-hidden="true" tabindex="-1"></a>  <span class="op">-&gt;</span> mdarray<span class="op">&lt;</span><span class="kw">typename</span> Container<span class="op">::</span>value_type,</span>
+<span id="cb24-15"><a href="#cb24-15" aria-hidden="true" tabindex="-1"></a>             extents<span class="op">&lt;</span>IndexType, Extents<span class="op">...&gt;</span>,</span>
+<span id="cb24-16"><a href="#cb24-16" aria-hidden="true" tabindex="-1"></a>             layout_right,</span>
+<span id="cb24-17"><a href="#cb24-17" aria-hidden="true" tabindex="-1"></a>             remove_const_t<span class="op">&lt;</span>remove_reference_t<span class="op">&lt;</span>Container<span class="op">&gt;&gt;&gt;</span>;</span>
+<span id="cb24-18"><a href="#cb24-18" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb24-19"><a href="#cb24-19" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Container, <span class="kw">class</span> IndexType, <span class="dt">size_t</span><span class="op">...</span> Extents<span class="op">&gt;</span></span>
+<span id="cb24-20"><a href="#cb24-20" aria-hidden="true" tabindex="-1"></a>mdarray<span class="op">(</span><span class="kw">const</span> layout_left<span class="op">::</span>mapping<span class="op">&lt;</span>extents<span class="op">&lt;</span>IndexType, Extents<span class="op">...&gt;&gt;&amp;</span>,</span>
+<span id="cb24-21"><a href="#cb24-21" aria-hidden="true" tabindex="-1"></a>        Container<span class="op">&amp;&amp;)</span></span>
+<span id="cb24-22"><a href="#cb24-22" aria-hidden="true" tabindex="-1"></a>  <span class="op">-&gt;</span> mdarray<span class="op">&lt;</span><span class="kw">typename</span> Container<span class="op">::</span>value_type,</span>
+<span id="cb24-23"><a href="#cb24-23" aria-hidden="true" tabindex="-1"></a>             extents<span class="op">&lt;</span>IndexType, Extents<span class="op">...&gt;</span>,</span>
+<span id="cb24-24"><a href="#cb24-24" aria-hidden="true" tabindex="-1"></a>             layout_left,</span>
+<span id="cb24-25"><a href="#cb24-25" aria-hidden="true" tabindex="-1"></a>             remove_const_t<span class="op">&lt;</span>remove_reference_t<span class="op">&lt;</span>Container<span class="op">&gt;&gt;&gt;</span>;</span>
+<span id="cb24-26"><a href="#cb24-26" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb24-27"><a href="#cb24-27" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Container, <span class="kw">class</span> IndexType, <span class="dt">size_t</span><span class="op">...</span> Extents<span class="op">&gt;</span></span>
+<span id="cb24-28"><a href="#cb24-28" aria-hidden="true" tabindex="-1"></a>mdarray<span class="op">(</span><span class="kw">const</span> layout_right<span class="op">::</span>mapping<span class="op">&lt;</span>extents<span class="op">&lt;</span>IndexType, Extents<span class="op">...&gt;&gt;&amp;</span>,</span>
+<span id="cb24-29"><a href="#cb24-29" aria-hidden="true" tabindex="-1"></a>        Container<span class="op">&amp;&amp;)</span></span>
+<span id="cb24-30"><a href="#cb24-30" aria-hidden="true" tabindex="-1"></a>  <span class="op">-&gt;</span> mdarray<span class="op">&lt;</span><span class="kw">typename</span> Container<span class="op">::</span>value_type,</span>
+<span id="cb24-31"><a href="#cb24-31" aria-hidden="true" tabindex="-1"></a>             extents<span class="op">&lt;</span>IndexType, Extents<span class="op">...&gt;</span>,</span>
+<span id="cb24-32"><a href="#cb24-32" aria-hidden="true" tabindex="-1"></a>             layout_right,</span>
+<span id="cb24-33"><a href="#cb24-33" aria-hidden="true" tabindex="-1"></a>             remove_const_t<span class="op">&lt;</span>remove_reference_t<span class="op">&lt;</span>Container<span class="op">&gt;&gt;&gt;</span>;</span>
+<span id="cb24-34"><a href="#cb24-34" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb24-35"><a href="#cb24-35" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Container, <span class="kw">class</span> IndexType, <span class="dt">size_t</span><span class="op">...</span> Extents<span class="op">&gt;</span></span>
+<span id="cb24-36"><a href="#cb24-36" aria-hidden="true" tabindex="-1"></a>mdarray<span class="op">(</span><span class="kw">const</span> layout_stride<span class="op">::</span>mapping<span class="op">&lt;</span>extents<span class="op">&lt;</span>IndexType, Extents<span class="op">...&gt;&gt;&amp;</span>,</span>
+<span id="cb24-37"><a href="#cb24-37" aria-hidden="true" tabindex="-1"></a>        Container<span class="op">&amp;&amp;)</span></span>
+<span id="cb24-38"><a href="#cb24-38" aria-hidden="true" tabindex="-1"></a>  <span class="op">-&gt;</span> mdarray<span class="op">&lt;</span><span class="kw">typename</span> Container<span class="op">::</span>value_type,</span>
+<span id="cb24-39"><a href="#cb24-39" aria-hidden="true" tabindex="-1"></a>             extents<span class="op">&lt;</span>IndexType, Extents<span class="op">...&gt;</span>,</span>
+<span id="cb24-40"><a href="#cb24-40" aria-hidden="true" tabindex="-1"></a>             layout_stride,</span>
+<span id="cb24-41"><a href="#cb24-41" aria-hidden="true" tabindex="-1"></a>             remove_const_t<span class="op">&lt;</span>remove_reference_t<span class="op">&lt;</span>Container<span class="op">&gt;&gt;&gt;</span>;</span>
+<span id="cb24-42"><a href="#cb24-42" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb24-43"><a href="#cb24-43" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ElementType, <span class="kw">class</span> Extents,</span>
+<span id="cb24-44"><a href="#cb24-44" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Layout, <span class="kw">class</span> Accessor<span class="op">&gt;</span></span>
+<span id="cb24-45"><a href="#cb24-45" aria-hidden="true" tabindex="-1"></a>mdarray<span class="op">(</span><span class="kw">const</span> mdspan<span class="op">&lt;</span>ElementType, Extents, Layout, Accessor<span class="op">&gt;&amp;)</span></span>
+<span id="cb24-46"><a href="#cb24-46" aria-hidden="true" tabindex="-1"></a>  <span class="op">-&gt;</span> mdarray<span class="op">&lt;</span>ElementType,</span>
+<span id="cb24-47"><a href="#cb24-47" aria-hidden="true" tabindex="-1"></a>             Extents,</span>
+<span id="cb24-48"><a href="#cb24-48" aria-hidden="true" tabindex="-1"></a>             Layout<span class="op">&gt;</span>;</span>
+<span id="cb24-49"><a href="#cb24-49" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb24-50"><a href="#cb24-50" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Container,</span>
+<span id="cb24-51"><a href="#cb24-51" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> ElementType, <span class="kw">class</span> Extents,</span>
+<span id="cb24-52"><a href="#cb24-52" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Layout, <span class="kw">class</span> Accessor<span class="op">&gt;</span></span>
+<span id="cb24-53"><a href="#cb24-53" aria-hidden="true" tabindex="-1"></a>mdarray<span class="op">(</span><span class="kw">const</span> mdspan<span class="op">&lt;</span>ElementType, Extents, Layout, Accessor<span class="op">&gt;&amp;</span>,</span>
+<span id="cb24-54"><a href="#cb24-54" aria-hidden="true" tabindex="-1"></a>        Container<span class="op">&amp;&amp;)</span></span>
+<span id="cb24-55"><a href="#cb24-55" aria-hidden="true" tabindex="-1"></a>  <span class="op">-&gt;</span> mdarray<span class="op">&lt;</span>ElementType,</span>
+<span id="cb24-56"><a href="#cb24-56" aria-hidden="true" tabindex="-1"></a>             Extents,</span>
+<span id="cb24-57"><a href="#cb24-57" aria-hidden="true" tabindex="-1"></a>             Layout,</span>
+<span id="cb24-58"><a href="#cb24-58" aria-hidden="true" tabindex="-1"></a>             remove_const_t<span class="op">&lt;</span>remove_reference_t<span class="op">&lt;</span>Container<span class="op">&gt;&gt;&gt;</span>;</span></code></pre></div>
+
+</div></td>
+</tr>
+</tbody>
+</table>
+<h2 data-number="3.3" id="extents-design-reused"><span class="header-section-number">3.3</span>
+<code class="sourceCode default">Extents</code> design reused<a href="#extents-design-reused" class="self-link"></a></h2>
+<p>As with <code class="sourceCode default">mdspan</code>, the
+<code class="sourceCode default">Extents</code> template parameter to
+<code class="sourceCode default">mdarray</code> shall be a template
+instantiation of <code class="sourceCode default">std::extents</code>,
+as described in <span class="citation" data-cites="P0009R18">[<a href="#ref-P0009R18" role="doc-biblioref">P0009R18</a>]</span>. The
+concerns addressed by this aspect of the design are exactly the same in
+<code class="sourceCode default">mdarray</code> and
+<code class="sourceCode default">mdspan</code>, so using the same form
+and mechanism seems like the right thing to do here.</p>
+<h2 data-number="3.4" id="layoutpolicy-design-reused"><span class="header-section-number">3.4</span>
+<code class="sourceCode default">LayoutPolicy</code> design reused<a href="#layoutpolicy-design-reused" class="self-link"></a></h2>
+<p>While not quite as straightforward, the decision to use the same
+design for <code class="sourceCode default">LayoutPolicy</code> from
+<code class="sourceCode default">mdspan</code> in
+<code class="sourceCode default">mdarray</code> is still quite obviously
+the best choice. The only pieces are perhaps a less perfect fit are the
+<code class="sourceCode default">is_contiguous()</code> and
+<code class="sourceCode default">is_always_contiguous()</code>
+requirements. While noncontiguous use cases for
+<code class="sourceCode default">mdspan</code> are quite common (e.g.,
+<code class="sourceCode default">subspan()</code>), noncontiguous use
+cases for <code class="sourceCode default">mdarray</code> are expected
+to be a bit more arcane. Nonetheless, reasonable use cases do exist (for
+instance, padding of the fast-running dimension in anticipation of a
+resize operation), and the reduction in cognitive load due to concept
+reuse certainly justifies reusing
+<code class="sourceCode default">LayoutPolicy</code> for
+<code class="sourceCode default">mdarray</code>.</p>
+<h2 data-number="3.5" id="accessorpolicy-replaced-by-container"><span class="header-section-number">3.5</span>
+<code class="sourceCode default">AccessorPolicy</code> replaced by
+<code class="sourceCode default">Container</code><a href="#accessorpolicy-replaced-by-container" class="self-link"></a></h2>
+<p>By far the most complicated aspect of the design for
+<code class="sourceCode default">mdarray</code> is the analog of the
+<code class="sourceCode default">AccessorPolicy</code> in
+<code class="sourceCode default">mdspan</code>. The
+<code class="sourceCode default">AccessorPolicy</code> for
+<code class="sourceCode default">mdspan</code> is designed for nonowning
+semantics. It provides a <code class="sourceCode default">pointer</code>
+type, a <code class="sourceCode default">reference</code> type, and a
+means of converting from a pointer and an offset to a reference. Beyond
+the lack of an allocation mechanism (that would be needed by
+<code class="sourceCode default">mdarray</code>), the
+<code class="sourceCode default">AccessorPolicy</code> requirements
+address concerns normally addressed by the allocation mechanism itself.
+For instance, the C++ named requirements for
+<code class="sourceCode default">Allocator</code> allow for the
+provision of the <code class="sourceCode default">pointer</code> type to
+<code class="sourceCode default">std::vector</code> and other
+containers. Arguably, consistency between
+<code class="sourceCode default">mdarray</code> and standard library
+containers is far more important than with
+<code class="sourceCode default">mdspan</code> in this respect. Several
+approaches to addressing this incongruity are discussed below.</p>
+<h3 data-number="3.5.1" id="expected-behavior-of-motivating-use-cases"><span class="header-section-number">3.5.1</span> Expected behavior of
+motivating use cases<a href="#expected-behavior-of-motivating-use-cases" class="self-link"></a></h3>
+<p>Regardless of the form of the solution, there are several use cases
+where we have a clear understanding of how we want them to work. As
+alluded to above, perhaps <em>the</em> most important motivating use
+case for <code class="sourceCode default">mdarray</code> is that of
+small, fixed-size extents. Consider a fictitious (not proposed)
+function, <em>get-underlying-container</em>, that somehow retrieves the
+underlying storage of an
+<code class="sourceCode default">mdarray</code>. For an
+<code class="sourceCode default">mdarray</code> of entirely fixed sizes,
+we would expect the default implementation to return something that is
+(at the very least) convertible to
+<code class="sourceCode default">array</code> of the correct size:</p>
+<div class="sourceCode" id="cb25"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb25-1"><a href="#cb25-1" aria-hidden="true" tabindex="-1"></a><span class="kw">auto</span> a <span class="op">=</span> mdarray<span class="op">&lt;</span><span class="dt">int</span>, <span class="dv">3</span>, <span class="dv">3</span><span class="op">&gt;()</span>;</span>
+<span id="cb25-2"><a href="#cb25-2" aria-hidden="true" tabindex="-1"></a>std<span class="op">::</span>array<span class="op">&lt;</span><span class="dt">int</span>, <span class="dv">9</span><span class="op">&gt;</span> data <span class="op">=</span> <em>get-underlying-container</em><span class="op">(</span>a<span class="op">)</span>; </span></code></pre></div>
+<p>(Whether or not a reference to the underlying container should be
+obtainable is slightly less clear, though we see no reason why this
+should not be allowed.) The default for an
+<code class="sourceCode default">mdarray</code> with variable extents is
+only slightly less clear, though it should almost certainly meet the
+requirements of <em>contiguous container</em>
+(<strong>[container.requirements.general]</strong>/13). The default
+model for <em>contiguous container</em> of variable size in the standard
+library is <code class="sourceCode default">vector</code>, so an
+entirely reasonable outcome would be to have:</p>
+<div class="sourceCode" id="cb26"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb26-1"><a href="#cb26-1" aria-hidden="true" tabindex="-1"></a><span class="kw">auto</span> a <span class="op">=</span> mdarray<span class="op">&lt;</span><span class="dt">int</span>, <span class="dv">3</span>, dynamic_extent<span class="op">&gt;()</span>;</span>
+<span id="cb26-2"><a href="#cb26-2" aria-hidden="true" tabindex="-1"></a>std<span class="op">::</span>vector<span class="op">&lt;</span><span class="dt">int</span><span class="op">&gt;</span> data <span class="op">=</span> <em>get-underlying-container</em><span class="op">(</span>a<span class="op">)</span>; </span></code></pre></div>
+<p>Moreover, taking a view of a
+<code class="sourceCode default">mdarray</code> should yield an
+analogous <code class="sourceCode default">mdspan</code> with consistent
+semantics (except, of course, that the latter is nonowning). We
+provisionally call the method for taking a view of an
+<code class="sourceCode default">mdarray</code>
+“<code class="sourceCode default">to_mdspan()</code>”:</p>
+<div class="sourceCode" id="cb27"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb27-1"><a href="#cb27-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T, <span class="kw">class</span> Extents, <span class="kw">class</span> LayoutPolicy, <span class="kw">class</span> ContainerPolicy<span class="op">&gt;</span></span>
+<span id="cb27-2"><a href="#cb27-2" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> frobnicate<span class="op">(</span>mdarray<span class="op">&lt;</span>T, Extents, LayoutPolicy, ContainerPolicy<span class="op">&gt;</span> data<span class="op">)</span></span>
+<span id="cb27-3"><a href="#cb27-3" aria-hidden="true" tabindex="-1"></a><span class="op">{</span></span>
+<span id="cb27-4"><a href="#cb27-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">auto</span> data_view <span class="op">=</span> data<span class="op">.</span>to_mdspan<span class="op">()</span>;</span>
+<span id="cb27-5"><a href="#cb27-5" aria-hidden="true" tabindex="-1"></a>  <span class="co">/* ... */</span></span>
+<span id="cb27-6"><a href="#cb27-6" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<p>In order for this to work,
+<code class="sourceCode default">Container::data()</code> should be
+required to return <code class="sourceCode default">T*</code>. That way,
+interoperability with <code class="sourceCode default">mdspan</code> is
+trivial, since it can simply be created as:</p>
+<div class="sourceCode" id="cb28"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb28-1"><a href="#cb28-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T, <span class="kw">class</span> Extents, <span class="kw">class</span> LayoutPolicy, <span class="kw">class</span> Container<span class="op">&gt;</span></span>
+<span id="cb28-2"><a href="#cb28-2" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> frobnicate<span class="op">(</span>mdarray<span class="op">&lt;</span>T, Extents, LayoutPolicy, Container<span class="op">&gt;</span> a<span class="op">)</span></span>
+<span id="cb28-3"><a href="#cb28-3" aria-hidden="true" tabindex="-1"></a><span class="op">{</span></span>
+<span id="cb28-4"><a href="#cb28-4" aria-hidden="true" tabindex="-1"></a>  mdspan a_view<span class="op">(</span>a<span class="op">.</span>data<span class="op">()</span>, a<span class="op">.</span>mapping<span class="op">())</span>;</span>
+<span id="cb28-5"><a href="#cb28-5" aria-hidden="true" tabindex="-1"></a>  <span class="co">/* ... */</span></span>
+<span id="cb28-6"><a href="#cb28-6" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<h3 data-number="3.5.2" id="analogs-in-the-standard-library-container-adapters"><span class="header-section-number">3.5.2</span> Analogs in the standard
+library: Container adapters<a href="#analogs-in-the-standard-library-container-adapters" class="self-link"></a></h3>
+<p>Perhaps the best analogs for what
+<code class="sourceCode default">mdarray</code> is doing with respect to
+allocation and ownership are the container adaptors
+(<strong>[container.adaptors]</strong>), since they imbue additional
+semantics to what is otherwise an ordinary container. These all take a
+<code class="sourceCode default">Container</code> template parameter,
+which defaults to <code class="sourceCode default">deque</code> for
+<code class="sourceCode default">stack</code> and
+<code class="sourceCode default">queue</code>, and to
+<code class="sourceCode default">vector</code> for
+<code class="sourceCode default">priority_queue</code>. The allocation
+concern is thus delegated to the container concept, reducing the
+cognitive load associated with the design. While this design approach
+overconstrains the template parameter slightly (that is, not all of the
+requirements of the <code class="sourceCode default">Container</code>
+concept are needed by the container adaptors), the simplicity arising
+from concept reuse more than justifies the cost of the extra
+constraints.</p>
+<p>It is difficult to say whether the use of
+<code class="sourceCode default">Container</code> directly, as with the
+container adaptors, is also the correct approach for
+<code class="sourceCode default">mdarray</code>. There are pieces of
+information that may need to be customized in some very reasonable use
+cases that are not provided by the standard container concept. The most
+important of these is the ability to produce a semantically consistent
+<code class="sourceCode default">AccessorPolicy</code> when creating a
+<code class="sourceCode default">mdspan</code> that refers to a
+<code class="sourceCode default">mdarray</code>. (Interoperability
+between <code class="sourceCode default">mdspan</code> and
+<code class="sourceCode default">mdarray</code> is considered a critical
+design requirement because of the nearly complete overlap in the set of
+algorithms that operate on them.) For instance, given a
+<code class="sourceCode default">Container</code> instance
+<code class="sourceCode default">c</code> and an
+<code class="sourceCode default">AccessorPolicy</code> instance
+<code class="sourceCode default">a</code>, the behavior of
+<code class="sourceCode default">a.access(p, n)</code> should be
+consistent with the behavior of
+<code class="sourceCode default">c[n]</code> for a
+<code class="sourceCode default">mdspan</code> wrapping
+<code class="sourceCode default">a</code> that is a view of a
+<code class="sourceCode default">mdarray</code> wrapping
+<code class="sourceCode default">c</code> (if
+<code class="sourceCode default">p</code> is
+<code class="sourceCode default">c.begin()</code>). But because
+<code class="sourceCode default">c[n]</code> is part of the container
+requirements and thus may encapsulate any arbitrary mapping from an
+offset of <code class="sourceCode default">c.begin()</code> to a
+reference, the only reasonable means of preserving these semantics for
+arbitrary container types is to reference the original container
+directly in the corresponding
+<code class="sourceCode default">AccessorPolicy</code>. In other words,
+the signature for the <code class="sourceCode default">view()</code>
+method of <code class="sourceCode default">mdarray</code> would need to
+look something like (ignoring, for the moment, whether the name for the
+type of the accessor is specified or implementation-defined):</p>
+<div class="sourceCode" id="cb29"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb29-1"><a href="#cb29-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ElementType,</span>
+<span id="cb29-2"><a href="#cb29-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Extents,</span>
+<span id="cb29-3"><a href="#cb29-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> LayoutPolicy,</span>
+<span id="cb29-4"><a href="#cb29-4" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Container<span class="op">&gt;</span></span>
+<span id="cb29-5"><a href="#cb29-5" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> mdarray <span class="op">{</span></span>
+<span id="cb29-6"><a href="#cb29-6" aria-hidden="true" tabindex="-1"></a> <span class="co">/* ... */</span></span>
+<span id="cb29-7"><a href="#cb29-7" aria-hidden="true" tabindex="-1"></a> mdspan<span class="op">&lt;</span></span>
+<span id="cb29-8"><a href="#cb29-8" aria-hidden="true" tabindex="-1"></a>   ElementType, Extents, LayoutPolicy,</span>
+<span id="cb29-9"><a href="#cb29-9" aria-hidden="true" tabindex="-1"></a>   container_reference_accessor<span class="op">&lt;</span>Container<span class="op">&gt;&gt;</span></span>
+<span id="cb29-10"><a href="#cb29-10" aria-hidden="true" tabindex="-1"></a> view<span class="op">()</span> <span class="kw">const</span> <span class="kw">noexcept</span>;</span>
+<span id="cb29-11"><a href="#cb29-11" aria-hidden="true" tabindex="-1"></a> <span class="co">/* ... */</span></span>
+<span id="cb29-12"><a href="#cb29-12" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
+<span id="cb29-13"><a href="#cb29-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb29-14"><a href="#cb29-14" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> Container<span class="op">&gt;</span></span>
+<span id="cb29-15"><a href="#cb29-15" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> __container_reference_accessor <span class="op">{</span> <span class="co">// not proposed</span></span>
+<span id="cb29-16"><a href="#cb29-16" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> pointer <span class="op">=</span> Container<span class="op">*</span>;</span>
+<span id="cb29-17"><a href="#cb29-17" aria-hidden="true" tabindex="-1"></a>  <span class="co">/* ... */</span></span>
+<span id="cb29-18"><a href="#cb29-18" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> Integer<span class="op">&gt;</span></span>
+<span id="cb29-19"><a href="#cb29-19" aria-hidden="true" tabindex="-1"></a>  reference access<span class="op">(</span>pointer p, Integer offset<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb29-20"><a href="#cb29-20" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> <span class="op">(*</span>p<span class="op">)[</span>offset<span class="op">]</span>;</span>
+<span id="cb29-21"><a href="#cb29-21" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb29-22"><a href="#cb29-22" aria-hidden="true" tabindex="-1"></a>  <span class="co">/* ... */</span></span>
+<span id="cb29-23"><a href="#cb29-23" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
+<p>However, this approach comes at the cost of an additional
+indirection: one for the pointer to the container, and one for the
+container dereference itself. This is likely unacceptable cost in a
+facility designed to target performance-sensitive use cases. The
+situation for the <code class="sourceCode default">offset</code>
+requirement (which is used by
+<code class="sourceCode default">submdspan</code>) is potentially even
+worse for arbitrary non-contiguous containers, adding up to one
+indirection per invocation of
+<code class="sourceCode default">submdspan</code>. This is likely
+unacceptable in many contexts.</p>
+<p>Nonetheless, using refinements of the existing
+<code class="sourceCode default">Container</code> concept directly with
+<code class="sourceCode default">mdarray</code> is an incredibly
+attractive option. This is because it avoids the introduction of an
+extra concept, and thus significantly decreases the cognitive cost of
+the abstraction. Thus, direct use of the existing
+<code class="sourceCode default">Container</code> concept hierarchy
+should be preferred to other options unless the shortcomings of the
+existing concept are so irreconcilable (or so complicated to reconcile)
+as to create more cognitive load than is needed for an entirely new
+concept.</p>
+<p>One straightforward way to resolve the above concerns with arbitrary
+container types, is to simply restrict what type of containers can be
+used. Specifically, we would restrict it such that creating an
+<code class="sourceCode default">mdspan</code> with
+<code class="sourceCode default">default_accessor</code> is
+straightforward. Thus we would require
+<code class="sourceCode default">decltype(Container::data())</code> to
+denote <code class="sourceCode default">ElementType*</code>, and
+<code class="sourceCode default">&amp;c[i]</code> to equal
+<code class="sourceCode default">c.data() + i</code> for all
+<code class="sourceCode default">i</code> in the range of <span class="math inline">[</span><code class="sourceCode default">0</code>,
+<code class="sourceCode default">c.size()</code><span class="math inline">)</span>.</p>
+<p>In what follows, we discuss two design alternatives.</p>
+<h3 data-number="3.5.3" id="not-proposed-alternative-a-dedicated-containerpolicy-concept"><span class="header-section-number">3.5.3</span> (Not proposed) alternative: A
+dedicated <code class="sourceCode default">ContainerPolicy</code>
+concept<a href="#not-proposed-alternative-a-dedicated-containerpolicy-concept" class="self-link"></a></h3>
+<p>Despite the additional cognitive load, there are a few arguments in
+favor of using a dedicated concept for the container description of
+<code class="sourceCode default">mdarray</code>. As is often the case
+with concept-driven design, the implementation of
+<code class="sourceCode default">mdarray</code> only needs a relatively
+small subset of the interface elements in the
+<code class="sourceCode default">Container</code> concept hierarchy.
+This alone is not enough to justify an additional concept external to
+the existing hierarchy; however, there are also quite a few features
+missing from the existing container concept hierarchy, without which an
+efficient <code class="sourceCode default">mdarray</code> implementation
+may be difficult or impossible. As alluded to above, conversion to an
+<code class="sourceCode default">AccessorPolicy</code> for the creation
+of a <code class="sourceCode default">mdspan</code> is one missing
+piece. (Another, interestingly, is sized construction of the container
+mixed with allocator awareness, which is surprisingly lacking in the
+current hierarchy somehow.) For these reasons, it is worth exploring a
+design based on analogy to the
+<code class="sourceCode default">AccessorPolicy</code> concept rather
+than on analogy to <code class="sourceCode default">Container</code>. If
+we make that abstraction owning, we might call it something like
+<code class="sourceCode default">_ContainerLikeThing</code> (not
+proposed here; included for discussion). In that case, a model of the
+<code class="sourceCode default">_ContainerLikeThing</code> concept that
+meets the needs of <code class="sourceCode default">mdarray</code> might
+look something like:</p>
+<div class="sourceCode" id="cb30"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb30-1"><a href="#cb30-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> ElementType, <span class="kw">class</span> Allocator<span class="op">=</span>std<span class="op">::</span>allocator<span class="op">&lt;</span>ElementType<span class="op">&gt;&gt;</span></span>
+<span id="cb30-2"><a href="#cb30-2" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> vector_container_like_thing <span class="co">// models _ContainerLikeThing</span></span>
+<span id="cb30-3"><a href="#cb30-3" aria-hidden="true" tabindex="-1"></a><span class="op">{</span></span>
+<span id="cb30-4"><a href="#cb30-4" aria-hidden="true" tabindex="-1"></a><span class="kw">public</span><span class="op">:</span></span>
+<span id="cb30-5"><a href="#cb30-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> element_type <span class="op">=</span> ElementType;</span>
+<span id="cb30-6"><a href="#cb30-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> container_type <span class="op">=</span> std<span class="op">::</span>vector<span class="op">&lt;</span>ElementType, Allocator<span class="op">&gt;</span>;</span>
+<span id="cb30-7"><a href="#cb30-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> allocator_type <span class="op">=</span> <span class="kw">typename</span> container_type<span class="op">::</span>allocator_type;</span>
+<span id="cb30-8"><a href="#cb30-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> pointer <span class="op">=</span> <span class="kw">typename</span> container_type<span class="op">::</span>pointer;</span>
+<span id="cb30-9"><a href="#cb30-9" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> const_pointer <span class="op">=</span> <span class="kw">typename</span> container_type<span class="op">::</span>const_pointer;</span>
+<span id="cb30-10"><a href="#cb30-10" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> reference <span class="op">=</span> <span class="kw">typename</span> container_type<span class="op">::</span>reference;</span>
+<span id="cb30-11"><a href="#cb30-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> const_reference <span class="op">=</span> <span class="kw">typename</span> container_type<span class="op">::</span>const_reference;</span>
+<span id="cb30-12"><a href="#cb30-12" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> accessor_policy <span class="op">=</span> std<span class="op">::</span>accessor_basic<span class="op">&lt;</span>element_type<span class="op">&gt;</span>;</span>
+<span id="cb30-13"><a href="#cb30-13" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> const_accessor_policy <span class="op">=</span> std<span class="op">::</span>accessor_basic<span class="op">&lt;</span><span class="kw">const</span> element_type<span class="op">&gt;</span>;</span>
+<span id="cb30-14"><a href="#cb30-14" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb30-15"><a href="#cb30-15" aria-hidden="true" tabindex="-1"></a>  <span class="co">// analogous to `access` method in `AccessorPolicy`</span></span>
+<span id="cb30-16"><a href="#cb30-16" aria-hidden="true" tabindex="-1"></a>  reference access<span class="op">(</span><span class="dt">ptrdiff_t</span> offset<span class="op">)</span> <span class="op">{</span> <span class="cf">return</span> __c<span class="op">[</span><span class="dt">size_t</span><span class="op">(</span>offset<span class="op">)]</span>; <span class="op">}</span></span>
+<span id="cb30-17"><a href="#cb30-17" aria-hidden="true" tabindex="-1"></a>  const_reference access<span class="op">(</span><span class="dt">ptrdiff_t</span> offset<span class="op">)</span> <span class="kw">const</span> <span class="op">{</span> <span class="cf">return</span> __c<span class="op">[</span><span class="dt">size_t</span><span class="op">(</span>offset<span class="op">)]</span>; <span class="op">}</span></span>
+<span id="cb30-18"><a href="#cb30-18" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb30-19"><a href="#cb30-19" aria-hidden="true" tabindex="-1"></a>  <span class="co">// Interface for mdspan creation</span></span>
+<span id="cb30-20"><a href="#cb30-20" aria-hidden="true" tabindex="-1"></a>  accessor_policy make_accessor_policy<span class="op">()</span> <span class="op">{</span> <span class="cf">return</span> <span class="op">{</span> <span class="op">}</span>; <span class="op">}</span></span>
+<span id="cb30-21"><a href="#cb30-21" aria-hidden="true" tabindex="-1"></a>  const_accessor_policy make_accessor_policy<span class="op">()</span> <span class="kw">const</span> <span class="op">{</span> <span class="cf">return</span> <span class="op">{</span> <span class="op">}</span>; <span class="op">}</span></span>
+<span id="cb30-22"><a href="#cb30-22" aria-hidden="true" tabindex="-1"></a>  <span class="kw">typename</span> pointer data<span class="op">()</span> <span class="op">{</span> <span class="cf">return</span>  __c<span class="op">.</span>data<span class="op">()</span>; <span class="op">}</span></span>
+<span id="cb30-23"><a href="#cb30-23" aria-hidden="true" tabindex="-1"></a>  <span class="kw">typename</span> const_pointer data<span class="op">()</span> <span class="kw">const</span> <span class="op">{</span> <span class="cf">return</span>  __c<span class="op">.</span>data<span class="op">()</span>; <span class="op">}</span></span>
+<span id="cb30-24"><a href="#cb30-24" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb30-25"><a href="#cb30-25" aria-hidden="true" tabindex="-1"></a>  <span class="co">// Interface for sized construction</span></span>
+<span id="cb30-26"><a href="#cb30-26" aria-hidden="true" tabindex="-1"></a>  <span class="kw">static</span> vector_container_policy create<span class="op">(</span><span class="dt">size_t</span> n<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb30-27"><a href="#cb30-27" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> vector_container_like_thing<span class="op">{</span>container_type<span class="op">(</span>n, element_type<span class="op">{})}</span>;</span>
+<span id="cb30-28"><a href="#cb30-28" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb30-29"><a href="#cb30-29" aria-hidden="true" tabindex="-1"></a>  <span class="kw">static</span> vector_container_policy create<span class="op">(</span><span class="dt">size_t</span> n, allocator_type <span class="kw">const</span><span class="op">&amp;</span> alloc<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb30-30"><a href="#cb30-30" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> vector_container_like_thing<span class="op">{</span>container_type<span class="op">(</span>n, element_type<span class="op">{}</span>, alloc<span class="op">)}</span>;</span>
+<span id="cb30-31"><a href="#cb30-31" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb30-32"><a href="#cb30-32" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb30-33"><a href="#cb30-33" aria-hidden="true" tabindex="-1"></a>  container_type __c;</span>
+<span id="cb30-34"><a href="#cb30-34" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
+<p>This approach solves many of the problems associated with using the
+<code class="sourceCode default">Container</code> concept directly. It
+is the most flexible and provides the best compatibility with
+<code class="sourceCode default">mdspan</code>, since the conversion to
+analogous <code class="sourceCode default">AccessorPolicy</code> is
+fully customizable. This comes at the cost of additional cognitive load,
+but this can be justified based on the observation that almost half of
+the functionality in the above sketch is absent from the container
+hierarchy: the
+<code class="sourceCode default">make_accessor_policy()</code>
+requirement and the sized, allocator-aware container creation
+(<code class="sourceCode default">create(n, alloc)</code>) have no
+analogs in the container concept hierarchy. Non-allocator-aware creation
+(<code class="sourceCode default">create(n)</code>) is analogous to
+sized construction from the sequence container concept, the
+<code class="sourceCode default">data()</code> method is analogous to
+<code class="sourceCode default">begin()</code> on the contiguous
+container concept, and <code class="sourceCode default">access(n)</code>
+is analogous to <code class="sourceCode default">operator[]</code> or
+<code class="sourceCode default">at(n)</code> from the optional sequence
+container requirements. Even for these latter pieces of functionality,
+though, we are required to combine several different concepts from the
+<code class="sourceCode default">Container</code> hierarchy. Based on
+this analysis, we have decided it is reasonable to pursue designs for
+this customization point that diverge from
+<code class="sourceCode default">Container</code>, including ones that
+use <code class="sourceCode default">AccessorPolicy</code> as a starting
+point. Given a better design, we would definitely consider reversing
+direction on this decision, but despite significant effort, we were
+unable to find a design that was more than an awkward and forced fit for
+the <code class="sourceCode default">Container</code> concept
+hierarchy.</p>
+<h3 data-number="3.5.4" id="not-proposed-alternative-containerpolicy-subsumes-accessorpolicy"><span class="header-section-number">3.5.4</span> (Not proposed) alternative:
+<code class="sourceCode default">ContainerPolicy</code> subsumes
+<code class="sourceCode default">AccessorPolicy</code><a href="#not-proposed-alternative-containerpolicy-subsumes-accessorpolicy" class="self-link"></a></h3>
+<p>The above approach has the significant drawback that the
+<code class="sourceCode default">_ContainerLikeThing</code> is an owning
+abstraction fairly similar to a container that diverges from the
+<code class="sourceCode default">Container</code> hierarchy. We
+initially explored this direction because it avoids having to provide a
+<code class="sourceCode default">mdarray</code> constructor that takes
+both a <code class="sourceCode default">Container</code> and a
+<code class="sourceCode default">ContainerPolicy</code>, which we felt
+was a “design smell.” Another alternative along these lines is to make
+the <code class="sourceCode default">mdarray</code> itself own the
+container instance and have the
+<code class="sourceCode default">ContainerPolicy</code> (name subject to
+bikeshedding; maybe
+<code class="sourceCode default">ContainerFactory</code> or
+<code class="sourceCode default">ContainerAccessor</code> is more
+appropriate?) be a nonowning abstraction that describes the container
+creation and access. While this approach leads to an ugly <code class="sourceCode default">mdarray(container_type, mapping_type, ContainerPolicy)</code>
+constructor, the analog that constructor affords to the <code class="sourceCode default">mdspan(pointer, mapping_type, AccessorPolicy)</code>
+constructor is a reasonable argument in favor of this design despite its
+quirkiness. Furthermore, this approach affords the opportunity to
+explore a <code class="sourceCode default">ContainerPolicy</code> design
+that subsumes <code class="sourceCode default">AccessorPolicy</code>,
+thus providing the needed conversion to
+<code class="sourceCode default">AccessorPolicy</code> for the analogous
+<code class="sourceCode default">mdspan</code> by simple subsumption.
+More importantly, this subsumption would significantly decrease the
+cognitive load for users already familiar with
+<code class="sourceCode default">mdspan</code>. A model of
+<code class="sourceCode default">ContainerPolicy</code> for this sort of
+approach might look something like:</p>
+<div class="sourceCode" id="cb31"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb31-1"><a href="#cb31-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> ElementType, <span class="kw">class</span> Allocator<span class="op">=</span>std<span class="op">::</span>allocator<span class="op">&lt;</span>ElementType<span class="op">&gt;&gt;</span></span>
+<span id="cb31-2"><a href="#cb31-2" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> vector_container_policy <span class="co">// models ContainerPolicy (and thus AccessorPolicy)</span></span>
+<span id="cb31-3"><a href="#cb31-3" aria-hidden="true" tabindex="-1"></a><span class="op">{</span></span>
+<span id="cb31-4"><a href="#cb31-4" aria-hidden="true" tabindex="-1"></a><span class="kw">public</span><span class="op">:</span></span>
+<span id="cb31-5"><a href="#cb31-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> element_type <span class="op">=</span> ElementType;</span>
+<span id="cb31-6"><a href="#cb31-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> container_type <span class="op">=</span> std<span class="op">::</span>vector<span class="op">&lt;</span>ElementType, Allocator<span class="op">&gt;</span>;</span>
+<span id="cb31-7"><a href="#cb31-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> allocator_type <span class="op">=</span> <span class="kw">typename</span> container_type<span class="op">::</span>allocator_type;</span>
+<span id="cb31-8"><a href="#cb31-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> pointer <span class="op">=</span> <span class="kw">typename</span> container_type<span class="op">::</span>pointer;</span>
+<span id="cb31-9"><a href="#cb31-9" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> const_pointer <span class="op">=</span> <span class="kw">typename</span> container_type<span class="op">::</span>const_pointer;</span>
+<span id="cb31-10"><a href="#cb31-10" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> reference <span class="op">=</span> <span class="kw">typename</span> container_type<span class="op">::</span>reference;</span>
+<span id="cb31-11"><a href="#cb31-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> const_reference <span class="op">=</span> <span class="kw">typename</span> container_type<span class="op">::</span>const_reference;</span>
+<span id="cb31-12"><a href="#cb31-12" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> offset_policy <span class="op">=</span> vector_container_policy<span class="op">&lt;</span>ElementType, Allocator<span class="op">&gt;</span></span>
+<span id="cb31-13"><a href="#cb31-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb31-14"><a href="#cb31-14" aria-hidden="true" tabindex="-1"></a>  <span class="co">// ContainerPolicy requirements:</span></span>
+<span id="cb31-15"><a href="#cb31-15" aria-hidden="true" tabindex="-1"></a>  reference access<span class="op">(</span>container_type<span class="op">&amp;</span> c, <span class="dt">ptrdiff_t</span> i<span class="op">)</span> <span class="op">{</span> <span class="cf">return</span> c<span class="op">[</span><span class="dt">size_t</span><span class="op">(</span>i<span class="op">)]</span>; <span class="op">}</span></span>
+<span id="cb31-16"><a href="#cb31-16" aria-hidden="true" tabindex="-1"></a>  const_reference access<span class="op">(</span>container_type <span class="kw">const</span><span class="op">&amp;</span> <span class="dt">ptrdiff_t</span> i<span class="op">)</span> <span class="kw">const</span> <span class="op">{</span> <span class="cf">return</span> c<span class="op">[</span><span class="dt">size_t</span><span class="op">(</span>i<span class="op">)]</span>; <span class="op">}</span></span>
+<span id="cb31-17"><a href="#cb31-17" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb31-18"><a href="#cb31-18" aria-hidden="true" tabindex="-1"></a>  <span class="co">// ContainerPolicy requirements (interface for sized construction):</span></span>
+<span id="cb31-19"><a href="#cb31-19" aria-hidden="true" tabindex="-1"></a>  container_type create<span class="op">(</span><span class="dt">size_t</span> n<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb31-20"><a href="#cb31-20" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> container_type<span class="op">(</span>n, element_type<span class="op">{})</span>;</span>
+<span id="cb31-21"><a href="#cb31-21" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb31-22"><a href="#cb31-22" aria-hidden="true" tabindex="-1"></a>  container_type create<span class="op">(</span><span class="dt">size_t</span> n, allocator_type <span class="kw">const</span><span class="op">&amp;</span> alloc<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb31-23"><a href="#cb31-23" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> container_type<span class="op">(</span>n, element_type<span class="op">{}</span>, alloc<span class="op">)</span>;</span>
+<span id="cb31-24"><a href="#cb31-24" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb31-25"><a href="#cb31-25" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb31-26"><a href="#cb31-26" aria-hidden="true" tabindex="-1"></a>  <span class="co">// AccessorPolicy requirement:</span></span>
+<span id="cb31-27"><a href="#cb31-27" aria-hidden="true" tabindex="-1"></a>  reference access<span class="op">(</span>pointer p, <span class="dt">ptrdiff_t</span> i<span class="op">)</span> <span class="op">{</span> <span class="cf">return</span> p<span class="op">[</span>i<span class="op">]</span>; <span class="op">}</span></span>
+<span id="cb31-28"><a href="#cb31-28" aria-hidden="true" tabindex="-1"></a>  <span class="co">// For the const analog of AccessorPolicy:</span></span>
+<span id="cb31-29"><a href="#cb31-29" aria-hidden="true" tabindex="-1"></a>  const_reference access<span class="op">(</span>const_pointer p, <span class="dt">ptrdiff_t</span> i<span class="op">)</span> <span class="kw">const</span> <span class="op">{</span> <span class="cf">return</span> p<span class="op">[</span>i<span class="op">]</span>; <span class="op">}</span></span>
+<span id="cb31-30"><a href="#cb31-30" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb31-31"><a href="#cb31-31" aria-hidden="true" tabindex="-1"></a>  <span class="co">// AccessorPolicy requirement:</span></span>
+<span id="cb31-32"><a href="#cb31-32" aria-hidden="true" tabindex="-1"></a>  pointer offset<span class="op">(</span>pointer p, <span class="dt">ptrdiff_t</span> i<span class="op">)</span> <span class="op">{</span> <span class="cf">return</span> p <span class="op">+</span> i; <span class="op">}</span></span>
+<span id="cb31-33"><a href="#cb31-33" aria-hidden="true" tabindex="-1"></a>  <span class="co">// For the const analog of AccessorPolicy:</span></span>
+<span id="cb31-34"><a href="#cb31-34" aria-hidden="true" tabindex="-1"></a>  const_pointer offset<span class="op">(</span>const_pointer p, <span class="dt">ptrdiff_t</span> i<span class="op">)</span> <span class="kw">const</span> <span class="op">{</span> <span class="cf">return</span> p <span class="op">+</span> i; <span class="op">}</span></span>
+<span id="cb31-35"><a href="#cb31-35" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb31-36"><a href="#cb31-36" aria-hidden="true" tabindex="-1"></a>  <span class="co">// AccessorPolicy requirement:</span></span>
+<span id="cb31-37"><a href="#cb31-37" aria-hidden="true" tabindex="-1"></a>  element_type<span class="op">*</span> decay<span class="op">(</span>pointer p<span class="op">)</span> <span class="op">{</span> <span class="cf">return</span> p; <span class="op">}</span></span>
+<span id="cb31-38"><a href="#cb31-38" aria-hidden="true" tabindex="-1"></a>  <span class="co">// For the const analog of AccessorPolicy:</span></span>
+<span id="cb31-39"><a href="#cb31-39" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> element_type<span class="op">*</span> decay<span class="op">(</span>pointer p<span class="op">)</span> <span class="kw">const</span> <span class="op">{</span> <span class="cf">return</span> p; <span class="op">}</span></span>
+<span id="cb31-40"><a href="#cb31-40" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb31-41"><a href="#cb31-41" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
+<p>The above sketch makes clear the biggest challenge with this
+approach: the mismatch in shallow versus deep
+<code class="sourceCode default">const</code>ness in for an abstractions
+designed to support <code class="sourceCode default">mdspan</code> and
+<code class="sourceCode default">mdarray</code>, respectively. The
+<code class="sourceCode default">ContainerPolicy</code> concept thus
+requires additional
+<code class="sourceCode default">const</code>-qualified overloads of the
+basis operations. Moreover, while the
+<code class="sourceCode default">ContainerPolicy</code> itself can be
+obtained directly from the corresponding
+<code class="sourceCode default">AccessorPolicy</code> in the case of
+the non-<code class="sourceCode default">const</code> method for
+creating the corresponding
+<code class="sourceCode default">mdspan</code> (provisionally called
+<code class="sourceCode default">view()</code>), the
+<code class="sourceCode default">const</code>-qualified version needs to
+adapt the policy, since the nested types have the wrong names (e.g.,
+<code class="sourceCode default">const_pointer</code> should be named
+<code class="sourceCode default">pointer</code> from the perspective of
+the <code class="sourceCode default">mdspan</code> that the
+<code class="sourceCode default">const</code>-qualified
+<code class="sourceCode default">view()</code> needs to return). This
+could be fixed without too much mess using an adapter (that does not
+need to be part of the specification):</p>
+<div class="sourceCode" id="cb32"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb32-1"><a href="#cb32-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>ContainerPolicy P<span class="op">&gt;</span></span>
+<span id="cb32-2"><a href="#cb32-2" aria-hidden="true" tabindex="-1"></a><span class="kw">class</span> __const_accessor_policy_adapter <span class="op">{</span> <span class="co">// models AccessorPolicy</span></span>
+<span id="cb32-3"><a href="#cb32-3" aria-hidden="true" tabindex="-1"></a><span class="kw">public</span><span class="op">:</span></span>
+<span id="cb32-4"><a href="#cb32-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> element_type <span class="op">=</span> add_const_t<span class="op">&lt;</span><span class="kw">typename</span> P<span class="op">::</span>element_type<span class="op">&gt;</span>;</span>
+<span id="cb32-5"><a href="#cb32-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> pointer <span class="op">=</span> <span class="kw">typename</span> P<span class="op">::</span>const_pointer;</span>
+<span id="cb32-6"><a href="#cb32-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> reference <span class="op">=</span> <span class="kw">typename</span> P<span class="op">::</span>const_reference;</span>
+<span id="cb32-7"><a href="#cb32-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> offset_policy <span class="op">=</span> __const_accessor_policy_adapter<span class="op">&lt;</span><span class="kw">typename</span> P<span class="op">::</span>offset_policy<span class="op">&gt;</span>;</span>
+<span id="cb32-8"><a href="#cb32-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb32-9"><a href="#cb32-9" aria-hidden="true" tabindex="-1"></a>  reference access<span class="op">(</span>pointer p, <span class="dt">ptrdiff_t</span> i<span class="op">)</span> <span class="op">{</span> <span class="cf">return</span> acc_<span class="op">.</span>access<span class="op">(</span>p, i<span class="op">)</span>; <span class="op">}</span></span>
+<span id="cb32-10"><a href="#cb32-10" aria-hidden="true" tabindex="-1"></a>  pointer offset<span class="op">(</span>pointer p, <span class="dt">ptrdiff_t</span> i<span class="op">)</span> <span class="op">{</span> <span class="cf">return</span> acc_<span class="op">.</span>offset<span class="op">(</span>p, i<span class="op">)</span>; <span class="op">}</span></span>
+<span id="cb32-11"><a href="#cb32-11" aria-hidden="true" tabindex="-1"></a>  element_type<span class="op">*</span> decay<span class="op">(</span>pointer p<span class="op">)</span> <span class="op">{</span> <span class="cf">return</span> acc_<span class="op">.</span>decay<span class="op">(</span>p<span class="op">)</span>; <span class="op">}</span></span>
+<span id="cb32-12"><a href="#cb32-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb32-13"><a href="#cb32-13" aria-hidden="true" tabindex="-1"></a><span class="kw">private</span><span class="op">:</span></span>
+<span id="cb32-14"><a href="#cb32-14" aria-hidden="true" tabindex="-1"></a>  <span class="op">[[</span><span class="at">no_unique_address</span><span class="op">]]</span> add_const_t<span class="op">&lt;</span>P<span class="op">&gt;</span> acc_;</span>
+<span id="cb32-15"><a href="#cb32-15" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
+<p>Compared to simply using a
+<code class="sourceCode default">container</code> as the argument, this
+approach has the benefit of enabling
+<code class="sourceCode default">mdarray</code> to use containers for
+which <code class="sourceCode default">data()[i]</code> is not giving
+access to the same element as
+<code class="sourceCode default">container[i]</code>. However, after
+more consideration we believe that the need for supporting such
+containers as underlying storage for
+<code class="sourceCode default">mdarray</code> is likely fairly niche.
+Furthermore, we believe one could later extent the design of
+<code class="sourceCode default">mdarray</code> to allow for such
+ContainerPolicies, even if the initial design only allows for a
+restricted set of containers.</p>
+<h3 data-number="3.5.5" id="extension-for-accessor-policy-from-container"><span class="header-section-number">3.5.5</span> Extension for accessor policy
+from container<a href="#extension-for-accessor-policy-from-container" class="self-link"></a></h3>
+<p>Most of the drawbacks of using container directly as the template
+parameter for <code class="sourceCode default">mdarray</code> addressed
+in the above design alternatives, can likely be remedied by introducing
+a customization point to obtain an accessor policy and the associated
+<code class="sourceCode default">data_handle</code> from an existing
+container. We do not propose such a customization point in this paper,
+but don’t expect this to be a major issue.</p>
+<h3 data-number="3.5.6" id="safety-and-other-issues-with-containers"><span class="header-section-number">3.5.6</span> Safety and other issues with
+containers<a href="#safety-and-other-issues-with-containers" class="self-link"></a></h3>
+<h4 data-number="3.5.6.1" id="size-and-access-guarantees-for-containers"><span class="header-section-number">3.5.6.1</span> Size and access guarantees
+for containers<a href="#size-and-access-guarantees-for-containers" class="self-link"></a></h4>
+<p>We have to somehow guarantee that containers constructed from sizes
+(or if such constructors are reintroduced from iterator pairs,
+initializer lists or ranges), are actually large enough after the
+construction so we can index into them. However, we don’t want full
+sequence container requirements (also there is no named requirement for
+a constructor which takes an integral only).</p>
+<p>To illustrate the problem consider a user defined container with a
+static size but that has a constructor which takes an init value.</p>
+<div class="sourceCode" id="cb33"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb33-1"><a href="#cb33-1" aria-hidden="true" tabindex="-1"></a>user<span class="op">::</span>static_vector<span class="op">&lt;</span><span class="dt">int</span>, <span class="dv">200</span><span class="op">&gt;</span> vec<span class="op">(</span><span class="dv">1000</span><span class="op">)</span>;</span>
+<span id="cb33-2"><a href="#cb33-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb33-3"><a href="#cb33-3" aria-hidden="true" tabindex="-1"></a><span class="ot">assert</span><span class="op">(</span>vec<span class="op">.</span>size<span class="op">()==</span><span class="dv">200</span><span class="op">)</span>;</span></code></pre></div>
+<p>From the perspective of
+<code class="sourceCode default">mdarray</code> this container looks
+like its constructible from a size, but that is not actually what the
+container does.</p>
+<p>We previously proposed a new set of named optional requirements for
+containers which guarantee the desired behavior.</p>
+<p>These requirements would need to go into the general container
+requirements, or be a new named requirement? But maybe there is also
+another way to require these semantics for containers used with
+<code class="sourceCode default">mdarray</code> instead, for example one
+might say it is undefined behavior if a container class is used which
+does not have a size of <code class="sourceCode default">n</code> when
+constructed with <code class="sourceCode default">n</code> as its sole
+argument.</p>
+<p>In Revision 4 we removed those named container requirements and
+instead propose an alternative approach - made easier by the removal of
+a lot of constructors in R3. Specifically, we enforce that containers
+constructed from sizes have that expected size via preconditions on the
+relevant containers.</p>
+<h4 data-number="3.5.6.2" id="size-requirements-for-construction-from-containers-etc."><span class="header-section-number">3.5.6.2</span> Size requirements for
+construction from containers etc.<a href="#size-requirements-for-construction-from-containers-etc." class="self-link"></a></h4>
+<p>We explicitly require that if an
+<code class="sourceCode default">mdarray</code> is constructed from some
+existing set of elements (container, iterators, range, etc.), that the
+size of that container etc. is larger or equal to the mappings required
+span size. The larger or equal is intentional, because the mapping may
+already be not exhaustive. I.e. the
+<code class="sourceCode default">mdarray</code> may not end up accessing
+all elements in its own container. But in that case it is not clear why
+having unused elements at the end should be different from having unused
+elements somewhere else in the container.</p>
+<h1 data-number="4" id="wording"><span class="header-section-number">4</span> Wording<a href="#wording" class="self-link"></a></h1>
+<p><br /></p>
+<p>Insert the following after section 24.6.6</p>
+<p><b>24.6.� Class template
+<code class="sourceCode default">mdarray</code> [mdarray]</b></p>
+<p><br /></p>
+<p><b>24.6.�.1 <code class="sourceCode default">mdarray</code> overview
+[mdarray.overview]</b></p>
+<p><span class="marginalizedparent"><a class="marginalized">1</a></span>
+<code class="sourceCode default">mdarray</code> is a multidimensional
+array of elements.</p>
+<div class="sourceCode" id="cb34"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb34-1"><a href="#cb34-1" aria-hidden="true" tabindex="-1"></a><span class="kw">namespace</span> std <span class="op">{</span></span>
+<span id="cb34-2"><a href="#cb34-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-3"><a href="#cb34-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ElementType, <span class="kw">class</span> Extents, <span class="kw">class</span> LayoutPolicy, <span class="kw">class</span> Container <span class="op">=</span> </span>
+<span id="cb34-4"><a href="#cb34-4" aria-hidden="true" tabindex="-1"></a>         vector<span class="op">&lt;</span>ElementType<span class="op">&gt;&gt;</span></span>
+<span id="cb34-5"><a href="#cb34-5" aria-hidden="true" tabindex="-1"></a><span class="kw">class</span> mdarray <span class="op">{</span></span>
+<span id="cb34-6"><a href="#cb34-6" aria-hidden="true" tabindex="-1"></a><span class="kw">public</span><span class="op">:</span></span>
+<span id="cb34-7"><a href="#cb34-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> extents_type <span class="op">=</span> Extents;</span>
+<span id="cb34-8"><a href="#cb34-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> layout_type <span class="op">=</span> LayoutPolicy;</span>
+<span id="cb34-9"><a href="#cb34-9" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> container_type <span class="op">=</span> Container;</span>
+<span id="cb34-10"><a href="#cb34-10" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> mapping_type <span class="op">=</span> <span class="kw">typename</span> layout_type<span class="op">::</span><span class="kw">template</span> mapping<span class="op">&lt;</span>extents_type<span class="op">&gt;</span>;</span>
+<span id="cb34-11"><a href="#cb34-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> element_type <span class="op">=</span> ElementType;</span>
+<span id="cb34-12"><a href="#cb34-12" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> mdspan_type <span class="op">=</span> mdspan<span class="op">&lt;</span>element_type, extents_type, layout_type<span class="op">&gt;</span>;</span>
+<span id="cb34-13"><a href="#cb34-13" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> const_mdspan_type <span class="op">=</span> mdspan<span class="op">&lt;</span><span class="kw">const</span> element_type, extents_type, layout_type<span class="op">&gt;</span>;</span>
+<span id="cb34-14"><a href="#cb34-14" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> value_type <span class="op">=</span> element_type;</span>
+<span id="cb34-15"><a href="#cb34-15" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> index_type <span class="op">=</span> <span class="kw">typename</span> Extents<span class="op">::</span>index_type;</span>
+<span id="cb34-16"><a href="#cb34-16" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> size_type <span class="op">=</span> <span class="kw">typename</span> Extents<span class="op">::</span>size_type;</span>
+<span id="cb34-17"><a href="#cb34-17" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> rank_type <span class="op">=</span> <span class="kw">typename</span> Extents<span class="op">::</span>rank_type;</span>
+<span id="cb34-18"><a href="#cb34-18" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> pointer <span class="op">=</span> <span class="kw">typename</span> container_type<span class="op">::</span>pointer;</span>
+<span id="cb34-19"><a href="#cb34-19" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> reference <span class="op">=</span> <span class="kw">typename</span> container_type<span class="op">::</span>reference;</span>
+<span id="cb34-20"><a href="#cb34-20" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> const_pointer <span class="op">=</span> <span class="kw">typename</span> container_type<span class="op">::</span>const_pointer;</span>
+<span id="cb34-21"><a href="#cb34-21" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> const_reference <span class="op">=</span> <span class="kw">typename</span> container_type<span class="op">::</span>const_reference;</span>
+<span id="cb34-22"><a href="#cb34-22" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-23"><a href="#cb34-23" aria-hidden="true" tabindex="-1"></a>  <span class="kw">static</span> <span class="kw">constexpr</span> rank_type rank<span class="op">()</span> <span class="kw">noexcept</span> <span class="op">{</span> <span class="cf">return</span> extents_type<span class="op">::</span>rank<span class="op">()</span>; <span class="op">}</span></span>
+<span id="cb34-24"><a href="#cb34-24" aria-hidden="true" tabindex="-1"></a>  <span class="kw">static</span> <span class="kw">constexpr</span> rank_type rank_dynamic<span class="op">()</span> <span class="kw">noexcept</span> <span class="op">{</span> <span class="cf">return</span> extents_type<span class="op">::</span>rank_dynamic<span class="op">()</span>; <span class="op">}</span></span>
+<span id="cb34-25"><a href="#cb34-25" aria-hidden="true" tabindex="-1"></a>  <span class="kw">static</span> <span class="kw">constexpr</span> <span class="dt">size_t</span> static_extent<span class="op">(</span>rank_type r<span class="op">)</span> <span class="kw">noexcept</span></span>
+<span id="cb34-26"><a href="#cb34-26" aria-hidden="true" tabindex="-1"></a>    <span class="op">{</span> <span class="cf">return</span> extents_type<span class="op">::</span>static_extent<span class="op">(</span>r<span class="op">)</span>; <span class="op">}</span></span>
+<span id="cb34-27"><a href="#cb34-27" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> index_type extent<span class="op">(</span>rank_type r<span class="op">)</span> <span class="kw">const</span> <span class="kw">noexcept</span> <span class="op">{</span> <span class="cf">return</span> extents<span class="op">().</span>extent<span class="op">(</span>r<span class="op">)</span>; <span class="op">}</span></span>
+<span id="cb34-28"><a href="#cb34-28" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-29"><a href="#cb34-29" aria-hidden="true" tabindex="-1"></a>  <span class="co">// [mdarray.ctors], mdarray constructors</span></span>
+<span id="cb34-30"><a href="#cb34-30" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> mdarray<span class="op">()</span> <span class="kw">requires</span><span class="op">(</span>rank_dynamic<span class="op">()</span> <span class="op">!=</span> <span class="dv">0</span><span class="op">)</span> <span class="op">=</span> <span class="cf">default</span>;</span>
+<span id="cb34-31"><a href="#cb34-31" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> mdarray<span class="op">&amp;</span> rhs<span class="op">)</span> <span class="op">=</span> <span class="cf">default</span>;</span>
+<span id="cb34-32"><a href="#cb34-32" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> mdarray<span class="op">(</span>mdarray<span class="op">&amp;&amp;</span> rhs<span class="op">)</span> <span class="op">=</span> <span class="cf">default</span>;</span>
+<span id="cb34-33"><a href="#cb34-33" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-34"><a href="#cb34-34" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span><span class="op">...</span> OtherIndexTypes<span class="op">&gt;</span></span>
+<span id="cb34-35"><a href="#cb34-35" aria-hidden="true" tabindex="-1"></a>    <span class="kw">explicit</span> <span class="kw">constexpr</span> mdarray<span class="op">(</span>OtherIndexTypes<span class="op">...</span> exts<span class="op">)</span>;</span>
+<span id="cb34-36"><a href="#cb34-36" aria-hidden="true" tabindex="-1"></a>  <span class="kw">explicit</span> <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> extents_type<span class="op">&amp;</span> ext<span class="op">)</span>;</span>
+<span id="cb34-37"><a href="#cb34-37" aria-hidden="true" tabindex="-1"></a>  <span class="kw">explicit</span> <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> mapping_type<span class="op">&amp;</span> m<span class="op">)</span>;</span>
+<span id="cb34-38"><a href="#cb34-38" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-39"><a href="#cb34-39" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> extents_type<span class="op">&amp;</span> ext, <span class="kw">const</span> value_type<span class="op">&amp;</span> val<span class="op">)</span>;</span>
+<span id="cb34-40"><a href="#cb34-40" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> mapping_type<span class="op">&amp;</span> m, <span class="kw">const</span> value_type<span class="op">&amp;</span> val<span class="op">)</span>;</span>
+<span id="cb34-41"><a href="#cb34-41" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-42"><a href="#cb34-42" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span><span class="op">...</span> OtherIndexTypes<span class="op">&gt;</span></span>
+<span id="cb34-43"><a href="#cb34-43" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> container_type<span class="op">&amp;</span> c, OtherIndexTypes<span class="op">...</span> exts<span class="op">)</span>;</span>
+<span id="cb34-44"><a href="#cb34-44" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> container_type<span class="op">&amp;</span> c, <span class="kw">const</span> extents_type<span class="op">&amp;</span> ext<span class="op">)</span>;</span>
+<span id="cb34-45"><a href="#cb34-45" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> container_type<span class="op">&amp;</span> c, <span class="kw">const</span> mapping_type<span class="op">&amp;</span> m<span class="op">)</span>;</span>
+<span id="cb34-46"><a href="#cb34-46" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-47"><a href="#cb34-47" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span><span class="op">...</span> OtherIndexTypes<span class="op">&gt;</span></span>
+<span id="cb34-48"><a href="#cb34-48" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span>container_type<span class="op">&amp;&amp;</span> c, OtherIndexTypes<span class="op">...</span> exts<span class="op">)</span>;</span>
+<span id="cb34-49"><a href="#cb34-49" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> mdarray<span class="op">(</span>container_type<span class="op">&amp;&amp;</span> c, <span class="kw">const</span> extents_type<span class="op">&amp;</span> ext<span class="op">)</span>;</span>
+<span id="cb34-50"><a href="#cb34-50" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> mdarray<span class="op">(</span>container_type<span class="op">&amp;&amp;</span> c, <span class="kw">const</span> mapping_type<span class="op">&amp;</span> m<span class="op">)</span>;</span>
+<span id="cb34-51"><a href="#cb34-51" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-52"><a href="#cb34-52" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-53"><a href="#cb34-53" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherElementType, <span class="kw">class</span> OtherExtents, </span>
+<span id="cb34-54"><a href="#cb34-54" aria-hidden="true" tabindex="-1"></a>           <span class="kw">class</span> OtherLayoutPolicy, <span class="kw">class</span> OtherContainer<span class="op">&gt;</span></span>
+<span id="cb34-55"><a href="#cb34-55" aria-hidden="true" tabindex="-1"></a>    <span class="kw">explicit</span><span class="op">(</span><em>see below</em><span class="op">)</span></span>
+<span id="cb34-56"><a href="#cb34-56" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span></span>
+<span id="cb34-57"><a href="#cb34-57" aria-hidden="true" tabindex="-1"></a>      <span class="kw">const</span> mdarray<span class="op">&lt;</span>OtherElementType, OtherExtents,</span>
+<span id="cb34-58"><a href="#cb34-58" aria-hidden="true" tabindex="-1"></a>                    OtherLayoutPolicy, OtherContainer<span class="op">&gt;&amp;</span> other<span class="op">)</span>;</span>
+<span id="cb34-59"><a href="#cb34-59" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-60"><a href="#cb34-60" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherElementType, <span class="kw">class</span> OtherExtents,</span>
+<span id="cb34-61"><a href="#cb34-61" aria-hidden="true" tabindex="-1"></a>           <span class="kw">class</span> OtherLayoutPolicy, <span class="kw">class</span> Accessor<span class="op">&gt;</span></span>
+<span id="cb34-62"><a href="#cb34-62" aria-hidden="true" tabindex="-1"></a>    <span class="kw">explicit</span><span class="op">(</span><em>see below</em><span class="op">)</span></span>
+<span id="cb34-63"><a href="#cb34-63" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> mdspan<span class="op">&lt;</span>OtherElementType, OtherExtents,</span>
+<span id="cb34-64"><a href="#cb34-64" aria-hidden="true" tabindex="-1"></a>                                   OtherLayoutPolicy, Accessor<span class="op">&gt;&amp;</span> other<span class="op">)</span>;</span>
+<span id="cb34-65"><a href="#cb34-65" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-66"><a href="#cb34-66" aria-hidden="true" tabindex="-1"></a>  <span class="co">// [mdarray.ctors.alloc], mdarray constructors with allocators</span></span>
+<span id="cb34-67"><a href="#cb34-67" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
+<span id="cb34-68"><a href="#cb34-68" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> extents_type<span class="op">&amp;</span> ext, <span class="kw">const</span> Alloc<span class="op">&amp;</span> a<span class="op">)</span>;</span>
+<span id="cb34-69"><a href="#cb34-69" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
+<span id="cb34-70"><a href="#cb34-70" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> mapping_type<span class="op">&amp;</span> m, <span class="kw">const</span> Alloc<span class="op">&amp;</span> a<span class="op">)</span>;</span>
+<span id="cb34-71"><a href="#cb34-71" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-72"><a href="#cb34-72" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
+<span id="cb34-73"><a href="#cb34-73" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> extents_type<span class="op">&amp;</span> ext, <span class="kw">const</span> value_type<span class="op">&amp;</span> val, <span class="kw">const</span> Alloc<span class="op">&amp;</span> a<span class="op">)</span>;</span>
+<span id="cb34-74"><a href="#cb34-74" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
+<span id="cb34-75"><a href="#cb34-75" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> mapping_type<span class="op">&amp;</span> m, <span class="kw">const</span> value_type<span class="op">&amp;</span> val, <span class="kw">const</span> Alloc<span class="op">&amp;</span> a<span class="op">)</span>;</span>
+<span id="cb34-76"><a href="#cb34-76" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-77"><a href="#cb34-77" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
+<span id="cb34-78"><a href="#cb34-78" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> container_type<span class="op">&amp;</span> c, <span class="kw">const</span> extents_type<span class="op">&amp;</span> ext, <span class="kw">const</span> Alloc<span class="op">&amp;</span> a<span class="op">)</span>;</span>
+<span id="cb34-79"><a href="#cb34-79" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
+<span id="cb34-80"><a href="#cb34-80" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> container_type<span class="op">&amp;</span> c, <span class="kw">const</span> mapping_type<span class="op">&amp;</span> m, <span class="kw">const</span> Alloc<span class="op">&amp;</span> a<span class="op">)</span>;</span>
+<span id="cb34-81"><a href="#cb34-81" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-82"><a href="#cb34-82" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
+<span id="cb34-83"><a href="#cb34-83" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span>container_type<span class="op">&amp;&amp;</span> c, <span class="kw">const</span> extents_type<span class="op">&amp;</span> ext, <span class="kw">const</span> Alloc<span class="op">&amp;</span> a<span class="op">)</span>;</span>
+<span id="cb34-84"><a href="#cb34-84" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
+<span id="cb34-85"><a href="#cb34-85" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span>container_type<span class="op">&amp;&amp;</span> c, <span class="kw">const</span> mapping_type<span class="op">&amp;</span> m, <span class="kw">const</span> Alloc<span class="op">&amp;</span> a<span class="op">)</span>;</span>
+<span id="cb34-86"><a href="#cb34-86" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-87"><a href="#cb34-87" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-88"><a href="#cb34-88" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherElementType, <span class="kw">class</span> OtherExtents, </span>
+<span id="cb34-89"><a href="#cb34-89" aria-hidden="true" tabindex="-1"></a>           <span class="kw">class</span> OtherLayoutPolicy, <span class="kw">class</span> OtherContainer, </span>
+<span id="cb34-90"><a href="#cb34-90" aria-hidden="true" tabindex="-1"></a>           <span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
+<span id="cb34-91"><a href="#cb34-91" aria-hidden="true" tabindex="-1"></a>    <span class="kw">explicit</span><span class="op">(</span><em>see below</em><span class="op">)</span></span>
+<span id="cb34-92"><a href="#cb34-92" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span></span>
+<span id="cb34-93"><a href="#cb34-93" aria-hidden="true" tabindex="-1"></a>      <span class="kw">const</span> mdarray<span class="op">&lt;</span>OtherElementType, OtherExtents, </span>
+<span id="cb34-94"><a href="#cb34-94" aria-hidden="true" tabindex="-1"></a>                    OtherLayoutPolicy, OtherContainer<span class="op">&gt;&amp;</span> other, <span class="kw">const</span> Alloc<span class="op">&amp;</span> a<span class="op">)</span>;</span>
+<span id="cb34-95"><a href="#cb34-95" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-96"><a href="#cb34-96" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherElementType, <span class="kw">class</span> OtherExtents,</span>
+<span id="cb34-97"><a href="#cb34-97" aria-hidden="true" tabindex="-1"></a>           <span class="kw">class</span> OtherLayoutPolicy, <span class="kw">class</span> Accessor,</span>
+<span id="cb34-98"><a href="#cb34-98" aria-hidden="true" tabindex="-1"></a>           <span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
+<span id="cb34-99"><a href="#cb34-99" aria-hidden="true" tabindex="-1"></a>    <span class="kw">explicit</span><span class="op">(</span><em>see below</em><span class="op">)</span></span>
+<span id="cb34-100"><a href="#cb34-100" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> mdspan<span class="op">&lt;</span>OtherElementType, OtherExtents,</span>
+<span id="cb34-101"><a href="#cb34-101" aria-hidden="true" tabindex="-1"></a>                                   OtherLayoutPolicy, Accessor<span class="op">&gt;&amp;</span> other,</span>
+<span id="cb34-102"><a href="#cb34-102" aria-hidden="true" tabindex="-1"></a>                      <span class="kw">const</span> Alloc<span class="op">&amp;</span> a<span class="op">)</span>;</span>
+<span id="cb34-103"><a href="#cb34-103" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-104"><a href="#cb34-104" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> mdarray<span class="op">&amp;</span> <span class="kw">operator</span><span class="op">=(</span><span class="kw">const</span> mdarray<span class="op">&amp;</span> rhs<span class="op">)</span> <span class="op">=</span> <span class="cf">default</span>;</span>
+<span id="cb34-105"><a href="#cb34-105" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> mdarray<span class="op">&amp;</span> <span class="kw">operator</span><span class="op">=(</span>mdarray<span class="op">&amp;&amp;</span> rhs<span class="op">)</span> <span class="op">=</span> <span class="cf">default</span>;</span>
+<span id="cb34-106"><a href="#cb34-106" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-107"><a href="#cb34-107" aria-hidden="true" tabindex="-1"></a>  <span class="co">// [mdarray.members], mdarray members</span></span>
+<span id="cb34-108"><a href="#cb34-108" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span><span class="op">...</span> OtherIndexTypes<span class="op">&gt;</span></span>
+<span id="cb34-109"><a href="#cb34-109" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> reference <span class="kw">operator</span><span class="op">[](</span>OtherIndexTypes<span class="op">...</span> indices<span class="op">)</span>;</span>
+<span id="cb34-110"><a href="#cb34-110" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherIndexType<span class="op">&gt;</span></span>
+<span id="cb34-111"><a href="#cb34-111" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> reference <span class="kw">operator</span><span class="op">[](</span>span<span class="op">&lt;</span>OtherIndexType, rank<span class="op">()&gt;</span> indices<span class="op">)</span>;</span>
+<span id="cb34-112"><a href="#cb34-112" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherIndexType<span class="op">&gt;</span></span>
+<span id="cb34-113"><a href="#cb34-113" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> reference <span class="kw">operator</span><span class="op">[](</span><span class="kw">const</span> array<span class="op">&lt;</span>OtherIndexType, rank<span class="op">()&gt;&amp;</span> indices<span class="op">)</span>;</span>
+<span id="cb34-114"><a href="#cb34-114" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span><span class="op">...</span> OtherIndexTypes<span class="op">&gt;</span></span>
+<span id="cb34-115"><a href="#cb34-115" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> const_reference <span class="kw">operator</span><span class="op">[](</span>OtherIndexTypes<span class="op">...</span> indices<span class="op">)</span> <span class="kw">const</span>;</span>
+<span id="cb34-116"><a href="#cb34-116" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherIndexType<span class="op">&gt;</span></span>
+<span id="cb34-117"><a href="#cb34-117" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> const_reference <span class="kw">operator</span><span class="op">[](</span>span<span class="op">&lt;</span>OtherIndexType, rank<span class="op">()&gt;</span> indices<span class="op">)</span> <span class="kw">const</span>;</span>
+<span id="cb34-118"><a href="#cb34-118" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherIndexType<span class="op">&gt;</span></span>
+<span id="cb34-119"><a href="#cb34-119" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> const_reference <span class="kw">operator</span><span class="op">[](</span><span class="kw">const</span> array<span class="op">&lt;</span>OtherIndexType, rank<span class="op">()&gt;&amp;</span> indices<span class="op">)</span> <span class="kw">const</span>;</span>
+<span id="cb34-120"><a href="#cb34-120" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-121"><a href="#cb34-121" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> size_type size<span class="op">()</span> <span class="kw">const</span>;</span>
+<span id="cb34-122"><a href="#cb34-122" aria-hidden="true" tabindex="-1"></a>  <span class="op">[[</span><span class="at">nodiscard</span><span class="op">]]</span> <span class="kw">constexpr</span> <span class="dt">bool</span> empty<span class="op">()</span> <span class="kw">const</span> <span class="kw">noexcept</span>;</span>
+<span id="cb34-123"><a href="#cb34-123" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-124"><a href="#cb34-124" aria-hidden="true" tabindex="-1"></a>  <span class="kw">friend</span> <span class="kw">constexpr</span> <span class="dt">void</span> swap<span class="op">(</span>mdarray<span class="op">&amp;</span> x, mdarray<span class="op">&amp;</span> y<span class="op">)</span> <span class="kw">noexcept</span>;</span>
+<span id="cb34-125"><a href="#cb34-125" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-126"><a href="#cb34-126" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> <span class="kw">const</span> extents_type<span class="op">&amp;</span> extents<span class="op">()</span> <span class="kw">const</span> <span class="op">{</span> <span class="cf">return</span> <em>map_</em><span class="op">.</span>extents<span class="op">()</span>; <span class="op">}</span></span>
+<span id="cb34-127"><a href="#cb34-127" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> pointer data<span class="op">()</span> <span class="op">{</span> <span class="cf">return</span> ctr\_<span class="op">.</span>data<span class="op">()</span>; <span class="op">}</span></span>
+<span id="cb34-128"><a href="#cb34-128" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> const_pointer data<span class="op">()</span> <span class="kw">const</span> <span class="op">{</span> <span class="cf">return</span> ctr\_<span class="op">.</span>data<span class="op">()</span>; <span class="op">}</span></span>
+<span id="cb34-129"><a href="#cb34-129" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> <span class="kw">const</span> mapping_type<span class="op">&amp;</span> mapping<span class="op">()</span> <span class="kw">const</span> <span class="op">{</span> <span class="cf">return</span> <em>map_</em>; <span class="op">}</span></span>
+<span id="cb34-130"><a href="#cb34-130" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-131"><a href="#cb34-131" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherElementType, <span class="kw">class</span> OtherExtents,</span>
+<span id="cb34-132"><a href="#cb34-132" aria-hidden="true" tabindex="-1"></a>           <span class="kw">class</span> OtherLayoutType, <span class="kw">class</span> OtherAccessorType<span class="op">&gt;</span></span>
+<span id="cb34-133"><a href="#cb34-133" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> <span class="kw">operator</span> mdspan <span class="op">()</span> <span class="kw">const</span>;</span>
+<span id="cb34-134"><a href="#cb34-134" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-135"><a href="#cb34-135" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherAccessorType <span class="op">=</span> default_accessor<span class="op">&lt;</span>element_type<span class="op">&gt;&gt;</span></span>
+<span id="cb34-136"><a href="#cb34-136" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdspan<span class="op">&lt;</span>element_type, extents_type, layout_type, OtherAccessorType<span class="op">&gt;</span></span>
+<span id="cb34-137"><a href="#cb34-137" aria-hidden="true" tabindex="-1"></a>      to_mdspan<span class="op">(</span><span class="kw">const</span> OtherAccessorType<span class="op">&amp;</span> a <span class="op">=</span> default_accessor<span class="op">&lt;</span>element_type<span class="op">&gt;())</span>;</span>
+<span id="cb34-138"><a href="#cb34-138" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherAccessorType <span class="op">=</span> default_accessor<span class="op">&lt;</span><span class="kw">const</span> element_type<span class="op">&gt;&gt;</span></span>
+<span id="cb34-139"><a href="#cb34-139" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdspan<span class="op">&lt;</span><span class="kw">const</span> element_type, extents_type, layout_type, OtherAccessorType<span class="op">&gt;</span></span>
+<span id="cb34-140"><a href="#cb34-140" aria-hidden="true" tabindex="-1"></a>      to_mdspan<span class="op">(</span><span class="kw">const</span> OtherAccessorType<span class="op">&amp;</span> a <span class="op">=</span> default_accessor<span class="op">&lt;</span>const_element_type<span class="op">&gt;())</span> <span class="kw">const</span>;</span>
+<span id="cb34-141"><a href="#cb34-141" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-142"><a href="#cb34-142" aria-hidden="true" tabindex="-1"></a>  <span class="kw">static</span> <span class="kw">constexpr</span> <span class="dt">bool</span> is_always_unique<span class="op">()</span> <span class="op">{</span></span>
+<span id="cb34-143"><a href="#cb34-143" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> mapping_type<span class="op">::</span>is_always_unique<span class="op">()</span>;</span>
+<span id="cb34-144"><a href="#cb34-144" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb34-145"><a href="#cb34-145" aria-hidden="true" tabindex="-1"></a>  <span class="kw">static</span> <span class="kw">constexpr</span> <span class="dt">bool</span> is_always_exhaustive<span class="op">()</span> <span class="op">{</span></span>
+<span id="cb34-146"><a href="#cb34-146" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> mapping_type<span class="op">::</span>is_always_exhaustive<span class="op">()</span>;</span>
+<span id="cb34-147"><a href="#cb34-147" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb34-148"><a href="#cb34-148" aria-hidden="true" tabindex="-1"></a>  <span class="kw">static</span> <span class="kw">constexpr</span> <span class="dt">bool</span> is_always_strided<span class="op">()</span> <span class="op">{</span></span>
+<span id="cb34-149"><a href="#cb34-149" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> mapping_type<span class="op">::</span>is_always_strided<span class="op">()</span>;</span>
+<span id="cb34-150"><a href="#cb34-150" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb34-151"><a href="#cb34-151" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-152"><a href="#cb34-152" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> <span class="dt">bool</span> is_unique<span class="op">()</span> <span class="kw">const</span> <span class="op">{</span></span>
+<span id="cb34-153"><a href="#cb34-153" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> <em>map_</em><span class="op">.</span>is_unique<span class="op">()</span>;</span>
+<span id="cb34-154"><a href="#cb34-154" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb34-155"><a href="#cb34-155" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> <span class="dt">bool</span> is_exhaustive<span class="op">()</span> <span class="kw">const</span> <span class="op">{</span></span>
+<span id="cb34-156"><a href="#cb34-156" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> <em>map_</em><span class="op">.</span>is_exhaustive<span class="op">()</span>;</span>
+<span id="cb34-157"><a href="#cb34-157" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb34-158"><a href="#cb34-158" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> <span class="dt">bool</span> is_strided<span class="op">()</span> <span class="kw">const</span> <span class="op">{</span></span>
+<span id="cb34-159"><a href="#cb34-159" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> <em>map_</em><span class="op">.</span>is_strided<span class="op">()</span>;</span>
+<span id="cb34-160"><a href="#cb34-160" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb34-161"><a href="#cb34-161" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> index_type stride<span class="op">(</span><span class="dt">size_t</span> r<span class="op">)</span> <span class="kw">const</span> <span class="op">{</span></span>
+<span id="cb34-162"><a href="#cb34-162" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> <em>map_</em><span class="op">.</span>stride<span class="op">(</span>r<span class="op">)</span>;</span>
+<span id="cb34-163"><a href="#cb34-163" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb34-164"><a href="#cb34-164" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-165"><a href="#cb34-165" aria-hidden="true" tabindex="-1"></a><span class="kw">private</span><span class="op">:</span></span>
+<span id="cb34-166"><a href="#cb34-166" aria-hidden="true" tabindex="-1"></a>  container_type ctr_;</span>
+<span id="cb34-167"><a href="#cb34-167" aria-hidden="true" tabindex="-1"></a>  mapping_type <em>map_</em>; <span class="co">// <em>exposition only</em></span></span>
+<span id="cb34-168"><a href="#cb34-168" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
+<span id="cb34-169"><a href="#cb34-169" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-170"><a href="#cb34-170" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> Container, <span class="kw">class</span><span class="op">...</span> Integrals<span class="op">&gt;</span></span>
+<span id="cb34-171"><a href="#cb34-171" aria-hidden="true" tabindex="-1"></a><span class="kw">requires</span><span class="op">((</span>is_convertible_v<span class="op">&lt;</span>Integrals, <span class="dt">size_t</span><span class="op">&gt;</span> <span class="op">&amp;&amp;</span> <span class="op">...)</span> <span class="op">&amp;&amp;</span> <span class="kw">sizeof</span><span class="op">...(</span>Integrals<span class="op">)</span> <span class="op">&gt;</span> <span class="dv">0</span><span class="op">)</span></span>
+<span id="cb34-172"><a href="#cb34-172" aria-hidden="true" tabindex="-1"></a><span class="kw">explicit</span> mdarray<span class="op">(</span><span class="kw">const</span> Container<span class="op">&amp;</span>, Integrals<span class="op">...)</span></span>
+<span id="cb34-173"><a href="#cb34-173" aria-hidden="true" tabindex="-1"></a>  <span class="op">-&gt;</span> mdarray<span class="op">&lt;</span><span class="kw">typename</span> Container<span class="op">::</span>value_type, dextents<span class="op">&lt;</span><span class="dt">size_t</span>, <span class="kw">sizeof</span><span class="op">...(</span>Integrals<span class="op">)&gt;</span>, layout_right, Container<span class="op">&gt;</span>;</span>
+<span id="cb34-174"><a href="#cb34-174" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-175"><a href="#cb34-175" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Container, <span class="kw">class</span> Extents<span class="op">&gt;</span></span>
+<span id="cb34-176"><a href="#cb34-176" aria-hidden="true" tabindex="-1"></a>mdarray<span class="op">(</span><span class="kw">const</span> Container<span class="op">&amp;</span>, <span class="kw">const</span> Extents<span class="op">&amp;)</span></span>
+<span id="cb34-177"><a href="#cb34-177" aria-hidden="true" tabindex="-1"></a>  <span class="op">-&gt;</span> mdarray<span class="op">&lt;</span><span class="kw">typename</span> Container<span class="op">::</span>value_type, Extents, layout_right, Container<span class="op">&gt;</span>;</span>
+<span id="cb34-178"><a href="#cb34-178" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-179"><a href="#cb34-179" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Container, <span class="kw">class</span> Mapping<span class="op">&gt;</span></span>
+<span id="cb34-180"><a href="#cb34-180" aria-hidden="true" tabindex="-1"></a>mdarray<span class="op">(</span><span class="kw">const</span> Container<span class="op">&amp;</span>, <span class="kw">const</span> Mapping<span class="op">&amp;)</span></span>
+<span id="cb34-181"><a href="#cb34-181" aria-hidden="true" tabindex="-1"></a>  <span class="op">-&gt;</span> mdarray<span class="op">&lt;</span><span class="kw">typename</span> Container<span class="op">::</span>value_type, <span class="kw">typename</span> Mapping<span class="op">::</span>extents_type, layout_right, Container<span class="op">&gt;</span>;</span>
+<span id="cb34-182"><a href="#cb34-182" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-183"><a href="#cb34-183" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> Container, <span class="kw">class</span><span class="op">...</span> Integrals<span class="op">&gt;</span></span>
+<span id="cb34-184"><a href="#cb34-184" aria-hidden="true" tabindex="-1"></a><span class="kw">requires</span><span class="op">((</span>is_convertible_v<span class="op">&lt;</span>Integrals, <span class="dt">size_t</span><span class="op">&gt;</span> <span class="op">&amp;&amp;</span> <span class="op">...)</span> <span class="op">&amp;&amp;</span> <span class="kw">sizeof</span><span class="op">...(</span>Integrals<span class="op">)</span> <span class="op">&gt;</span> <span class="dv">0</span><span class="op">)</span></span>
+<span id="cb34-185"><a href="#cb34-185" aria-hidden="true" tabindex="-1"></a><span class="kw">explicit</span> mdarray<span class="op">(</span>Container<span class="op">&amp;&amp;</span>, Integrals<span class="op">...)</span></span>
+<span id="cb34-186"><a href="#cb34-186" aria-hidden="true" tabindex="-1"></a>  <span class="op">-&gt;</span> mdarray<span class="op">&lt;</span><span class="kw">typename</span> Container<span class="op">::</span>value_type, dextents<span class="op">&lt;</span><span class="dt">size_t</span>, <span class="kw">sizeof</span><span class="op">...(</span>Integrals<span class="op">)&gt;</span>, layout_right, Container<span class="op">&gt;</span>;</span>
+<span id="cb34-187"><a href="#cb34-187" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-188"><a href="#cb34-188" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Container, <span class="kw">class</span> Extents<span class="op">&gt;</span></span>
+<span id="cb34-189"><a href="#cb34-189" aria-hidden="true" tabindex="-1"></a>mdarray<span class="op">(</span>Container<span class="op">&amp;&amp;</span>, <span class="kw">const</span> Extents<span class="op">&amp;)</span></span>
+<span id="cb34-190"><a href="#cb34-190" aria-hidden="true" tabindex="-1"></a>  <span class="op">-&gt;</span> mdarray<span class="op">&lt;</span><span class="kw">typename</span> Container<span class="op">::</span>value_type, Extents, layout_right, Container<span class="op">&gt;</span>;</span>
+<span id="cb34-191"><a href="#cb34-191" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-192"><a href="#cb34-192" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Container, <span class="kw">class</span> Mapping<span class="op">&gt;</span></span>
+<span id="cb34-193"><a href="#cb34-193" aria-hidden="true" tabindex="-1"></a>mdarray<span class="op">(</span>Container<span class="op">&amp;&amp;</span>, <span class="kw">const</span> Mapping<span class="op">&amp;)</span></span>
+<span id="cb34-194"><a href="#cb34-194" aria-hidden="true" tabindex="-1"></a>  <span class="op">-&gt;</span> mdarray<span class="op">&lt;</span><span class="kw">typename</span> Container<span class="op">::</span>value_type, <span class="kw">typename</span> Mapping<span class="op">::</span>extents_type, layout_right, Container<span class="op">&gt;</span>;</span>
+<span id="cb34-195"><a href="#cb34-195" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-196"><a href="#cb34-196" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ElementType, <span class="kw">class</span> Extents, <span class="kw">class</span> Layout, <span class="kw">class</span> Accessor<span class="op">&gt;</span></span>
+<span id="cb34-197"><a href="#cb34-197" aria-hidden="true" tabindex="-1"></a>mdarray<span class="op">(</span><span class="kw">const</span> mdspan<span class="op">&lt;</span>ElementType, Extents, Layout, Accessor<span class="op">&gt;&amp;)</span></span>
+<span id="cb34-198"><a href="#cb34-198" aria-hidden="true" tabindex="-1"></a>  <span class="op">-&gt;</span> mdarray<span class="op">&lt;</span>ElementType, Extents, Layout<span class="op">&gt;</span>;</span>
+<span id="cb34-199"><a href="#cb34-199" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-200"><a href="#cb34-200" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Container, <span class="kw">class</span> Extents, <span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
+<span id="cb34-201"><a href="#cb34-201" aria-hidden="true" tabindex="-1"></a>mdarray<span class="op">(</span><span class="kw">const</span> Container<span class="op">&amp;</span>, <span class="kw">const</span> Extents<span class="op">&amp;</span>, <span class="kw">const</span> Alloc<span class="op">&amp;)</span></span>
+<span id="cb34-202"><a href="#cb34-202" aria-hidden="true" tabindex="-1"></a>  <span class="op">-&gt;</span> mdarray<span class="op">&lt;</span><span class="kw">typename</span> Container<span class="op">::</span>value_type, Extents, layout_right, Container<span class="op">&gt;</span>;</span>
+<span id="cb34-203"><a href="#cb34-203" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-204"><a href="#cb34-204" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Container, <span class="kw">class</span> Mapping, <span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
+<span id="cb34-205"><a href="#cb34-205" aria-hidden="true" tabindex="-1"></a>mdarray<span class="op">(</span><span class="kw">const</span> Container<span class="op">&amp;</span>, <span class="kw">const</span> Mapping<span class="op">&amp;</span>, <span class="kw">const</span> Alloc<span class="op">&amp;)</span></span>
+<span id="cb34-206"><a href="#cb34-206" aria-hidden="true" tabindex="-1"></a>  <span class="op">-&gt;</span> mdarray<span class="op">&lt;</span><span class="kw">typename</span> Container<span class="op">::</span>value_type, <span class="kw">typename</span> Mapping<span class="op">::</span>extents_type, layout_right, Container<span class="op">&gt;</span>;</span>
+<span id="cb34-207"><a href="#cb34-207" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-208"><a href="#cb34-208" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Container, <span class="kw">class</span> Extents, <span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
+<span id="cb34-209"><a href="#cb34-209" aria-hidden="true" tabindex="-1"></a>mdarray<span class="op">(</span>Container<span class="op">&amp;&amp;</span>, <span class="kw">const</span> Extents<span class="op">&amp;</span>, <span class="kw">const</span> Alloc<span class="op">&amp;)</span></span>
+<span id="cb34-210"><a href="#cb34-210" aria-hidden="true" tabindex="-1"></a>  <span class="op">-&gt;</span> mdarray<span class="op">&lt;</span><span class="kw">typename</span> Container<span class="op">::</span>value_type, Extents, layout_right, Container<span class="op">&gt;</span>;</span>
+<span id="cb34-211"><a href="#cb34-211" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-212"><a href="#cb34-212" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Container, <span class="kw">class</span> Mapping, <span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
+<span id="cb34-213"><a href="#cb34-213" aria-hidden="true" tabindex="-1"></a>mdarray<span class="op">(</span>Container<span class="op">&amp;&amp;</span>, <span class="kw">const</span> Mapping<span class="op">&amp;</span>, <span class="kw">const</span> Alloc<span class="op">&amp;)</span></span>
+<span id="cb34-214"><a href="#cb34-214" aria-hidden="true" tabindex="-1"></a>  <span class="op">-&gt;</span> mdarray<span class="op">&lt;</span><span class="kw">typename</span> Container<span class="op">::</span>value_type, <span class="kw">typename</span> Mapping<span class="op">::</span>extents_type, layout_right, Container<span class="op">&gt;</span>;</span>
+<span id="cb34-215"><a href="#cb34-215" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-216"><a href="#cb34-216" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ElementType, <span class="kw">class</span> Extents, <span class="kw">class</span> Layout, <span class="kw">class</span> Accessor, <span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
+<span id="cb34-217"><a href="#cb34-217" aria-hidden="true" tabindex="-1"></a>mdarray<span class="op">(</span><span class="kw">const</span> mdspan<span class="op">&lt;</span>ElementType, Extents, Layout, Accessor<span class="op">&gt;&amp;</span>, <span class="kw">const</span> Alloc<span class="op">&amp;)</span></span>
+<span id="cb34-218"><a href="#cb34-218" aria-hidden="true" tabindex="-1"></a>  <span class="op">-&gt;</span> mdarray<span class="op">&lt;</span>ElementType, Extents, Layout<span class="op">&gt;</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized">2</a></span>
+<em>Mandates:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(2.1)</a></span>
+<code class="sourceCode default">ElementType</code> is a a complete
+object type that is neither an abstract class type nor an array
+type,</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(2.2)</a></span>
+<code class="sourceCode default">Extents</code> is a specialization of
+<code class="sourceCode default">extents</code>, and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(2.3)</a></span>
+<code class="sourceCode default">is_same_v&lt;ElementType, typename Container::value_type&gt;</code>
+is <code class="sourceCode default">true</code>.</p></li>
+</ul>
+<p><span class="marginalizedparent"><a class="marginalized">3</a></span>
+<code class="sourceCode default">LayoutPolicy</code> shall meet the
+layout mapping policy requirements [mdspan.layoutpolicy.reqmts], and</p>
+<p><span class="marginalizedparent"><a class="marginalized">4</a></span>
+<code class="sourceCode default">Container</code> shall meet the
+requirements of contiguous container.</p>
+<p><span class="marginalizedparent"><a class="marginalized">5</a></span>
+Each specialization <code class="sourceCode default">MDA</code> of
+<code class="sourceCode default">mdarray</code> models
+<code class="sourceCode default">copyable</code> and</p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(5.1)</a></span>
+<code class="sourceCode default">is_nothrow_move_constructible_v&lt;MDA&gt;</code>
+is <code class="sourceCode default">true</code> if <code class="sourceCode default">is_nothrow_move_constructible_v&lt;Container&gt;</code>
+is <code class="sourceCode default">true</code>,</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(5.2)</a></span>
+<code class="sourceCode default">is_nothrow_move_assignable_v&lt;MDA&gt;</code>
+is <code class="sourceCode default">true</code> if <code class="sourceCode default">is_nothrow_move_assignable_v&lt;Container&gt;</code>
+is <code class="sourceCode default">true</code> , and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(5.3)</a></span>
+<code class="sourceCode default">is_nothrow_swappable_v&lt;MDA&gt;</code> is
+<code class="sourceCode default">true</code> if <code class="sourceCode default">is_nothrow_swappable_v&lt;Container&gt;</code>
+is <code class="sourceCode default">true</code>.</p></li>
+</ul>
+<p><span class="marginalizedparent"><a class="marginalized">6</a></span>
+A specialization of <code class="sourceCode default">mdarray</code> is a
+trivially copyable type if its
+<code class="sourceCode default">container_type</code> and
+<code class="sourceCode default">mapping_type</code> are trivially
+copyable types.</p>
+<p><b>24.6.�.2 Exposition only functions </b></p>
+<div class="sourceCode" id="cb35"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb35-1"><a href="#cb35-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ValueType, <span class="kw">class</span> Index<span class="op">&gt;</span></span>
+<span id="cb35-2"><a href="#cb35-2" aria-hidden="true" tabindex="-1"></a><span class="kw">decltype</span><span class="op">(</span><span class="kw">auto</span><span class="op">)</span> <em>just-value</em><span class="op">(</span>Index, ValueType<span class="op">&amp;&amp;</span> t<span class="op">)</span> <span class="op">{</span> <span class="cf">return</span> forward<span class="op">&lt;</span>ValueType<span class="op">&amp;&amp;&gt;(</span>t<span class="op">)</span>; <span class="op">}</span></span>
+<span id="cb35-3"><a href="#cb35-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb35-4"><a href="#cb35-4" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ValueType, <span class="dt">size_t</span> N<span class="op">&gt;</span></span>
+<span id="cb35-5"><a href="#cb35-5" aria-hidden="true" tabindex="-1"></a>array<span class="op">&lt;</span>ValueType, N<span class="op">&gt;</span></span>
+<span id="cb35-6"><a href="#cb35-6" aria-hidden="true" tabindex="-1"></a><em>value-to-array</em><span class="op">(</span><span class="kw">const</span> ValueType<span class="op">&amp;</span> t<span class="op">)</span></span>
+<span id="cb35-7"><a href="#cb35-7" aria-hidden="true" tabindex="-1"></a><span class="op">{</span></span>
+<span id="cb35-8"><a href="#cb35-8" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> <span class="op">[&amp;]&lt;</span><span class="dt">size_t</span> <span class="op">...</span> Indices<span class="op">&gt;(</span>index_sequence<span class="op">&lt;</span>Indices<span class="op">...&gt;)</span> <span class="op">{</span></span>
+<span id="cb35-9"><a href="#cb35-9" aria-hidden="true" tabindex="-1"></a>        <span class="cf">return</span> array<span class="op">&lt;</span>ValueType, N<span class="op">&gt;{</span> <em>just-value</em><span class="op">(</span>Indices, t<span class="op">)...</span> <span class="op">}</span>;</span>
+<span id="cb35-10"><a href="#cb35-10" aria-hidden="true" tabindex="-1"></a>    <span class="op">}(</span> make_index_sequence<span class="op">&lt;</span>N<span class="op">&gt;()</span> <span class="op">)</span>;</span>
+<span id="cb35-11"><a href="#cb35-11" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<!--
+
+ ##              #               #
+#   ### ##   ## ### ### # # ### ### ### ###  ##
+#   # # # #  #   #  #   # # #    #  # # #    #
+#   ### # # ##   ## #   ### ###  ## ### #   ##
+ ##
+
+-->
+<p><b>24.6.�.2 <code class="sourceCode default">mdarray</code>
+constructors [mdarray.ctors]</b></p>
+<div class="sourceCode" id="cb36"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb36-1"><a href="#cb36-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span><span class="op">...</span> OtherIndexTypes<span class="op">&gt;</span></span>
+<span id="cb36-2"><a href="#cb36-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">explicit</span> <span class="kw">constexpr</span> mdarray<span class="op">(</span>OtherIndexTypes<span class="op">...</span> exts<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized">1</a></span>
+<em>Constraints:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(1.1)</a></span>
+<code class="sourceCode default">(is_convertible_v&lt;OtherIndexTypes, index_type&gt; &amp;&amp; ...)</code>
+is <code class="sourceCode default">true</code>,</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(1.2)</a></span>
+<code class="sourceCode default">(is_nothrow_constructible_v&lt;index_type, OtherIndexTypes&gt; &amp;&amp; ...)</code>
+is <code class="sourceCode default">true</code>,</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(1.3)</a></span>
+<code class="sourceCode default">is_constructible_v&lt;extents_type, OtherIndexTypes...&gt;</code>
+is <code class="sourceCode default">true</code>,</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(1.4)</a></span>
+<code class="sourceCode default">is_constructible_v&lt;mapping_type, extents_type&gt;</code>
+is <code class="sourceCode default">true</code>, and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(1.5)</a></span> if
+<code class="sourceCode default">container_type</code> is not a
+specialization of <code class="sourceCode default">array</code>, <code class="sourceCode default">is_constructible_v&lt;container_type, size_t&gt;</code>
+is <code class="sourceCode default">true</code>.</p></li>
+</ul>
+<p><span class="marginalizedparent"><a class="marginalized">2</a></span>
+<em>Preconditions:</em></p>
+<ul>
+<li><p>[2.1] Let <code class="sourceCode default">map</code> be <code class="sourceCode default">mapping_type(extents_type(static_cast&lt;index_type&gt;(std::move(exts)...)))</code>,
+then</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(2.2)</a></span> if
+<code class="sourceCode default">container_type</code> is a
+specialization of <code class="sourceCode default">array</code>, <code class="sourceCode default">map.required_span_size() &lt;= size(container_type())</code>
+is <code class="sourceCode default">true</code>, otherwise</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(2.3)</a></span>
+<code class="sourceCode default">map.required_span_size() &lt;= size(container_type(map.required_span_size()))</code>
+is <code class="sourceCode default">true</code>.</p></li>
+</ul>
+<p><span class="marginalizedparent"><a class="marginalized">3</a></span>
+<em>Effects:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(3.1)</a></span>
+Direct-non-list-initializes
+<em><code class="sourceCode default">map_</code></em> with <code class="sourceCode default">extents_type(static_cast&lt;index_type&gt;(std::move(exts))...)</code>,
+and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(3.2)</a></span> if
+<code class="sourceCode default">is_constructible_v&lt;container_type, size_t&gt;</code>
+is <code class="sourceCode default">true</code>,
+direct-non-list-initializes <code class="sourceCode default">ctr_</code>
+with
+<code class="sourceCode default">container_type(</code><em><code class="sourceCode default">map_</code></em><code class="sourceCode default">.required_span_size())</code>,
+otherwise default constructs
+<code class="sourceCode default">ctr_</code>.</p></li>
+</ul>
+<div class="sourceCode" id="cb37"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb37-1"><a href="#cb37-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> extents_type<span class="op">&amp;</span> ext<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized">4</a></span>
+<em>Constraints:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(4.1)</a></span>
+<code class="sourceCode default">is_constructible_v&lt;mapping_type, const extents_type&amp;&gt;</code>
+is <code class="sourceCode default">true</code>, and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(4.2)</a></span> if
+<code class="sourceCode default">container_type</code> is not a
+specialization of <code class="sourceCode default">array</code>, <code class="sourceCode default">is_constructible_v&lt;container_type, size_t&gt;</code>
+is <code class="sourceCode default">true</code>.</p></li>
+</ul>
+<p><span class="marginalizedparent"><a class="marginalized">5</a></span>
+<em>Preconditions:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(5.1)</a></span> Let
+<code class="sourceCode default">map</code> be
+<code class="sourceCode default">mapping_type(ext)</code>, then</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(5.2)</a></span> if
+<code class="sourceCode default">container_type</code> is a
+specialization of <code class="sourceCode default">array</code>, <code class="sourceCode default">map.required_span_size() &lt;= size(container_type())</code>
+is <code class="sourceCode default">true</code>, otherwise</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(5.3)</a></span>
+<code class="sourceCode default">map.required_span_size() &lt;= size(container_type(map.required_span_size()))</code>
+is <code class="sourceCode default">true</code>.</p></li>
+</ul>
+<p><span class="marginalizedparent"><a class="marginalized">6</a></span>
+<em>Effects:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(6.1)</a></span>
+Direct-non-list-initializes
+<em><code class="sourceCode default">map_</code></em> with
+<code class="sourceCode default">ext</code>, and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(6.2)</a></span> if
+<code class="sourceCode default">is_constructible_v&lt;container_type, size_t&gt;</code>
+is <code class="sourceCode default">true</code>,
+direct-non-list-initializes <code class="sourceCode default">ctr_</code>
+with
+<code class="sourceCode default">container_type(</code><em><code class="sourceCode default">map_</code></em><code class="sourceCode default">.required_span_size())</code>,
+otherwise default constructs
+<code class="sourceCode default">ctr_</code>.</p></li>
+</ul>
+<div class="sourceCode" id="cb38"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb38-1"><a href="#cb38-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> mapping_type<span class="op">&amp;</span> map<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized">7</a></span>
+<em>Constraints:</em> if
+<code class="sourceCode default">container_type</code> is not a
+specialization of <code class="sourceCode default">array</code>, <code class="sourceCode default">is_constructible_v&lt;container_type, size_t&gt;</code>
+is <code class="sourceCode default">true</code>.</p>
+<p><span class="marginalizedparent"><a class="marginalized">8</a></span>
+<em>Preconditions:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(8.1)</a></span> if
+<code class="sourceCode default">container_type</code> is a
+specialization of <code class="sourceCode default">array</code>, <code class="sourceCode default">map.required_span_size() &lt;= size(container_type())</code>
+is <code class="sourceCode default">true</code>, otherwise</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(8.2)</a></span>
+<code class="sourceCode default">map.required_span_size() &lt;= size(container_type(map.required_span_size()))</code>
+is <code class="sourceCode default">true</code>.</p></li>
+</ul>
+<p><span class="marginalizedparent"><a class="marginalized">9</a></span>
+<em>Effects:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(9.1)</a></span>
+Direct-non-list-initializes
+<em><code class="sourceCode default">map_</code></em> with
+<code class="sourceCode default">map</code>, and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(9.2)</a></span> If
+<code class="sourceCode default">is_constructible_v&lt;container_type, size_t&gt;</code>
+is <code class="sourceCode default">true</code>,
+direct-non-list-initializes <code class="sourceCode default">ctr_</code>
+with
+<code class="sourceCode default">container_type(</code><em><code class="sourceCode default">map_</code></em><code class="sourceCode default">.required_span_size())</code>,
+otherwise default constructs
+<code class="sourceCode default">ctr_</code>.</p></li>
+</ul>
+<div class="sourceCode" id="cb39"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb39-1"><a href="#cb39-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> extents_type<span class="op">&amp;</span> ext, <span class="kw">const</span> value_type<span class="op">&amp;</span> val<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized">10</a></span>
+<em>Constraints:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(10.1)</a></span>
+<code class="sourceCode default">is_constructible_v&lt;mapping_type, const extents_type&amp;&gt;</code>
+is <code class="sourceCode default">true</code>, and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(10.2)</a></span> if
+<code class="sourceCode default">container_type</code> is not a
+specialization of <code class="sourceCode default">array</code>, <code class="sourceCode default">is_constructible_v&lt;container_type, size_t, value_type&gt;</code>
+is <code class="sourceCode default">true</code>.</p></li>
+</ul>
+<p><span class="marginalizedparent"><a class="marginalized">11</a></span>
+<em>Preconditions:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(11.1)</a></span> Let
+<code class="sourceCode default">map</code> be
+<code class="sourceCode default">mapping_type(ext)</code>, then</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(11.2)</a></span> if
+<code class="sourceCode default">container_type</code> is a
+specialization of <code class="sourceCode default">array</code>, <code class="sourceCode default">map.required_span_size() &lt;= size(container_type())</code>
+is <code class="sourceCode default">true</code>, otherwise</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(11.3)</a></span>
+<code class="sourceCode default">map.required_span_size() &lt;= size(container_type(map.required_span_size()))</code>
+is <code class="sourceCode default">true</code>.</p></li>
+</ul>
+<p><span class="marginalizedparent"><a class="marginalized">12</a></span>
+<em>Effects:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(12.1)</a></span>
+Direct-non-list-initializes
+<em><code class="sourceCode default">map_</code></em> with
+<code class="sourceCode default">ext</code>, and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(12.2)</a></span> if
+<code class="sourceCode default">is_constructible_v&lt;container_type, size_t, value_type&gt;</code>
+is <code class="sourceCode default">true</code>,
+direct-non-list-initializes <code class="sourceCode default">ctr_</code>
+with
+<code class="sourceCode default">container_type(</code><em><code class="sourceCode default">map_</code></em><code class="sourceCode default">.required_span_size(), val)</code>,
+otherwise direct-non-list-initializes
+<code class="sourceCode default">ctr_</code> with
+<em><code class="sourceCode default">value-to-array</code></em><code class="sourceCode default">&lt;element_type, size(declval&lt;container_type&gt;())&gt;()</code>.</p></li>
+</ul>
+<div class="sourceCode" id="cb40"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb40-1"><a href="#cb40-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> mapping_type<span class="op">&amp;</span> m, <span class="kw">const</span> value_type<span class="op">&amp;</span> val<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized">13</a></span>
+<em>Constraints:</em> if
+<code class="sourceCode default">container_type</code> is not a
+specialization of <code class="sourceCode default">array</code>, <code class="sourceCode default">is_constructible_v&lt;container_type, size_t, value_type&gt;</code>
+is <code class="sourceCode default">true</code>.</p>
+<p><span class="marginalizedparent"><a class="marginalized">14</a></span>
+<em>Preconditions:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(14.1)</a></span> if
+<code class="sourceCode default">container_type</code> is a
+specialization of <code class="sourceCode default">array</code>, <code class="sourceCode default">map.required_span_size() &lt;= size(container_type())</code>
+is <code class="sourceCode default">true</code>, otherwise</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(14.2)</a></span>
+<code class="sourceCode default">map.required_span_size() &lt;= size(container_type(map.required_span_size(), val))</code>
+is <code class="sourceCode default">true</code>.</p></li>
+</ul>
+<p><span class="marginalizedparent"><a class="marginalized">15</a></span>
+<em>Effects:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(15.1)</a></span>
+Direct-non-list-initializes
+<em><code class="sourceCode default">map_</code></em> with
+<code class="sourceCode default">m</code>, and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(15.2)</a></span> if
+<code class="sourceCode default">is_constructible_v&lt;container_type, size_t, value_type&gt;</code>
+is <code class="sourceCode default">true</code>,
+direct-non-list-initializes <code class="sourceCode default">ctr_</code>
+with
+<code class="sourceCode default">container_type(</code><em><code class="sourceCode default">map_</code></em><code class="sourceCode default">.required_span_size(), val)</code>,
+otherwise direct-non-list-initializes
+<code class="sourceCode default">ctr_</code> with
+<em><code class="sourceCode default">value-to-array</code></em><code class="sourceCode default">&lt;element_type, size(declval&lt;container_type&gt;())&gt;()</code>.</p></li>
+</ul>
+<div class="sourceCode" id="cb41"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb41-1"><a href="#cb41-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span><span class="op">...</span> OtherIndexTypes<span class="op">&gt;</span></span>
+<span id="cb41-2"><a href="#cb41-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">explicit</span> <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> container_type<span class="op">&amp;</span> c, OtherIndexTypes<span class="op">...</span> exts<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized">16</a></span>
+<em>Constraints:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(16.1)</a></span>
+<code class="sourceCode default">(is_convertible_v&lt;OtherIndexTypes, index_type&gt; &amp;&amp; ...)</code>
+is <code class="sourceCode default">true</code>,</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(16.2)</a></span>
+<code class="sourceCode default">(is_nothrow_constructible_v&lt;index_type, OtherIndexTypes&gt; &amp;&amp; ...)</code>
+is <code class="sourceCode default">true</code>,</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(16.3)</a></span>
+<code class="sourceCode default">is_constructible_v&lt;extents_type, OtherIndexTypes...&gt;</code>
+is <code class="sourceCode default">true</code>,</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(16.4)</a></span>
+<code class="sourceCode default">is_constructible_v&lt;mapping_type, extents_type&gt;</code>
+is <code class="sourceCode default">true</code>, and</p></li>
+</ul>
+<p><span class="marginalizedparent"><a class="marginalized">17</a></span>
+<em>Preconditions:</em> <code class="sourceCode default">c.size() &gt;= mapping_type(extents_type(static_cast&lt;index_type&gt;(std::move(exts))...)).required_span_size()</code>
+is <code class="sourceCode default">true</code>.</p>
+<p><span class="marginalizedparent"><a class="marginalized">18</a></span>
+<em>Effects:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(18.1)</a></span>
+Direct-non-list-initializes
+<em><code class="sourceCode default">map_</code></em> with <code class="sourceCode default">extents_type(static_cast&lt;index_type&gt;(std::move(exts))...)</code>,
+and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(18.2)</a></span>
+Direct-non-list-initializes <code class="sourceCode default">ctr_</code>
+with <code class="sourceCode default">c</code>.</p></li>
+</ul>
+<div class="sourceCode" id="cb42"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb42-1"><a href="#cb42-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> container_type<span class="op">&amp;</span> c, <span class="kw">const</span> extents_type<span class="op">&amp;</span> ext<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized">19</a></span>
+<em>Constraints:</em> <code class="sourceCode default">is_constructible_v&lt;mapping_type, const extents_type&amp;&gt;</code>
+is <code class="sourceCode default">true</code>, and</p>
+<p><span class="marginalizedparent"><a class="marginalized">20</a></span>
+<em>Preconditions:</em> <code class="sourceCode default">c.size() &gt;= mapping_type(ext).required_span_size()</code>
+is <code class="sourceCode default">true</code>.</p>
+<p><span class="marginalizedparent"><a class="marginalized">21</a></span>
+<em>Effects:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(21.1)</a></span>
+Direct-non-list-initializes
+<em><code class="sourceCode default">map_</code></em> with
+<code class="sourceCode default">ext</code>, and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(21.2)</a></span>
+Direct-non-list-initializes <code class="sourceCode default">ctr_</code>
+with <code class="sourceCode default">c</code>.</p></li>
+</ul>
+<div class="sourceCode" id="cb43"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb43-1"><a href="#cb43-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> container_type<span class="op">&amp;</span> c, <span class="kw">const</span> mapping_type<span class="op">&amp;</span> m<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized">22</a></span>
+<em>Preconditions:</em> <code class="sourceCode default">c.size() &gt;= m.required_span_size()</code>
+is <code class="sourceCode default">true</code>.</p>
+<p><span class="marginalizedparent"><a class="marginalized">23</a></span>
+<em>Effects:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(23.1)</a></span>
+Direct-non-list-initializes
+<em><code class="sourceCode default">map_</code></em> with
+<code class="sourceCode default">m</code>, and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(23.2)</a></span>
+Direct-non-list-initializes <code class="sourceCode default">ctr_</code>
+with <code class="sourceCode default">c</code>.</p></li>
+</ul>
+<div class="sourceCode" id="cb44"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb44-1"><a href="#cb44-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span><span class="op">...</span> OtherIndexTypes<span class="op">&gt;</span></span>
+<span id="cb44-2"><a href="#cb44-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">explicit</span> <span class="kw">constexpr</span> mdarray<span class="op">(</span>container_type<span class="op">&amp;&amp;</span> c, OtherIndexTypes<span class="op">...</span> exts<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized">24</a></span>
+<em>Constraints:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(24.1)</a></span>
+<code class="sourceCode default">(is_convertible_v&lt;OtherIndexTypes, index_type&gt; &amp;&amp; ...)</code>
+is <code class="sourceCode default">true</code>,</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(24.2)</a></span>
+<code class="sourceCode default">(is_nothrow_constructible_v&lt;index_type, OtherIndexTypes&gt; &amp;&amp; ...)</code>
+is <code class="sourceCode default">true</code>,</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(24.3)</a></span>
+<code class="sourceCode default">is_constructible_v&lt;extents_type, static_cast&lt;index_type&gt;(OtherIndexTypes)...&gt;</code>
+is <code class="sourceCode default">true</code>,</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(24.4)</a></span>
+<code class="sourceCode default">is_constructible_v&lt;mapping_type, extents_type&gt;</code>
+is <code class="sourceCode default">true</code>, and</p></li>
+</ul>
+<p><span class="marginalizedparent"><a class="marginalized">25</a></span>
+<em>Preconditions:</em> <code class="sourceCode default">c.size() &gt;= mapping_type(extents_type(static_cast&lt;index_type&gt;(std::move(exts))...)).required_span_size()</code>
+is <code class="sourceCode default">true</code>.</p>
+<p><span class="marginalizedparent"><a class="marginalized">26</a></span>
+<em>Effects:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(26.1)</a></span>
+Direct-non-list-initializes
+<em><code class="sourceCode default">map_</code></em> with <code class="sourceCode default">extents_type(static_cast&lt;index_type&gt;(std::move(exts))...)</code>,
+and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(26.2)</a></span>
+Direct-non-list-initializes <code class="sourceCode default">ctr_</code>
+with <code class="sourceCode default">std::move(c)</code>.</p></li>
+</ul>
+<div class="sourceCode" id="cb45"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb45-1"><a href="#cb45-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> mdarray<span class="op">(</span>container_type<span class="op">&amp;&amp;</span> c, <span class="kw">const</span> extents_type<span class="op">&amp;</span> ext<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized">27</a></span>
+<em>Constraints:</em> <code class="sourceCode default">is_constructible_v&lt;mapping_type, const extents_type&amp;&gt;</code>
+is <code class="sourceCode default">true</code>, and</p>
+<p><span class="marginalizedparent"><a class="marginalized">28</a></span>
+<em>Preconditions:</em> <code class="sourceCode default">c.size() &gt;= mapping_type(ext).required_span_size()</code>
+is <code class="sourceCode default">true</code>.</p>
+<p><span class="marginalizedparent"><a class="marginalized">29</a></span>
+<em>Effects:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(29.1)</a></span>
+Direct-non-list-initializes
+<em><code class="sourceCode default">map_</code></em> with
+<code class="sourceCode default">ext</code>, and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(29.2)</a></span>
+Direct-non-list-initializes <code class="sourceCode default">ctr_</code>
+with <code class="sourceCode default">std::move(c)</code>.</p></li>
+</ul>
+<div class="sourceCode" id="cb46"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb46-1"><a href="#cb46-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> mdarray<span class="op">(</span>container_type<span class="op">&amp;&amp;</span> c, <span class="kw">const</span> mapping_type<span class="op">&amp;</span> m<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized">30</a></span>
+<em>Preconditions:</em> <code class="sourceCode default">c.size() &gt;= m.required_span_size()</code>
+is <code class="sourceCode default">true</code>.</p>
+<p><span class="marginalizedparent"><a class="marginalized">31</a></span>
+<em>Effects:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(31.1)</a></span>
+Direct-non-list-initializes
+<em><code class="sourceCode default">map_</code></em> with
+<code class="sourceCode default">m</code>, and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(31.2)</a></span>
+Direct-non-list-initializes <code class="sourceCode default">ctr_</code>
+with <code class="sourceCode default">std::move(c)</code>.</p></li>
+</ul>
+<div class="sourceCode" id="cb47"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb47-1"><a href="#cb47-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherElementType, <span class="kw">class</span> OtherExtents,</span>
+<span id="cb47-2"><a href="#cb47-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> OtherLayoutPolicy, <span class="kw">class</span> OtherContainer<span class="op">&gt;</span></span>
+<span id="cb47-3"><a href="#cb47-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">explicit</span><span class="op">(</span><em>see below</em><span class="op">)</span></span>
+<span id="cb47-4"><a href="#cb47-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> mdarray<span class="op">&lt;</span>OtherElementType, OtherExtents, </span>
+<span id="cb47-5"><a href="#cb47-5" aria-hidden="true" tabindex="-1"></a>                                OtherLayoutPolicy, OtherContainer<span class="op">&gt;&amp;</span> other<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized">32</a></span>
+<em>Mandates:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(32.1)</a></span>
+<code class="sourceCode default">is_constructible_v&lt;Container, const OtherContainer&amp;&gt;</code>
+is <code class="sourceCode default">true</code>, and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(32.2)</a></span>
+<code class="sourceCode default">is_constructible_v&lt;extents_type, OtherExtents&gt;</code>
+is <code class="sourceCode default">true</code>.</p></li>
+</ul>
+<p><span class="marginalizedparent"><a class="marginalized">33</a></span>
+<em>Constraints:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(33.1)</a></span>
+<code class="sourceCode default">is_constructible_v&lt;mapping_type, const OtherLayoutPolicy::template mapping&lt;OtherExtents&gt;&amp;&gt;</code>
+is <code class="sourceCode default">true</code>, and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(33.2)</a></span>
+<code class="sourceCode default">is_constructible_v&lt;container_type, OtherContainer&gt;</code>
+is <code class="sourceCode default">true</code>.</p></li>
+</ul>
+<p><span class="marginalizedparent"><a class="marginalized">34</a></span>
+<em>Preconditions:</em> For each rank index
+<code class="sourceCode default">r</code> of
+<code class="sourceCode default">extents_type</code>, <code class="sourceCode default">static_extent(r) == dynamic_extent || static_extent(r) == other.extent(r)</code>
+is <code class="sourceCode default">true</code>.</p>
+<p><span class="marginalizedparent"><a class="marginalized">35</a></span>
+<em>Effects:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(35.1)</a></span>
+Direct-non-list-initializes <code class="sourceCode default">ctr_</code>
+with <code class="sourceCode default">other.ctr_</code>, and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(35.2)</a></span>
+Direct-non-list-initializes
+<em><code class="sourceCode default">map_</code></em> with
+<code class="sourceCode default">other.</code><em><code class="sourceCode default">map_</code></em>.</p></li>
+</ul>
+<p><span class="marginalizedparent"><a class="marginalized">36</a></span>
+<em>Remarks:</em> The expression inside
+<code class="sourceCode default">explicit</code> is:</p>
+<div class="sourceCode" id="cb48"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb48-1"><a href="#cb48-1" aria-hidden="true" tabindex="-1"></a>  <span class="op">!</span>is_convertible_v<span class="op">&lt;</span><span class="kw">const</span> <span class="kw">typename</span> OtherLayoutPolicy<span class="op">::</span>mapping_type<span class="op">&amp;</span>, mapping_type<span class="op">&gt;</span> <span class="op">||</span></span>
+<span id="cb48-2"><a href="#cb48-2" aria-hidden="true" tabindex="-1"></a>  <span class="op">!</span>is_convertible_v<span class="op">&lt;</span><span class="kw">const</span> OtherContainer<span class="op">&amp;</span>, Container<span class="op">&gt;</span></span></code></pre></div>
+<div class="sourceCode" id="cb49"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb49-1"><a href="#cb49-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherElementType, <span class="kw">class</span> OtherExtents,</span>
+<span id="cb49-2"><a href="#cb49-2" aria-hidden="true" tabindex="-1"></a>           <span class="kw">class</span> OtherLayoutPolicy, <span class="kw">class</span> Accessor<span class="op">&gt;</span></span>
+<span id="cb49-3"><a href="#cb49-3" aria-hidden="true" tabindex="-1"></a>    <span class="kw">explicit</span><span class="op">(</span><em>see below</em><span class="op">)</span></span>
+<span id="cb49-4"><a href="#cb49-4" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> mdspan<span class="op">&lt;</span>OtherElementType, OtherExtents,</span>
+<span id="cb49-5"><a href="#cb49-5" aria-hidden="true" tabindex="-1"></a>                                   OtherLayoutPolicy, Accessor<span class="op">&gt;&amp;</span> other<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized">37</a></span>
+<em>Mandates:</em></p>
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized">(37.1)</a></span>
+<code class="sourceCode default">is_constructible_v&lt;extents_type, OtherExtents&gt;</code>
+is <code class="sourceCode default">true</code>.</li>
+</ul>
+<p><span class="marginalizedparent"><a class="marginalized">38</a></span>
+<em>Constraints:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(38.1)</a></span>
+<code class="sourceCode default">is_constructible_v&lt;value_type, Accessor::reference&gt;</code>
+is <code class="sourceCode default">true</code>,</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(38.2)</a></span>
+<code class="sourceCode default">is_assignable_v&lt;Accessor::reference, value_type&gt;</code>
+is <code class="sourceCode default">true</code>,</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(38.3)</a></span>
+<code class="sourceCode default">is_default_constructible_v&lt;value_type&gt;</code>
+is <code class="sourceCode default">true</code>,</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(38.4)</a></span>
+<code class="sourceCode default">is_constructible_v&lt;mapping_type, const OtherLayoutPolicy::template mapping&lt;OtherExtents&gt;&amp;&gt;</code>
+is <code class="sourceCode default">true</code>, and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(38.5)</a></span> if
+<code class="sourceCode default">container_type</code> is not a
+specialization of <code class="sourceCode default">array</code>, <code class="sourceCode default">is_constructible_v&lt;container_type, size_t&gt;</code>
+is <code class="sourceCode default">true</code>.</p></li>
+</ul>
+<p><span class="marginalizedparent"><a class="marginalized">39</a></span>
+<em>Preconditions:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(39.1)</a></span> For
+each rank index <code class="sourceCode default">r</code> of
+<code class="sourceCode default">extents_type</code>, <code class="sourceCode default">static_extent(r) == dynamic_extent || static_extent(r) == other.extent(r)</code>
+is <code class="sourceCode default">true</code>, and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(39.2)</a></span> if
+<code class="sourceCode default">container_type</code> is a
+specialization of <code class="sourceCode default">array</code>, then
+<code class="sourceCode default">container_type().size() &gt;= other.mapping().required_span_size()</code>.</p></li>
+</ul>
+<p><span class="marginalizedparent"><a class="marginalized">40</a></span>
+<em>Effects:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(40.1)</a></span>
+Direct-non-list-initializes
+<em><code class="sourceCode default">map_</code></em> with
+<code class="sourceCode default">other.mapping()</code>;</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(40.2)</a></span> If
+<code class="sourceCode default">is_constructible_v&lt;container_type, size_t&gt;</code>
+is <code class="sourceCode default">true</code>,
+direct-non-list-initializes <code class="sourceCode default">ctr_</code>
+with <code class="sourceCode default">container_type(other.mapping().required_span_size())</code>,
+otherwise default constructs
+<em><code class="sourceCode default">ctr_</code></em>; and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(40.3)</a></span> For
+all unique multidimensional indices
+<code class="sourceCode default">i...</code> in
+<code class="sourceCode default">other.extents()</code>, assigns
+<code class="sourceCode default">other[i...]</code> to
+<code class="sourceCode default">ctr_[</code><em><code class="sourceCode default">map_</code></em><code class="sourceCode default">(i...)]</code>.</p></li>
+</ul>
+<p><i>[Note:</i> Requiring default constructibility of
+<code class="sourceCode default">value_type</code> means that
+<code class="sourceCode default">ctr_</code> may first be constructed
+with its required span size, and then filled by iterating over all
+unique multidimensional indices
+<code class="sourceCode default">i...</code> in the
+<code class="sourceCode default">mdarray</code>’s domain. Alternately,
+<code class="sourceCode default">ctr_</code> may be constructed via
+<code class="sourceCode default">ranges::to</code>, if the elements of
+<code class="sourceCode default">other</code> can be viewed by a range.
+The intent is to permit
+<code class="sourceCode default">ranges::to</code> initialization of
+<code class="sourceCode default">ctr_</code> if possible, without
+requiring a particular iteration order (as the best-performing order can
+depend sensitively on the two layouts) or even requiring all
+<code class="sourceCode default">mdspan</code> to be iterable by a
+range.<i>— end note]</i></p>
+<p><span class="marginalizedparent"><a class="marginalized">41</a></span>
+<em>Remarks:</em> The expression inside
+<code class="sourceCode default">explicit</code> is:</p>
+<div class="sourceCode" id="cb50"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb50-1"><a href="#cb50-1" aria-hidden="true" tabindex="-1"></a>  <span class="op">!</span>is_convertible_v<span class="op">&lt;</span><span class="kw">const</span> <span class="kw">typename</span> OtherLayoutPolicy<span class="op">::</span>mapping_type<span class="op">&amp;</span>, mapping_type<span class="op">&gt;</span> <span class="op">||</span></span>
+<span id="cb50-2"><a href="#cb50-2" aria-hidden="true" tabindex="-1"></a>  <span class="op">!</span>is_convertible_v<span class="op">&lt;</span>Accessor<span class="op">::</span>reference, value_type<span class="op">&gt;</span></span></code></pre></div>
+<p><b>24.6.�.3 <code class="sourceCode default">mdarray</code>
+constructors with allocators [mdarray.ctors.alloc]</b></p>
+<div class="sourceCode" id="cb51"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb51-1"><a href="#cb51-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
+<span id="cb51-2"><a href="#cb51-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> extents_type<span class="op">&amp;</span> ext, <span class="kw">const</span> Alloc<span class="op">&amp;</span> a<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized">1</a></span>
+<em>Constraints:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(1.1)</a></span>
+<code class="sourceCode default">is_constructible_v&lt;mapping_type, const extents_type&amp;&gt;</code>
+is <code class="sourceCode default">true</code>, and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(1.2)</a></span>
+<code class="sourceCode default">is_constructible_v&lt;container_type, size_t, Alloc&gt;</code>
+is <code class="sourceCode default">true</code>.</p></li>
+</ul>
+<p><span class="marginalizedparent"><a class="marginalized">2</a></span>
+<em>Preconditions:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(2.1)</a></span> Let
+<code class="sourceCode default">map</code> be
+<code class="sourceCode default">mapping_type(ext)</code>, then</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(2.2)</a></span> if
+<code class="sourceCode default">container_type</code> is a
+specialization of <code class="sourceCode default">array</code>, <code class="sourceCode default">map.required_span_size() &lt;= size(container_type())</code>
+is <code class="sourceCode default">true</code>, otherwise</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(2.3)</a></span>
+<code class="sourceCode default">map.required_span_size() &lt;= size(container_type(map.required_span_size(), a))</code>
+is <code class="sourceCode default">true</code>.</p></li>
+</ul>
+<p><span class="marginalizedparent"><a class="marginalized">3</a></span>
+<em>Effects:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(3.1)</a></span>
+Direct-non-list-initializes
+<em><code class="sourceCode default">map_</code></em> with
+<code class="sourceCode default">ext</code>, and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(3.2)</a></span>
+Direct-non-list-initializes <code class="sourceCode default">ctr_</code>
+with
+<em><code class="sourceCode default">map_</code></em><code class="sourceCode default">.required_span_size()</code>
+as the first argument and <code class="sourceCode default">a</code> as
+the second argument.</p></li>
+</ul>
+<div class="sourceCode" id="cb52"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb52-1"><a href="#cb52-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
+<span id="cb52-2"><a href="#cb52-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> mapping_type<span class="op">&amp;</span> map, <span class="kw">const</span> Alloc<span class="op">&amp;</span> a<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized">4</a></span>
+<em>Constraints:</em> <code class="sourceCode default">is_constructible_v&lt;container_type, size_t, Alloc&gt;</code>
+is <code class="sourceCode default">true</code>.</p>
+<p><span class="marginalizedparent"><a class="marginalized">5</a></span>
+<em>Preconditions:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(5.1)</a></span> if
+<code class="sourceCode default">container_type</code> is a
+specialization of <code class="sourceCode default">array</code>, <code class="sourceCode default">map.required_span_size() &lt;= size(container_type())</code>
+is <code class="sourceCode default">true</code>, otherwise</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(5.2)</a></span>
+<code class="sourceCode default">map.required_span_size() &lt;= size(container_type(map.required_span_size(), a))</code>
+is <code class="sourceCode default">true</code>.</p></li>
+</ul>
+<p><span class="marginalizedparent"><a class="marginalized">6</a></span>
+<em>Effects:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(6.1)</a></span>
+Direct-non-list-initializes
+<em><code class="sourceCode default">map_</code></em> with
+<code class="sourceCode default">map</code>, and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(6.2)</a></span>
+Direct-non-list-initializes <code class="sourceCode default">ctr_</code>
+with <code class="sourceCode default">map.required_span_size()</code> as
+the first argument and <code class="sourceCode default">a</code> as the
+second argument.</p></li>
+</ul>
+<div class="sourceCode" id="cb53"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb53-1"><a href="#cb53-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
+<span id="cb53-2"><a href="#cb53-2" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> extents_type<span class="op">&amp;</span> ext, <span class="kw">const</span> value_type<span class="op">&amp;</span> val, <span class="kw">const</span> Alloc<span class="op">&amp;</span> a<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized">7</a></span>
+<em>Constraints:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(7.1)</a></span>
+<code class="sourceCode default">is_constructible_v&lt;mapping_type, const extents_type&amp;&gt;</code>
+is <code class="sourceCode default">true</code>, and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(7.2)</a></span> if
+<code class="sourceCode default">container_type</code> is not a
+specialization of <code class="sourceCode default">array</code>, <code class="sourceCode default">is_constructible_v&lt;container_type, size_t, value_type, Alloc&gt;</code>
+is <code class="sourceCode default">true</code>.</p></li>
+</ul>
+<p><span class="marginalizedparent"><a class="marginalized">8</a></span>
+<em>Preconditions:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(8.1)</a></span> Let
+<code class="sourceCode default">map</code> be
+<code class="sourceCode default">mapping_type(ext)</code>, then</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(8.2)</a></span> if
+<code class="sourceCode default">container_type</code> is a
+specialization of <code class="sourceCode default">array</code>, <code class="sourceCode default">map.required_span_size() &lt;= size(container_type())</code>
+is <code class="sourceCode default">true</code>, otherwise</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(8.3)</a></span>
+<code class="sourceCode default">map.required_span_size() &lt;= size(container_type(map.required_span_size(), val, a))</code>
+is <code class="sourceCode default">true</code>.</p></li>
+</ul>
+<p><span class="marginalizedparent"><a class="marginalized">9</a></span>
+<em>Effects:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(9.1)</a></span>
+Direct-non-list-initializes
+<em><code class="sourceCode default">map_</code></em> with
+<code class="sourceCode default">ext</code>, and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(9.2)</a></span> if
+<code class="sourceCode default">is_constructible_v&lt;container_type, size_t, value_type&gt;</code>
+is <code class="sourceCode default">true</code>,
+direct-non-list-initializes <code class="sourceCode default">ctr_</code>
+with
+<code class="sourceCode default">container_type(</code><em><code class="sourceCode default">map_</code></em><code class="sourceCode default">.required_span_size(), val)</code>,
+otherwise direct-non-list-initializes
+<code class="sourceCode default">ctr_</code> with
+<em><code class="sourceCode default">value-to-array</code></em><code class="sourceCode default">&lt;element_type, size(declval&lt;container_type&gt;())&gt;()</code>.</p></li>
+</ul>
+<div class="sourceCode" id="cb54"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb54-1"><a href="#cb54-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
+<span id="cb54-2"><a href="#cb54-2" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> mapping_type<span class="op">&amp;</span> map, <span class="kw">const</span> value_type<span class="op">&amp;</span> val, <span class="kw">const</span> Alloc<span class="op">&amp;</span> a<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized">10</a></span>
+<em>Constraints:</em> if
+<code class="sourceCode default">container_type</code> is not a
+specialization of <code class="sourceCode default">array</code>, <code class="sourceCode default">is_constructible_v&lt;container_type, size_t, value_type&gt;</code>
+is <code class="sourceCode default">true</code>.</p>
+<p><span class="marginalizedparent"><a class="marginalized">11</a></span>
+<em>Preconditions:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(11.1)</a></span> if
+<code class="sourceCode default">container_type</code> is a
+specialization of <code class="sourceCode default">array</code>, <code class="sourceCode default">map.required_span_size() &lt;= size(container_type())</code>
+is <code class="sourceCode default">true</code>, otherwise</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(11.2)</a></span>
+<code class="sourceCode default">map.required_span_size() &lt;= size(container_type(map.required_span_size(), val, a))</code>
+is <code class="sourceCode default">true</code>.</p></li>
+</ul>
+<p><span class="marginalizedparent"><a class="marginalized">12</a></span>
+<em>Effects:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(12.1)</a></span>
+Direct-non-list-initializes
+<em><code class="sourceCode default">map_</code></em> with
+<code class="sourceCode default">map</code>, and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(12.2)</a></span> if
+<code class="sourceCode default">is_constructible_v&lt;container_type, size_t, value_type&gt;</code>
+is <code class="sourceCode default">true</code>,
+direct-non-list-initializes <code class="sourceCode default">ctr_</code>
+with
+<code class="sourceCode default">container_type(</code><em><code class="sourceCode default">map_</code></em><code class="sourceCode default">.required_span_size(), val)</code>,
+otherwise direct-non-list-initializes
+<code class="sourceCode default">ctr_</code> with
+<em><code class="sourceCode default">value-to-array</code></em><code class="sourceCode default">&lt;element_type, size(declval&lt;container_type&gt;())&gt;()</code>.</p></li>
+</ul>
+<div class="sourceCode" id="cb55"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb55-1"><a href="#cb55-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
+<span id="cb55-2"><a href="#cb55-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> container_type<span class="op">&amp;</span> c, <span class="kw">const</span> extents_type<span class="op">&amp;</span> ext, <span class="kw">const</span> Alloc<span class="op">&amp;</span> a<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized">13</a></span>
+<em>Constraints:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(13.1)</a></span>
+<code class="sourceCode default">is_constructible_v&lt;mapping_type, const extents_type&amp;&gt;</code>
+is <code class="sourceCode default">true</code>, and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(13.2)</a></span>
+<code class="sourceCode default">is_constructible_v&lt;container_type, container_type, Alloc&gt;</code>
+is <code class="sourceCode default">true</code>.</p></li>
+</ul>
+<p><span class="marginalizedparent"><a class="marginalized">14</a></span>
+<em>Preconditions:</em> <code class="sourceCode default">c.size() &gt;= mapping_type(ext).required_span_size()</code>
+is <code class="sourceCode default">true</code>.</p>
+<p><span class="marginalizedparent"><a class="marginalized">15</a></span>
+<em>Effects:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(15.1)</a></span>
+Direct-non-list-initializes
+<em><code class="sourceCode default">map_</code></em> with
+<code class="sourceCode default">ext</code>, and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(15.2)</a></span>
+Direct-non-list-initializes <code class="sourceCode default">ctr_</code>
+with <code class="sourceCode default">c</code> as the first argument and
+<code class="sourceCode default">a</code> as the second
+argument.</p></li>
+</ul>
+<div class="sourceCode" id="cb56"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb56-1"><a href="#cb56-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
+<span id="cb56-2"><a href="#cb56-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> container_type<span class="op">&amp;</span> c, <span class="kw">const</span> mapping_type<span class="op">&amp;</span> m, <span class="kw">const</span> Alloc<span class="op">&amp;</span> a<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized">16</a></span>
+<em>Constraints:</em> <code class="sourceCode default">is_constructible_v&lt;container_type, container_type, Alloc&gt;</code>
+is <code class="sourceCode default">true</code>.</p>
+<p><span class="marginalizedparent"><a class="marginalized">17</a></span>
+<em>Preconditions:</em> <code class="sourceCode default">c.size() &gt;= m.required_span_size()</code>
+is <code class="sourceCode default">true</code>.</p>
+<p><span class="marginalizedparent"><a class="marginalized">18</a></span>
+<em>Effects:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(18.1)</a></span>
+Direct-non-list-initializes
+<em><code class="sourceCode default">map_</code></em> with
+<code class="sourceCode default">m</code>, and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(18.2)</a></span>
+Direct-non-list-initializes <code class="sourceCode default">ctr_</code>
+with <code class="sourceCode default">c</code> as the first argument and
+<code class="sourceCode default">a</code> as the second
+argument.</p></li>
+</ul>
+<div class="sourceCode" id="cb57"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb57-1"><a href="#cb57-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
+<span id="cb57-2"><a href="#cb57-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> mdarray<span class="op">(</span>container_type<span class="op">&amp;&amp;</span> c, <span class="kw">const</span> extents_type<span class="op">&amp;</span> ext, <span class="kw">const</span> Alloc<span class="op">&amp;</span> a<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized">19</a></span>
+<em>Constraints:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(19.1)</a></span>
+<code class="sourceCode default">is_constructible_v&lt;mapping_type, const extents_type&amp;&gt;</code>
+is <code class="sourceCode default">true</code>, and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(19.2)</a></span>
+<code class="sourceCode default">is_constructible_v&lt;container_type, container_type, Alloc&gt;</code>
+is <code class="sourceCode default">true</code>.</p></li>
+</ul>
+<p><span class="marginalizedparent"><a class="marginalized">20</a></span>
+<em>Preconditions:</em> <code class="sourceCode default">c.size() &gt;= mapping_type(ext).required_span_size()</code>
+is <code class="sourceCode default">true</code>.</p>
+<p><span class="marginalizedparent"><a class="marginalized">21</a></span>
+<em>Effects:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(21.1)</a></span>
+Direct-non-list-initializes
+<em><code class="sourceCode default">map_</code></em> with
+<code class="sourceCode default">ext</code>, and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(21.2)</a></span>
+Direct-non-list-initializes <code class="sourceCode default">ctr_</code>
+with <code class="sourceCode default">std::move(c)</code> as the first
+argument and <code class="sourceCode default">a</code> as the second
+argument.</p></li>
+</ul>
+<div class="sourceCode" id="cb58"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb58-1"><a href="#cb58-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
+<span id="cb58-2"><a href="#cb58-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> mdarray<span class="op">(</span>container_type<span class="op">&amp;&amp;</span> c, <span class="kw">const</span> mapping_type<span class="op">&amp;</span> m, <span class="kw">const</span> Alloc<span class="op">&amp;</span> a<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized">22</a></span>
+<em>Constraints:</em> <code class="sourceCode default">is_constructible_v&lt;container_type, container_type, Alloc&gt;</code>
+is <code class="sourceCode default">true</code>.</p>
+<p><span class="marginalizedparent"><a class="marginalized">23</a></span>
+<em>Preconditions:</em> <code class="sourceCode default">c.size() &gt;= m.required_span_size()</code>
+is <code class="sourceCode default">true</code>.</p>
+<p><span class="marginalizedparent"><a class="marginalized">24</a></span>
+<em>Effects:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(24.1)</a></span>
+Direct-non-list-initializes
+<em><code class="sourceCode default">map_</code></em> with
+<code class="sourceCode default">m</code>, and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(24.2)</a></span>
+Direct-non-list-initializes <code class="sourceCode default">ctr_</code>
+with <code class="sourceCode default">std::move(c)</code> as the first
+argument and <code class="sourceCode default">a</code> as the second
+argument.</p></li>
+</ul>
+<div class="sourceCode" id="cb59"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb59-1"><a href="#cb59-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherElementType, <span class="kw">class</span> OtherExtents,</span>
+<span id="cb59-2"><a href="#cb59-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> OtherLayoutPolicy, <span class="kw">class</span> OtherContainer, <span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
+<span id="cb59-3"><a href="#cb59-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">explicit</span><span class="op">(</span><em>see below</em><span class="op">)</span></span>
+<span id="cb59-4"><a href="#cb59-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> mdarray<span class="op">&lt;</span>OtherElementType, OtherExtents, </span>
+<span id="cb59-5"><a href="#cb59-5" aria-hidden="true" tabindex="-1"></a>                                  OtherLayoutPolicy, OtherContainer<span class="op">&gt;&amp;</span> other,</span>
+<span id="cb59-6"><a href="#cb59-6" aria-hidden="true" tabindex="-1"></a>                    <span class="kw">const</span> Alloc<span class="op">&amp;</span> a<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized">25</a></span>
+<em>Mandates:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(25.1)</a></span>
+<code class="sourceCode default">is_constructible_v&lt;Container, OtherContainer, Alloc&gt;</code>
+is <code class="sourceCode default">true</code>, and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(25.2)</a></span>
+<code class="sourceCode default">is_constructible_v&lt;extents_type, OtherExtents&gt;</code>
+is <code class="sourceCode default">true</code>.</p></li>
+</ul>
+<p><span class="marginalizedparent"><a class="marginalized">26</a></span>
+<em>Constraints:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(26.1)</a></span>
+<code class="sourceCode default">is_constructible_v&lt;mapping_type, const OtherLayoutPolicy::template mapping&lt;OtherExtents&gt;&amp;&gt;</code>
+is <code class="sourceCode default">true</code>, and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(26.2)</a></span>
+<code class="sourceCode default">is_constructible_v&lt;container_type, OtherContainer, Alloc&gt;</code>
+is <code class="sourceCode default">true</code>.</p></li>
+</ul>
+<p><span class="marginalizedparent"><a class="marginalized">27</a></span>
+<em>Preconditions:</em> For each rank index
+<code class="sourceCode default">r</code> of
+<code class="sourceCode default">extents_type</code>, <code class="sourceCode default">static_extent(r) == dynamic_extent || static_extent(r) == other.extent(r)</code>
+is <code class="sourceCode default">true</code>.</p>
+<p><span class="marginalizedparent"><a class="marginalized">28</a></span>
+<em>Effects:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(28.1)</a></span>
+Direct-non-list-initializes
+<em><code class="sourceCode default">map_</code></em> with
+<code class="sourceCode default">other.</code><em><code class="sourceCode default">map_</code></em>,
+and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(28.2)</a></span>
+Direct-non-list-initializes <code class="sourceCode default">ctr_</code>
+with <code class="sourceCode default">other.ctr_</code> as the first
+argument and <code class="sourceCode default">a</code> as the second
+argument.</p></li>
+</ul>
+<p><span class="marginalizedparent"><a class="marginalized">29</a></span>
+<em>Remarks:</em> The expression inside
+<code class="sourceCode default">explicit</code> is:</p>
+<div class="sourceCode" id="cb60"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb60-1"><a href="#cb60-1" aria-hidden="true" tabindex="-1"></a>  <span class="op">!</span>is_convertible_v<span class="op">&lt;</span><span class="kw">const</span> <span class="kw">typename</span> OtherLayoutPolicy<span class="op">::</span>mapping_type<span class="op">&amp;</span>, mapping_type<span class="op">&gt;</span> <span class="op">||</span></span>
+<span id="cb60-2"><a href="#cb60-2" aria-hidden="true" tabindex="-1"></a>  <span class="op">!</span>is_convertible_v<span class="op">&lt;</span><span class="kw">const</span> OtherContainer<span class="op">&amp;</span>, Container<span class="op">&gt;</span></span></code></pre></div>
+<div class="sourceCode" id="cb61"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb61-1"><a href="#cb61-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherElementType, <span class="kw">class</span> OtherExtents,</span>
+<span id="cb61-2"><a href="#cb61-2" aria-hidden="true" tabindex="-1"></a>           <span class="kw">class</span> OtherLayoutPolicy, <span class="kw">class</span> Accessor,</span>
+<span id="cb61-3"><a href="#cb61-3" aria-hidden="true" tabindex="-1"></a>           <span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
+<span id="cb61-4"><a href="#cb61-4" aria-hidden="true" tabindex="-1"></a>    <span class="kw">explicit</span><span class="op">(</span><em>see below</em><span class="op">)</span></span>
+<span id="cb61-5"><a href="#cb61-5" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> mdspan<span class="op">&lt;</span>OtherElementType, OtherExtents,</span>
+<span id="cb61-6"><a href="#cb61-6" aria-hidden="true" tabindex="-1"></a>                                   OtherLayoutPolicy, Accessor<span class="op">&gt;&amp;</span> other,</span>
+<span id="cb61-7"><a href="#cb61-7" aria-hidden="true" tabindex="-1"></a>                      <span class="kw">const</span> Alloc<span class="op">&amp;</span> a<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized">30</a></span>
+<em>Mandates:</em> <code class="sourceCode default">is_constructible_v&lt;extents_type, OtherExtents&gt;</code>
+is <code class="sourceCode default">true</code>.</p>
+<p><span class="marginalizedparent"><a class="marginalized">31</a></span>
+<em>Constraints:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(31.1)</a></span>
+<code class="sourceCode default">is_constructible_v&lt;container_type, size_t, Alloc&gt;</code>
+is <code class="sourceCode default">true</code>,</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(31.2)</a></span>
+<code class="sourceCode default">is_constructible_v&lt;value_type, Accessor::reference&gt;</code>
+is <code class="sourceCode default">true</code>,</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(31.3)</a></span>
+<code class="sourceCode default">is_assignable_v&lt;Accessor::reference, value_type&gt;</code>
+is <code class="sourceCode default">true</code>,</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(31.4)</a></span>
+<code class="sourceCode default">is_default_constructible_v&lt;value_type&gt;</code>
+is <code class="sourceCode default">true</code>, and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(31.5)</a></span>
+<code class="sourceCode default">is_constructible_v&lt;mapping_type, const OtherLayoutPolicy::template mapping&lt;OtherExtents&gt;&amp;&gt;</code>
+is <code class="sourceCode default">true</code>.</p></li>
+</ul>
+<p><span class="marginalizedparent"><a class="marginalized">32</a></span>
+<em>Preconditions:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(32.1)</a></span> For
+each rank index <code class="sourceCode default">r</code> of
+<code class="sourceCode default">extents_type</code>, <code class="sourceCode default">static_extent(r) == dynamic_extent || static_extent(r) == other.extent(r)</code>
+is <code class="sourceCode default">true</code>, and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(32.2)</a></span> if
+<code class="sourceCode default">container_type</code> is a
+specialization of <code class="sourceCode default">array</code>, then
+<code class="sourceCode default">container_type().size() &gt;= other.mapping().required_span_size()</code>.</p></li>
+</ul>
+<p><span class="marginalizedparent"><a class="marginalized">33</a></span>
+<em>Effects:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(33.1)</a></span>
+Direct-non-list-initializes
+<em><code class="sourceCode default">map_</code></em> with
+<code class="sourceCode default">extents_type(other.extents())</code>;</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(33.2)</a></span>
+direct-non-list-initializes <code class="sourceCode default">ctr_</code>
+with
+<code class="sourceCode default">container_type(</code><em><code class="sourceCode default">map_</code></em><code class="sourceCode default">.required_span_size(), a)</code>;
+and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(33.3)</a></span> for
+all unique multidimensional indices
+<code class="sourceCode default">i...</code> in other.extents(), assigns
+<code class="sourceCode default">other[i...]</code> to
+<code class="sourceCode default">ctr_[</code><em><code class="sourceCode default">map_</code></em><code class="sourceCode default">(i...)]</code>.</p></li>
+</ul>
+<p><i>[Note:</i> For intent, please see Note on the
+<code class="sourceCode default">mdarray</code> constructor taking an
+<code class="sourceCode default">mdspan</code> with no allocator.<i>—
+end note]</i></p>
+<p><span class="marginalizedparent"><a class="marginalized">34</a></span>
+<em>Remarks:</em> The expression inside
+<code class="sourceCode default">explicit</code> is:</p>
+<div class="sourceCode" id="cb62"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb62-1"><a href="#cb62-1" aria-hidden="true" tabindex="-1"></a>  <span class="op">!</span>is_convertible_v<span class="op">&lt;</span><span class="kw">const</span> <span class="kw">typename</span> OtherLayoutPolicy<span class="op">::</span>mapping_type<span class="op">&amp;</span>, mapping_type<span class="op">&gt;</span> <span class="op">||</span></span>
+<span id="cb62-2"><a href="#cb62-2" aria-hidden="true" tabindex="-1"></a>  <span class="op">!</span>is_convertible_v<span class="op">&lt;</span>Accessor<span class="op">::</span>reference, value_type<span class="op">&gt;</span> <span class="op">||</span></span>
+<span id="cb62-3"><a href="#cb62-3" aria-hidden="true" tabindex="-1"></a>  <span class="op">!</span>is_convertible_v<span class="op">&lt;</span>Alloc, container_type<span class="op">::</span>allocator_type<span class="op">&gt;</span></span></code></pre></div>
+<!--
+
+  #              #                           #
+### ### ###  ##     ##      ###  ## ### ###     ##  ###
+# # # # ### # #  #  # #     ### # # # # # #  #  # # # #
+### ### # # ###  ## # #     # # ### ### ###  ## # #  ##
+                                    #   #           ###
+-->
+<p><br /> <b>24.6.�.4 <code class="sourceCode default">mdarray</code>
+members [mdarray.members]</b></p>
+<div class="sourceCode" id="cb63"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb63-1"><a href="#cb63-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span><span class="op">...</span> OtherIndexTypes<span class="op">&gt;</span></span>
+<span id="cb63-2"><a href="#cb63-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> reference <span class="kw">operator</span><span class="op">[](</span>OtherIndexTypes<span class="op">...</span> indices<span class="op">)</span>;</span>
+<span id="cb63-3"><a href="#cb63-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span><span class="op">...</span> OtherIndexTypes<span class="op">&gt;</span></span>
+<span id="cb63-4"><a href="#cb63-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> const_reference <span class="kw">operator</span><span class="op">[](</span>OtherIndexTypes<span class="op">...</span> indices<span class="op">)</span> <span class="kw">const</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized">1</a></span>
+<em>Constraints:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(1.1)</a></span>
+<code class="sourceCode default">(is_convertible_v&lt;OtherIndexTypes, index_type&gt; &amp;&amp; ...)</code>
+is <code class="sourceCode default">true</code>,</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(1.2)</a></span>
+<code class="sourceCode default">(is_nothrow_constructible_v&lt;index_type, OtherIndexTypes&gt; &amp;&amp; ...)</code>
+is <code class="sourceCode default">true</code>, and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(1.3)</a></span>
+<code class="sourceCode default">sizeof...(OtherIndexTypes) == rank()</code>
+is <code class="sourceCode default">true</code>.</p></li>
+</ul>
+<p><span class="marginalizedparent"><a class="marginalized">2</a></span>
+Let <code class="sourceCode default">I</code> be
+<code class="sourceCode default">extents_type::</code><em><code class="sourceCode default">index-cast</code></em><code class="sourceCode default">(std::move(indices))</code>.</p>
+<p><span class="marginalizedparent"><a class="marginalized">3</a></span>
+<em>Preconditions:</em> <code class="sourceCode default">I</code> is a
+multidimensional index in
+<code class="sourceCode default">extents()</code>. <i>[Note:</i> This
+implies that
+<em><code class="sourceCode default">map_</code></em><code class="sourceCode default">(I...) &lt;</code><em><code class="sourceCode default">map_</code></em><code class="sourceCode default">.required_span_size()</code>
+is <code class="sourceCode default">true</code>.<i>— end note]</i>;</p>
+<p><span class="marginalizedparent"><a class="marginalized">4</a></span>
+<em>Effects:</em> Equivalent to:
+<code class="sourceCode default">return</code>
+<em><code class="sourceCode default">acc_</code></em><code class="sourceCode default">.access(</code><em><code class="sourceCode default">ptr_</code></em><code class="sourceCode default">,</code><em><code class="sourceCode default">map_</code></em><code class="sourceCode default">(static_cast&lt;index_type&gt;(std::move(indices))...));</code></p>
+<div class="sourceCode" id="cb64"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb64-1"><a href="#cb64-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherIndexType<span class="op">&gt;</span></span>
+<span id="cb64-2"><a href="#cb64-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> reference <span class="kw">operator</span><span class="op">[](</span>span<span class="op">&lt;</span>OtherIndexType, rank<span class="op">()&gt;</span> indices<span class="op">)</span>;</span>
+<span id="cb64-3"><a href="#cb64-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherIndexType<span class="op">&gt;</span></span>
+<span id="cb64-4"><a href="#cb64-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> const_reference <span class="kw">operator</span><span class="op">[](</span>span<span class="op">&lt;</span>OtherIndexType, rank<span class="op">()&gt;</span> indices<span class="op">)</span> <span class="kw">const</span>;</span>
+<span id="cb64-5"><a href="#cb64-5" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherIndexType<span class="op">&gt;</span></span>
+<span id="cb64-6"><a href="#cb64-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> reference <span class="kw">operator</span><span class="op">[](</span><span class="kw">const</span> array<span class="op">&lt;</span>OtherIndexType, rank<span class="op">()&gt;&amp;</span> indices<span class="op">)</span>;</span>
+<span id="cb64-7"><a href="#cb64-7" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherIndexType<span class="op">&gt;</span></span>
+<span id="cb64-8"><a href="#cb64-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> const_reference <span class="kw">operator</span><span class="op">[](</span><span class="kw">const</span> array<span class="op">&lt;</span>OtherIndexType, rank<span class="op">()&gt;&amp;</span> indices<span class="op">)</span> <span class="kw">const</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized">5</a></span>
+<em>Constraints:</em></p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized">(5.1)</a></span>
+<code class="sourceCode default">is_convertible_v&lt;const OtherIndexType&amp;, index_type&gt;</code>
+is <code class="sourceCode default">true</code>, and</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(5.2)</a></span>
+<code class="sourceCode default">is_nothrow_constructible_v&lt;index_type, const OtherIndexType&amp;&gt;</code>
+is <code class="sourceCode default">true</code>.</p></li>
+</ul>
+<p><span class="marginalizedparent"><a class="marginalized">6</a></span>
+<em>Effects:</em> Let <code class="sourceCode default">P</code> be a
+parameter pack such that <code class="sourceCode default">is_same_v&lt;make_index_sequence&lt;rank()&gt;, index_sequence&lt;P...&gt;&gt;</code>
+is <code class="sourceCode default">true</code>. <br /> Equivalent to:
+<code class="sourceCode default">return operator[](as_const(indices[P])...);</code></p>
+<div class="sourceCode" id="cb65"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb65-1"><a href="#cb65-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> size_type size<span class="op">()</span> <span class="kw">const</span> <span class="kw">noexcept</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized">7</a></span>
+<em>Precondition:</em> The size of the multidimensional index space
+<code class="sourceCode default">extents()</code> is a representable
+value of type <code class="sourceCode default">size_type</code>
+([basic.fundamental]).</p>
+<p><span class="marginalizedparent"><a class="marginalized">8</a></span>
+<em>Returns:</em>
+<code class="sourceCode default">extents().</code><em><code class="sourceCode default">fwd-prod-of-extents</code></em><code class="sourceCode default">(rank())</code>.</p>
+<div class="sourceCode" id="cb66"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb66-1"><a href="#cb66-1" aria-hidden="true" tabindex="-1"></a><span class="op">[[</span><span class="at">nodiscard</span><span class="op">]]</span> <span class="kw">constexpr</span> <span class="dt">bool</span> empty<span class="op">()</span> <span class="kw">const</span> <span class="kw">noexcept</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized">9</a></span>
+<em>Returns:</em> <code class="sourceCode default">true</code> if the
+size of the multidimensional index space
+<code class="sourceCode default">extents()</code> is 0, otherwise
+<code class="sourceCode default">false</code>.</p>
+<div class="sourceCode" id="cb67"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb67-1"><a href="#cb67-1" aria-hidden="true" tabindex="-1"></a><span class="kw">friend</span> <span class="kw">constexpr</span> <span class="dt">void</span> swap<span class="op">(</span>mdarray<span class="op">&amp;</span> x, mdarray<span class="op">&amp;</span> y<span class="op">)</span> <span class="kw">noexcept</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized">10</a></span>
+<em>Effects:</em> Equivalent to:</p>
+<div class="sourceCode" id="cb68"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb68-1"><a href="#cb68-1" aria-hidden="true" tabindex="-1"></a>swap<span class="op">(</span>x<span class="op">.</span>ctr_, y<span class="op">.</span>ctr_<span class="op">)</span>;</span>
+<span id="cb68-2"><a href="#cb68-2" aria-hidden="true" tabindex="-1"></a>swap<span class="op">(</span>x<span class="op">.</span><em>map</em>_, y<span class="op">.</span><em>map</em>_<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb69"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb69-1"><a href="#cb69-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherElementType, <span class="kw">class</span> OtherExtents,</span>
+<span id="cb69-2"><a href="#cb69-2" aria-hidden="true" tabindex="-1"></a>           <span class="kw">class</span> OtherLayoutType, <span class="kw">class</span> OtherAccessorType<span class="op">&gt;</span></span>
+<span id="cb69-3"><a href="#cb69-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">operator</span> mdspan <span class="op">()</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized">11</a></span>
+<em>Constraints:</em> <code class="sourceCode default">is_assignable_v&lt;mdspan&lt;element_type, extents_type, layout_type&gt;, mdspan&lt;OtherElementType, OtherExtents, OtherLayoutType, OtherAccessorType&gt;&gt;</code>
+is <code class="sourceCode default">true</code>.</p>
+<p><span class="marginalizedparent"><a class="marginalized">12</a></span>
+<em>Returns:</em>
+<code class="sourceCode default">mdspan(data(),</code><em><code class="sourceCode default">map_</code></em>)`</p>
+<div class="sourceCode" id="cb70"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb70-1"><a href="#cb70-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherAccessorType<span class="op">&gt;</span></span>
+<span id="cb70-2"><a href="#cb70-2" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdspan<span class="op">&lt;</span>element_type, extents_type, layout_type, OtherAccessorType<span class="op">&gt;</span></span>
+<span id="cb70-3"><a href="#cb70-3" aria-hidden="true" tabindex="-1"></a>      to_mdspan<span class="op">(</span><span class="kw">const</span> OtherAccessorType<span class="op">&amp;</span> a <span class="op">=</span> default_accessor<span class="op">&lt;</span>element_type<span class="op">&gt;())</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized">13</a></span>
+<em>Constraints:</em> <code class="sourceCode default">is_assignable_v&lt;mdspan&lt;element_type, extents_type, layout_type&gt;, mdspan&lt;element_type, extents_type, layout_type, OtherAccessorType&gt;&gt;</code>
+is <code class="sourceCode default">true</code>.</p>
+<p><span class="marginalizedparent"><a class="marginalized">14</a></span>
+<em>Returns:</em>
+<code class="sourceCode default">mdspan(data(),</code><em><code class="sourceCode default">map_</code></em><code class="sourceCode default">, a)</code></p>
+<div class="sourceCode" id="cb71"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb71-1"><a href="#cb71-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherAccessorType<span class="op">&gt;</span></span>
+<span id="cb71-2"><a href="#cb71-2" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdspan<span class="op">&lt;</span><span class="kw">const</span> element_type, extents_type, layout_type, OtherAccessorType<span class="op">&gt;</span></span>
+<span id="cb71-3"><a href="#cb71-3" aria-hidden="true" tabindex="-1"></a>      to_mdspan<span class="op">(</span><span class="kw">const</span> OtherAccessorType<span class="op">&amp;</span> a <span class="op">=</span> default_accessor<span class="op">&lt;</span><span class="kw">const</span> element_type<span class="op">&gt;())</span> <span class="kw">const</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized">15</a></span>
+<em>Constraints:</em> <code class="sourceCode default">is_assignable_v&lt;mdspan&lt;const element_type, extents_type, layout_type&gt;, mdspan&lt;const element_type, extents_type, layout_type, OtherAccessorType&gt;&gt;</code>
+is <code class="sourceCode default">true</code>.</p>
+<p><span class="marginalizedparent"><a class="marginalized">16</a></span>
+<em>Returns:</em>
+<code class="sourceCode default">mdspan(data(),</code><em><code class="sourceCode default">map_</code></em><code class="sourceCode default">, a)</code></p>
+<p><br /></p>
+<p>Add to <code class="sourceCode default">mdspan</code> deduction
+guides</p>
+<div class="sourceCode" id="cb72"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb72-1"><a href="#cb72-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ElementType, <span class="kw">class</span> Extents, <span class="kw">class</span> Layout, <span class="kw">class</span> Container<span class="op">&gt;</span></span>
+<span id="cb72-2"><a href="#cb72-2" aria-hidden="true" tabindex="-1"></a>mdspan<span class="op">(</span>mdarray<span class="op">&lt;</span>ElementType, Extents, Layout, Container<span class="op">&gt;)</span> <span class="op">-&gt;</span> mdspan<span class="op">&lt;</span></span>
+<span id="cb72-3"><a href="#cb72-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">decltype</span><span class="op">(</span>declval<span class="op">&lt;</span>mdarray<span class="op">&lt;</span>ElementType, Extents, Layout, Container<span class="op">&gt;&gt;().</span>to_mdspan<span class="op">())::</span>element_type,</span>
+<span id="cb72-4"><a href="#cb72-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">decltype</span><span class="op">(</span>declval<span class="op">&lt;</span>mdarray<span class="op">&lt;</span>ElementType, Extents, Layout, Container<span class="op">&gt;&gt;().</span>to_mdspan<span class="op">())::</span>extens_type,</span>
+<span id="cb72-5"><a href="#cb72-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">decltype</span><span class="op">(</span>declval<span class="op">&lt;</span>mdarray<span class="op">&lt;</span>ElementType, Extents, Layout, Container<span class="op">&gt;&gt;().</span>to_mdspan<span class="op">())::</span>layout_type,</span>
+<span id="cb72-6"><a href="#cb72-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">decltype</span><span class="op">(</span>declval<span class="op">&lt;</span>mdarray<span class="op">&lt;</span>ElementType, Extents, Layout, Container<span class="op">&gt;&gt;().</span>to_mdspan<span class="op">())::</span>accessor_type<span class="op">&gt;</span>;</span></code></pre></div>
+<h1 data-number="5" id="bibliography"><span class="header-section-number">5</span> References<a href="#bibliography" class="self-link"></a></h1>
+<div id="refs" class="references csl-bib-body hanging-indent" role="doc-bibliography">
+<div id="ref-P0009R18" class="csl-entry" role="doc-biblioentry">
+[P0009R18] Christian Trott, D.S. Hollman, Damien Lebrun-Grandie, Mark
+Hoemmen, Daniel Sunderland, H. Carter Edwards, Bryce Adelstein Lelbach,
+Mauro Bianco, Ben Sander, Athanasios Iliopoulos, John Michopoulos, Nevin
+Liber. 2022-07-13. MDSPAN. <a href="https://wg21.link/p0009r18"><div class="csl-block">https://wg21.link/p0009r18</div></a>
+</div>
+<div id="ref-P1684R0" class="csl-entry" role="doc-biblioentry">
+[P1684R0] D. S. Hollman, Christian Trott, Mark Hoemmen, Daniel
+Sundernland. 2019-06-16. mdarray: An Owning Multidimensional Array
+Analog of mdspan. <a href="https://wg21.link/p1684r0"><div class="csl-block">https://wg21.link/p1684r0</div></a>
+</div>
+</div>
+</div>
+</div>
+</body>
+</html>

--- a/P1684-mdarray/P1684.md
+++ b/P1684-mdarray/P1684.md
@@ -367,6 +367,13 @@ This is teachable with these simple rules:
 * Otherwise, if you have a container object, it comes first.
 * For constructors that take a parameter pack of extents (as opposed to an extents/mapping object), they come last.
 
+The deduction guides have been reworked for the new constructors.
+Because we need to deduce the container type, a `Container` parameter is
+provided for all the guides which are not using the default container,
+and that container is  then copied or moved into the `mdarray` on construction.
+This works because providing a container as the only parameter
+to the `Args...` parameter pack in any of the constructors effectively implements this.
+
 ::: cmptable
 #### Original (26 `mdarray` constructors)
 ```cpp

--- a/P1684-mdarray/P1684.md
+++ b/P1684-mdarray/P1684.md
@@ -1,6 +1,6 @@
 ---
 title: "`mdarray`: An Owning Multidimensional Array Analog of `mdspan`"
-document: P1684R4
+document: D1684R5a
 date: today
 audience: Library Evolution
 author:
@@ -14,10 +14,18 @@ author:
     email: <dansunderland@gmail.com>
   - name: Damien Lebrun-Grandie
     email: <lebrungrandt@ornl.gov>
+  - name: Nevin Liber
+    email: <nliber@anl.gov>
 ---
 
 
 # Revision History
+
+## P1684R4: pre-Varna mailing (2023-05)
+
+#### Changes from R4
+
+- Propose alternate constructor design design
 
 ## P1684R3: 2022-07 Mailing
 
@@ -333,6 +341,197 @@ mdarray a(std::move(vector(first, last)), N, M);
 In R3 we decided to radically cut back on constructors and simply leave those out. 
 
 Finally, `mdarray` does not have the analog of `mdspan`'s constructor that takes an `array<IndexType, N>` of dynamic extents.  This avoids any ambiguity or confusion with a constructor that takes a container instance, in the case where the `container` happens to be an `array<IndexType, N>`.
+
+### Alternative constructor design
+
+We can both significantly reduce the number of constructors (from 26 down to 12) *and*
+gain the ability to emplace the container.  This requires
+a bit of shuffling of the arguments, adding a tag and adding a parameter pack.
+
+* Whenever `extents_type` or `mapping_type` is provided, it must come first.
+* Whenever an `mdarray` is constructed with `val`, it must be preceded by a tag.
+* Add a parameter pack `Args...` that essentially emplace constructs the container.
+
+The original adaptors couldn't do this, because variadics didn't exist in C++98.
+We can and should do better now that we have better language facilities.
+
+In the original design,
+the unconstrained `Alloc` parameter is in a weird spot in the constructors
+by not being next to the container it is being passed to.
+This alternate design addresses that but introduces a different weirdness between
+"take an integer pack" and "take extents/mapping"
+constructors in terms of position of the container argument.
+This is teachable with these simple rules:
+
+* If you have an extents/mapping object, it comes first.
+* Otherwise, if you have a container object, it comes first.
+* For constructors that take a parameter pack of extents (as opposed to an extents/mapping object), they come last.
+
+::: cmptable
+#### Original (6 constructors -- no change)
+```cpp
+  constexpr mdarray() requires(rank_dynamic() != 0) = default;
+  constexpr mdarray(const mdarray& rhs) = default;
+  constexpr mdarray(mdarray&& rhs) = default;
+
+  template<class... OtherIndexTypes>
+    explicit constexpr mdarray(OtherIndexTypes... exts);
+
+  template<class... OtherIndexTypes>
+    constexpr mdarray(const container_type& c, OtherIndexTypes... exts);
+
+  template<class... OtherIndexTypes>
+    constexpr mdarray(container_type&& c, OtherIndexTypes... exts);
+```
+
+#### Alternate (6 constructors -- no change)
+```cpp
+  constexpr mdarray() requires(rank_dynamic() != 0) = default;
+  constexpr mdarray(const mdarray& rhs) = default;
+  constexpr mdarray(mdarray&& rhs) = default;
+
+  template<class... OtherIndexTypes>
+    explicit constexpr mdarray(OtherIndexTypes... exts);
+
+  template<class... OtherIndexTypes>
+    constexpr mdarray(const container_type& c, OtherIndexTypes... exts);
+
+  template<class... OtherIndexTypes>
+    constexpr mdarray(container_type&& c, OtherIndexTypes... exts);
+```
+
+:::
+
+::: cmptable
+#### Original (12 constructors)
+```cpp
+  explicit constexpr mdarray(const extents_type& ext);
+  explicit constexpr mdarray(const mapping_type& m);
+
+  constexpr mdarray(const container_type& c, const extents_type& ext);
+  constexpr mdarray(const container_type& c, const mapping_type& m);
+
+  template<class Alloc>
+    constexpr mdarray(const extents_type& ext, const Alloc& a);
+  template<class Alloc>
+    constexpr mdarray(const mapping_type& m, const Alloc& a);
+
+  constexpr mdarray(container_type&& c, const extents_type& ext);
+  constexpr mdarray(container_type&& c, const mapping_type& m);
+
+  template<class Alloc>
+    constexpr mdarray(const container_type& c, const extents_type& ext, const Alloc& a);
+  template<class Alloc>
+    constexpr mdarray(const container_type& c, const mapping_type& m, const Alloc& a);
+
+  template<class Alloc>
+    constexpr mdarray(container_type&& c, const extents_type& ext, const Alloc& a);
+  template<class Alloc>
+    constexpr mdarray(container_type&& c, const mapping_type& m, const Alloc& a);
+```
+
+#### Alternate (2 constructors)
+```cpp
+  template<class... Args>
+    explicit(sizeof...(Args) == 0)
+    constexpr mdarray(const extents_type& ext, Args&&... args);
+
+  template<class... Args>
+    explicit(sizeof...(Args) == 0)
+    constexpr mdarray(const mapping_type& m, Args&&... args);
+```
+
+:::
+
+::: cmptable
+
+#### Original (4 constructors)
+```cpp
+  constexpr mdarray(const extents_type& ext, const value_type& val);
+  constexpr mdarray(const mapping_type& m, const value_type& val);
+
+  template<class Alloc>
+    constexpr mdarray(const extents_type& ext, const value_type& val, const Alloc& a);
+  template<class Alloc>
+    constexpr mdarray(const mapping_type& m, const value_type& val, const Alloc& a);
+```
+
+#### Alternate (2 constructors)
+```cpp
+namespace std {
+  struct fill_t {
+    explicit fill_t() = default;
+  };
+  inline constexpr fill_t fill();
+}
+
+//...
+
+  template<class... Args>
+    constexpr mdarray(const extents_type& ext, fill_t,
+      const value_type& val, Args&&... args);
+  template<class... Args>
+    constexpr mdarray(const mapping_type& m, fill_t,
+      const value_type& val, Args&&... args);
+```
+
+:::
+
+::: cmptable
+
+#### Original (4 constructors)
+```cpp
+  template<class OtherElementType, class OtherExtents, 
+           class OtherLayoutPolicy, class OtherContainer>
+    explicit(@_see below_@)
+    constexpr mdarray(
+      const mdarray<OtherElementType, OtherExtents,
+                    OtherLayoutPolicy, OtherContainer>& other);
+
+  template<class OtherElementType, class OtherExtents,
+           class OtherLayoutPolicy, class Accessor>
+    explicit(@_see below_@)
+    constexpr mdarray(const mdspan<OtherElementType, OtherExtents,
+                                   OtherLayoutPolicy, Accessor>& other);
+
+  template<class OtherElementType, class OtherExtents, 
+           class OtherLayoutPolicy, class OtherContainer, 
+           class Alloc>
+    explicit(@_see below_@)
+    constexpr mdarray(
+      const mdarray<OtherElementType, OtherExtents, 
+                    OtherLayoutPolicy, OtherContainer>& other, const Alloc& a);
+
+  template<class OtherElementType, class OtherExtents,
+           class OtherLayoutPolicy, class Accessor,
+           class Alloc>
+    explicit(@_see below_@)
+    constexpr mdarray(const mdspan<OtherElementType, OtherExtents,
+                                   OtherLayoutPolicy, Accessor>& other,
+                      const Alloc& a);
+```
+
+#### Alternate (2 constructors)
+```cpp
+  template<class OtherElementType, class OtherExtents, 
+           class OtherLayoutPolicy, class OtherContainer, 
+           class... Args>
+    explicit(@_see below_@)
+    constexpr mdarray(
+      const mdarray<OtherElementType, OtherExtents, 
+                    OtherLayoutPolicy, OtherContainer>& other,
+      Args&&... args);
+
+  template<class OtherElementType, class OtherExtents,
+           class OtherLayoutPolicy, class Accessor,
+           class... Args>
+    explicit(@_see below_@)
+    constexpr mdarray(mdspan<OtherElementType, OtherExtents,
+                             OtherLayoutPolicy, Accessor> other,
+      Args&&... args);
+```
+
+:::
 
 ## `Extents` design reused
 

--- a/P1684-mdarray/P1684.md
+++ b/P1684-mdarray/P1684.md
@@ -616,6 +616,12 @@ mdarray(const layout_stride::mapping<extents<IndexType, Extents...>>&, Container
              layout_stride,
              remove_const_t<remove_reference_t<Container>>>;
 
+template<class ElementType, class Extents, class Layout, class Accessor>
+mdarray(const mdspan<ElementType, Extents, Layout, Accessor>&, Container&& = vector<ElementType>())
+  -> mdarray<ElementType,
+             Extents,
+             Layout>;
+
 template<class Container, class ElementType, class Extents, class Layout, class Accessor>
 mdarray(const mdspan<ElementType, Extents, Layout, Accessor>&, Container&& = vector<ElementType>())
   -> mdarray<ElementType,

--- a/P1684-mdarray/P1684.md
+++ b/P1684-mdarray/P1684.md
@@ -344,7 +344,7 @@ Finally, `mdarray` does not have the analog of `mdspan`'s constructor that takes
 
 ### Alternative constructor design
 
-We can both significantly reduce the number of constructors (from 26 down to 12) *and*
+We can both significantly reduce the number of constructors *and*
 gain the ability to emplace the container.  This requires
 a bit of shuffling of the arguments, adding a tag and adding a parameter pack.
 
@@ -368,7 +368,22 @@ This is teachable with these simple rules:
 * For constructors that take a parameter pack of extents (as opposed to an extents/mapping object), they come last.
 
 ::: cmptable
-#### Original (6 constructors -- no change)
+#### Original (26 `mdarray` constructors)
+```cpp
+```
+
+#### Alternate (12 `mdarray` constructors)
+```cpp
+namespace std {
+  struct fill_t {
+    explicit fill_t() = default;
+  };
+  inline constexpr fill_t fill();
+}
+```
+
+---
+
 ```cpp
   constexpr mdarray() requires(rank_dynamic() != 0) = default;
   constexpr mdarray(const mdarray& rhs) = default;
@@ -384,7 +399,6 @@ This is teachable with these simple rules:
     constexpr mdarray(container_type&& c, OtherIndexTypes... exts);
 ```
 
-#### Alternate (6 constructors -- no change)
 ```cpp
   constexpr mdarray() requires(rank_dynamic() != 0) = default;
   constexpr mdarray(const mdarray& rhs) = default;
@@ -400,10 +414,8 @@ This is teachable with these simple rules:
     constexpr mdarray(container_type&& c, OtherIndexTypes... exts);
 ```
 
-:::
+---
 
-::: cmptable
-#### Original (12 constructors)
 ```cpp
   explicit constexpr mdarray(const extents_type& ext);
   explicit constexpr mdarray(const mapping_type& m);
@@ -430,7 +442,6 @@ This is teachable with these simple rules:
     constexpr mdarray(container_type&& c, const mapping_type& m, const Alloc& a);
 ```
 
-#### Alternate (2 constructors)
 ```cpp
   template<class... Args>
     explicit(sizeof...(Args) == 0)
@@ -441,11 +452,8 @@ This is teachable with these simple rules:
     constexpr mdarray(const mapping_type& m, Args&&... args);
 ```
 
-:::
+---
 
-::: cmptable
-
-#### Original (4 constructors)
 ```cpp
   constexpr mdarray(const extents_type& ext, const value_type& val);
   constexpr mdarray(const mapping_type& m, const value_type& val);
@@ -456,30 +464,18 @@ This is teachable with these simple rules:
     constexpr mdarray(const mapping_type& m, const value_type& val, const Alloc& a);
 ```
 
-#### Alternate (2 constructors)
 ```cpp
-namespace std {
-  struct fill_t {
-    explicit fill_t() = default;
-  };
-  inline constexpr fill_t fill();
-}
-
-//...
+  template<class... Args>
+    constexpr mdarray(const extents_type& ext,
+                      fill_t, const value_type& val, Args&&... args);
 
   template<class... Args>
-    constexpr mdarray(const extents_type& ext, fill_t,
-      const value_type& val, Args&&... args);
-  template<class... Args>
-    constexpr mdarray(const mapping_type& m, fill_t,
-      const value_type& val, Args&&... args);
+    constexpr mdarray(const mapping_type& m,
+                      fill_t, const value_type& val, Args&&... args);
 ```
 
-:::
+---
 
-::: cmptable
-
-#### Original (4 constructors)
 ```cpp
   template<class OtherElementType, class OtherExtents, 
            class OtherLayoutPolicy, class OtherContainer>
@@ -511,24 +507,22 @@ namespace std {
                       const Alloc& a);
 ```
 
-#### Alternate (2 constructors)
 ```cpp
   template<class OtherElementType, class OtherExtents, 
            class OtherLayoutPolicy, class OtherContainer, 
            class... Args>
     explicit(@_see below_@)
-    constexpr mdarray(
-      const mdarray<OtherElementType, OtherExtents, 
-                    OtherLayoutPolicy, OtherContainer>& other,
-      Args&&... args);
+    constexpr mdarray(const mdarray<OtherElementType, OtherExtents, 
+                                    OtherLayoutPolicy, OtherContainer>& other,
+                      Args&&... args);
 
   template<class OtherElementType, class OtherExtents,
            class OtherLayoutPolicy, class Accessor,
            class... Args>
     explicit(@_see below_@)
-    constexpr mdarray(mdspan<OtherElementType, OtherExtents,
-                             OtherLayoutPolicy, Accessor> other,
-      Args&&... args);
+    constexpr mdarray(const mdspan<OtherElementType, OtherExtents,
+                                   OtherLayoutPolicy, Accessor>& other,
+                      Args&&... args);
 ```
 
 :::

--- a/P1684-mdarray/P1684.md
+++ b/P1684-mdarray/P1684.md
@@ -370,7 +370,7 @@ This is teachable with these simple rules:
 The deduction guides have been reworked for the new constructors.
 Because we need to deduce the container type, a `Container` parameter is
 provided for all the guides which are not using the default container,
-and that container is  then copied or moved into the `mdarray` on construction.
+and that container is then copied or moved into the `mdarray` on construction.
 This works because providing a container as the only parameter
 to the `Args...` parameter pack in any of the constructors effectively implements this.
 
@@ -379,7 +379,7 @@ to the `Args...` parameter pack in any of the constructors effectively implement
 ```cpp
 ```
 
-#### Alternate (12 `mdarray` constructors)
+#### Alternative (12 `mdarray` constructors)
 ```cpp
 namespace std {
   struct fill_t {
@@ -392,7 +392,9 @@ namespace std {
 ---
 
 ```cpp
-  constexpr mdarray() requires(rank_dynamic() != 0) = default;
+  constexpr mdarray()
+    requires(rank_dynamic() != 0)
+    = default;
   constexpr mdarray(const mdarray& rhs) = default;
   constexpr mdarray(mdarray&& rhs) = default;
 
@@ -400,14 +402,18 @@ namespace std {
     explicit constexpr mdarray(OtherIndexTypes... exts);
 
   template<class... OtherIndexTypes>
-    constexpr mdarray(const container_type& c, OtherIndexTypes... exts);
+    constexpr mdarray(const container_type& c,
+                      OtherIndexTypes... exts);
 
   template<class... OtherIndexTypes>
-    constexpr mdarray(container_type&& c, OtherIndexTypes... exts);
+    constexpr mdarray(container_type&& c,
+                      OtherIndexTypes... exts);
 ```
 
 ```cpp
-  constexpr mdarray() requires(rank_dynamic() != 0) = default;
+  constexpr mdarray()
+    requires(rank_dynamic() != 0)
+    = default;
   constexpr mdarray(const mdarray& rhs) = default;
   constexpr mdarray(mdarray&& rhs) = default;
 
@@ -415,10 +421,12 @@ namespace std {
     explicit constexpr mdarray(OtherIndexTypes... exts);
 
   template<class... OtherIndexTypes>
-    constexpr mdarray(const container_type& c, OtherIndexTypes... exts);
+    constexpr mdarray(const container_type& c,
+                      OtherIndexTypes... exts);
 
   template<class... OtherIndexTypes>
-    constexpr mdarray(container_type&& c, OtherIndexTypes... exts);
+    constexpr mdarray(container_type&& c,
+                      OtherIndexTypes... exts);
 ```
 
 ---
@@ -427,58 +435,84 @@ namespace std {
   explicit constexpr mdarray(const extents_type& ext);
   explicit constexpr mdarray(const mapping_type& m);
 
-  constexpr mdarray(const container_type& c, const extents_type& ext);
-  constexpr mdarray(const container_type& c, const mapping_type& m);
+  constexpr mdarray(const container_type& c,
+                    const extents_type& ext);
+  constexpr mdarray(const container_type& c,
+                    const mapping_type& m);
 
   template<class Alloc>
-    constexpr mdarray(const extents_type& ext, const Alloc& a);
+    constexpr mdarray(const extents_type& ext,
+                      const Alloc& a);
   template<class Alloc>
-    constexpr mdarray(const mapping_type& m, const Alloc& a);
+    constexpr mdarray(const mapping_type& m,
+                      const Alloc& a);
 
-  constexpr mdarray(container_type&& c, const extents_type& ext);
-  constexpr mdarray(container_type&& c, const mapping_type& m);
+  constexpr mdarray(container_type&& c,
+                    const extents_type& ext);
+  constexpr mdarray(container_type&& c,
+                    const mapping_type& m);
 
   template<class Alloc>
-    constexpr mdarray(const container_type& c, const extents_type& ext, const Alloc& a);
+    constexpr mdarray(const container_type& c,
+                      const extents_type& ext,
+                      const Alloc& a);
   template<class Alloc>
-    constexpr mdarray(const container_type& c, const mapping_type& m, const Alloc& a);
+    constexpr mdarray(const container_type& c,
+                      const mapping_type& m,
+                      const Alloc& a);
 
   template<class Alloc>
-    constexpr mdarray(container_type&& c, const extents_type& ext, const Alloc& a);
+    constexpr mdarray(container_type&& c,
+                      const extents_type& ext,
+                      const Alloc& a);
   template<class Alloc>
-    constexpr mdarray(container_type&& c, const mapping_type& m, const Alloc& a);
+    constexpr mdarray(container_type&& c,
+                      const mapping_type& m,
+                      const Alloc& a);
 ```
 
 ```cpp
   template<class... Args>
     explicit(sizeof...(Args) == 0)
-    constexpr mdarray(const extents_type& ext, Args&&... args);
+    constexpr mdarray(const extents_type& ext,
+                      Args&&... args);
 
   template<class... Args>
     explicit(sizeof...(Args) == 0)
-    constexpr mdarray(const mapping_type& m, Args&&... args);
+    constexpr mdarray(const mapping_type& m,
+                      Args&&... args);
 ```
 
 ---
 
 ```cpp
-  constexpr mdarray(const extents_type& ext, const value_type& val);
-  constexpr mdarray(const mapping_type& m, const value_type& val);
+  constexpr mdarray(const extents_type& ext,
+                    const value_type& val);
+  constexpr mdarray(const mapping_type& m,
+                    const value_type& val);
 
   template<class Alloc>
-    constexpr mdarray(const extents_type& ext, const value_type& val, const Alloc& a);
+    constexpr mdarray(const extents_type& ext,
+                      const value_type& val,
+                      const Alloc& a);
   template<class Alloc>
-    constexpr mdarray(const mapping_type& m, const value_type& val, const Alloc& a);
+    constexpr mdarray(const mapping_type& m,
+                      const value_type& val,
+                      const Alloc& a);
 ```
 
 ```cpp
   template<class... Args>
     constexpr mdarray(const extents_type& ext,
-                      fill_t, const value_type& val, Args&&... args);
+                      fill_t,
+                      const value_type& val,
+                      Args&&... args);
 
   template<class... Args>
     constexpr mdarray(const mapping_type& m,
-                      fill_t, const value_type& val, Args&&... args);
+                      fill_t,
+                      const value_type& val,
+                      Args&&... args);
 ```
 
 ---
@@ -487,30 +521,37 @@ namespace std {
   template<class OtherElementType, class OtherExtents, 
            class OtherLayoutPolicy, class OtherContainer>
     explicit(@_see below_@)
-    constexpr mdarray(
-      const mdarray<OtherElementType, OtherExtents,
-                    OtherLayoutPolicy, OtherContainer>& other);
+    constexpr mdarray(const mdarray<OtherElementType,
+                    OtherExtents,
+                    OtherLayoutPolicy,
+                    OtherContainer>& other);
 
   template<class OtherElementType, class OtherExtents,
            class OtherLayoutPolicy, class Accessor>
     explicit(@_see below_@)
-    constexpr mdarray(const mdspan<OtherElementType, OtherExtents,
-                                   OtherLayoutPolicy, Accessor>& other);
+    constexpr mdarray(const mdspan<OtherElementType,
+                                   OtherExtents,
+                                   OtherLayoutPolicy,
+                                   Accessor>& other);
 
   template<class OtherElementType, class OtherExtents, 
            class OtherLayoutPolicy, class OtherContainer, 
            class Alloc>
     explicit(@_see below_@)
-    constexpr mdarray(
-      const mdarray<OtherElementType, OtherExtents, 
-                    OtherLayoutPolicy, OtherContainer>& other, const Alloc& a);
+    constexpr mdarray(const mdarray<OtherElementType,
+                                    OtherExtents, 
+                                    OtherLayoutPolicy,
+                                    OtherContainer>& other,
+                      const Alloc& a);
 
   template<class OtherElementType, class OtherExtents,
            class OtherLayoutPolicy, class Accessor,
            class Alloc>
     explicit(@_see below_@)
-    constexpr mdarray(const mdspan<OtherElementType, OtherExtents,
-                                   OtherLayoutPolicy, Accessor>& other,
+    constexpr mdarray(const mdspan<OtherElementType,
+                                   OtherExtents,
+                                   OtherLayoutPolicy,
+                                   Accessor>& other,
                       const Alloc& a);
 ```
 
@@ -519,16 +560,20 @@ namespace std {
            class OtherLayoutPolicy, class OtherContainer, 
            class... Args>
     explicit(@_see below_@)
-    constexpr mdarray(const mdarray<OtherElementType, OtherExtents, 
-                                    OtherLayoutPolicy, OtherContainer>& other,
+    constexpr mdarray(const mdarray<OtherElementType,
+                                    OtherExtents, 
+                                    OtherLayoutPolicy,
+                                    OtherContainer>& other,
                       Args&&... args);
 
   template<class OtherElementType, class OtherExtents,
            class OtherLayoutPolicy, class Accessor,
            class... Args>
     explicit(@_see below_@)
-    constexpr mdarray(const mdspan<OtherElementType, OtherExtents,
-                                   OtherLayoutPolicy, Accessor>& other,
+    constexpr mdarray(const mdspan<OtherElementType,
+                                   OtherExtents,
+                                   OtherLayoutPolicy,
+                                   Accessor>& other,
                       Args&&... args);
 ```
 
@@ -536,101 +581,150 @@ namespace std {
 
 ```cpp
 template <class Container, class... Integrals>
-requires((is_convertible_v<Integrals, size_t> && ...) && sizeof...(Integrals) > 0)
+requires((is_convertible_v<Integrals, size_t> && ...) &&
+         sizeof...(Integrals) > 0)
 explicit mdarray(const Container&, Integrals...)
-  -> mdarray<typename Container::value_type, dextents<size_t, sizeof...(Integrals)>, layout_right, Container>;
+  -> mdarray<typename Container::value_type,
+             dextents<size_t, sizeof...(Integrals)>,
+             layout_right,
+             Container>;
 
 template<class Container, class Extents>
 mdarray(const Container&, const Extents&)
-  -> mdarray<typename Container::value_type, Extents, layout_right, Container>;
+  -> mdarray<typename Container::value_type,
+             Extents,
+             layout_right,
+             Container>;
 
 template<class Container, class Mapping>
 mdarray(const Container&, const Mapping&)
-  -> mdarray<typename Container::value_type, typename Mapping::extents_type, layout_right, Container>;
+  -> mdarray<typename Container::value_type,
+             typename Mapping::extents_type,
+             layout_right,
+             Container>;
 
 template <class Container, class... Integrals>
-requires((is_convertible_v<Integrals, size_t> && ...) && sizeof...(Integrals) > 0)
+requires((is_convertible_v<Integrals, size_t> && ...) &&
+         sizeof...(Integrals) > 0)
 explicit mdarray(Container&&, Integrals...)
-  -> mdarray<typename Container::value_type, dextents<size_t, sizeof...(Integrals)>, layout_right, Container>;
+  -> mdarray<typename Container::value_type,
+             dextents<size_t, sizeof...(Integrals)>,
+             layout_right,
+             Container>;
 
 template<class Container, class Extents>
 mdarray(Container&&, const Extents&)
-  -> mdarray<typename Container::value_type, Extents, layout_right, Container>;
+  -> mdarray<typename Container::value_type,
+             Extents,
+             layout_right,
+             Container>;
 
 template<class Container, class Mapping>
 mdarray(Container&&, const Mapping&)
-  -> mdarray<typename Container::value_type, typename Mapping::extents_type, layout_right, Container>;
+  -> mdarray<typename Container::value_type,
+             typename Mapping::extents_type,
+             layout_right,
+             Container>;
 
-template<class ElementType, class Extents, class Layout, class Accessor>
+template<class ElementType, class Extents,
+         class Layout, class Accessor>
 mdarray(const mdspan<ElementType, Extents, Layout, Accessor>&)
-  -> mdarray<ElementType, Extents, Layout>;
+  -> mdarray<ElementType,
+             Extents,
+             Layout>;
 
 template<class Container, class Extents, class Alloc>
 mdarray(const Container&, const Extents&, const Alloc&)
-  -> mdarray<typename Container::value_type, Extents, layout_right, Container>;
+  -> mdarray<typename Container::value_type,
+             Extents,
+             layout_right,
+             Container>;
 
 template<class Container, class Mapping, class Alloc>
 mdarray(const Container&, const Mapping&, const Alloc&)
-  -> mdarray<typename Container::value_type, typename Mapping::extents_type, layout_right, Container>;
+  -> mdarray<typename Container::value_type,
+             typename Mapping::extents_type,
+             layout_right,
+             Container>;
 
 template<class Container, class Extents, class Alloc>
 mdarray(Container&&, const Extents&, const Alloc&)
-  -> mdarray<typename Container::value_type, Extents, layout_right, Container>;
+  -> mdarray<typename Container::value_type,
+             Extents,
+             layout_right,
+             Container>;
 
 template<class Container, class Mapping, class Alloc>
 mdarray(Container&&, const Mapping&, const Alloc&)
-  -> mdarray<typename Container::value_type, typename Mapping::extents_type, layout_right, Container>;
+  -> mdarray<typename Container::value_type,
+             typename Mapping::extents_type,
+             layout_right,
+             Container>;
 
-template<class ElementType, class Extents, class Layout, class Accessor, class Alloc>
-mdarray(const mdspan<ElementType, Extents, Layout, Accessor>&, const Alloc&)
-  -> mdarray<ElementType, Extents, Layout>;
+template<class ElementType, class Extents,
+         class Layout, class Accessor, class Alloc>
+mdarray(const mdspan<ElementType, Extents, Layout, Accessor>&,
+        const Alloc&)
+  -> mdarray<ElementType,
+             Extents,
+             Layout>;
 ```
 
 ```cpp
 template<class Container, class... Integrals>
-requires((is_convertible_v<Integrals, size_t> && ...) && sizeof...(Integrals) > 0)
-mdarray(Container&&, Integrals...)
+requires((is_convertible_v<Integrals, size_t> && ...) &&
+         sizeof...(Integrals) > 0)
+mdarray(Container&&,
+        Integrals...)
   -> mdarray<typename Container::value_type,
              dextents<size_t, sizeof...(Integrals)>,
              layout_right,
              remove_const_t<remove_reference_t<Container>>>;
 
 template<class Container, class IndexType, size_t... Extents>
-mdarray(const extents<IndexType, Extents...>&, Container&&)
+mdarray(const extents<IndexType, Extents...>&,
+        Container&&)
   -> mdarray<typename Container::value_type,
              extents<IndexType, Extents...>,
              layout_right,
              remove_const_t<remove_reference_t<Container>>>;
 
 template<class Container, class IndexType, size_t... Extents>
-mdarray(const layout_left::mapping<extents<IndexType, Extents...>>&, Container&&)
+mdarray(const layout_left::mapping<extents<IndexType, Extents...>>&,
+        Container&&)
   -> mdarray<typename Container::value_type,
              extents<IndexType, Extents...>,
              layout_left,
              remove_const_t<remove_reference_t<Container>>>;
 
 template<class Container, class IndexType, size_t... Extents>
-mdarray(const layout_right::mapping<extents<IndexType, Extents...>>&, Container&&)
+mdarray(const layout_right::mapping<extents<IndexType, Extents...>>&,
+        Container&&)
   -> mdarray<typename Container::value_type,
              extents<IndexType, Extents...>,
              layout_right,
              remove_const_t<remove_reference_t<Container>>>;
 
 template<class Container, class IndexType, size_t... Extents>
-mdarray(const layout_stride::mapping<extents<IndexType, Extents...>>&, Container&&)
+mdarray(const layout_stride::mapping<extents<IndexType, Extents...>>&,
+        Container&&)
   -> mdarray<typename Container::value_type,
              extents<IndexType, Extents...>,
              layout_stride,
              remove_const_t<remove_reference_t<Container>>>;
 
-template<class ElementType, class Extents, class Layout, class Accessor>
+template<class ElementType, class Extents,
+         class Layout, class Accessor>
 mdarray(const mdspan<ElementType, Extents, Layout, Accessor>&)
   -> mdarray<ElementType,
              Extents,
              Layout>;
 
-template<class Container, class ElementType, class Extents, class Layout, class Accessor>
-mdarray(const mdspan<ElementType, Extents, Layout, Accessor>&, Container&&)
+template<class Container,
+         class ElementType, class Extents,
+         class Layout, class Accessor>
+mdarray(const mdspan<ElementType, Extents, Layout, Accessor>&,
+        Container&&)
   -> mdarray<ElementType,
              Extents,
              Layout,

--- a/P1684-mdarray/P1684.md
+++ b/P1684-mdarray/P1684.md
@@ -617,13 +617,13 @@ mdarray(const layout_stride::mapping<extents<IndexType, Extents...>>&, Container
              remove_const_t<remove_reference_t<Container>>>;
 
 template<class ElementType, class Extents, class Layout, class Accessor>
-mdarray(const mdspan<ElementType, Extents, Layout, Accessor>&, Container&& = vector<ElementType>())
+mdarray(const mdspan<ElementType, Extents, Layout, Accessor>&)
   -> mdarray<ElementType,
              Extents,
              Layout>;
 
 template<class Container, class ElementType, class Extents, class Layout, class Accessor>
-mdarray(const mdspan<ElementType, Extents, Layout, Accessor>&, Container&& = vector<ElementType>())
+mdarray(const mdspan<ElementType, Extents, Layout, Accessor>&, Container&&)
   -> mdarray<ElementType,
              Extents,
              Layout,

--- a/P1684-mdarray/P1684.md
+++ b/P1684-mdarray/P1684.md
@@ -525,6 +525,105 @@ namespace std {
                       Args&&... args);
 ```
 
+---
+
+```cpp
+template <class Container, class... Integrals>
+requires((is_convertible_v<Integrals, size_t> && ...) && sizeof...(Integrals) > 0)
+explicit mdarray(const Container&, Integrals...)
+  -> mdarray<typename Container::value_type, dextents<size_t, sizeof...(Integrals)>, layout_right, Container>;
+
+template<class Container, class Extents>
+mdarray(const Container&, const Extents&)
+  -> mdarray<typename Container::value_type, Extents, layout_right, Container>;
+
+template<class Container, class Mapping>
+mdarray(const Container&, const Mapping&)
+  -> mdarray<typename Container::value_type, typename Mapping::extents_type, layout_right, Container>;
+
+template <class Container, class... Integrals>
+requires((is_convertible_v<Integrals, size_t> && ...) && sizeof...(Integrals) > 0)
+explicit mdarray(Container&&, Integrals...)
+  -> mdarray<typename Container::value_type, dextents<size_t, sizeof...(Integrals)>, layout_right, Container>;
+
+template<class Container, class Extents>
+mdarray(Container&&, const Extents&)
+  -> mdarray<typename Container::value_type, Extents, layout_right, Container>;
+
+template<class Container, class Mapping>
+mdarray(Container&&, const Mapping&)
+  -> mdarray<typename Container::value_type, typename Mapping::extents_type, layout_right, Container>;
+
+template<class ElementType, class Extents, class Layout, class Accessor>
+mdarray(const mdspan<ElementType, Extents, Layout, Accessor>&)
+  -> mdarray<ElementType, Extents, Layout>;
+
+template<class Container, class Extents, class Alloc>
+mdarray(const Container&, const Extents&, const Alloc&)
+  -> mdarray<typename Container::value_type, Extents, layout_right, Container>;
+
+template<class Container, class Mapping, class Alloc>
+mdarray(const Container&, const Mapping&, const Alloc&)
+  -> mdarray<typename Container::value_type, typename Mapping::extents_type, layout_right, Container>;
+
+template<class Container, class Extents, class Alloc>
+mdarray(Container&&, const Extents&, const Alloc&)
+  -> mdarray<typename Container::value_type, Extents, layout_right, Container>;
+
+template<class Container, class Mapping, class Alloc>
+mdarray(Container&&, const Mapping&, const Alloc&)
+  -> mdarray<typename Container::value_type, typename Mapping::extents_type, layout_right, Container>;
+
+template<class ElementType, class Extents, class Layout, class Accessor, class Alloc>
+mdarray(const mdspan<ElementType, Extents, Layout, Accessor>&, const Alloc&)
+  -> mdarray<ElementType, Extents, Layout>;
+```
+
+```cpp
+template<class Container, class... Integrals>
+requires((is_convertible_v<Integrals, size_t> && ...) && sizeof...(Integrals) > 0)
+mdarray(Container&&, Integrals...)
+  -> mdarray<typename Container::value_type,
+             dextents<size_t, sizeof...(Integrals)>,
+             layout_right,
+             remove_const_t<remove_reference_t<Container>>>;
+
+template<class Container, class IndexType, size_t... Extents>
+mdarray(const extents<IndexType, Extents...>&, Container&&)
+  -> mdarray<typename Container::value_type,
+             extents<IndexType, Extents...>,
+             layout_right,
+             remove_const_t<remove_reference_t<Container>>>;
+
+template<class Container, class IndexType, size_t... Extents>
+mdarray(const layout_left::mapping<extents<IndexType, Extents...>>&, Container&&)
+  -> mdarray<typename Container::value_type,
+             extents<IndexType, Extents...>,
+             layout_left,
+             remove_const_t<remove_reference_t<Container>>>;
+
+template<class Container, class IndexType, size_t... Extents>
+mdarray(const layout_right::mapping<extents<IndexType, Extents...>>&, Container&&)
+  -> mdarray<typename Container::value_type,
+             extents<IndexType, Extents...>,
+             layout_right,
+             remove_const_t<remove_reference_t<Container>>>;
+
+template<class Container, class IndexType, size_t... Extents>
+mdarray(const layout_stride::mapping<extents<IndexType, Extents...>>&, Container&&)
+  -> mdarray<typename Container::value_type,
+             extents<IndexType, Extents...>,
+             layout_stride,
+             remove_const_t<remove_reference_t<Container>>>;
+
+template<class Container, class ElementType, class Extents, class Layout, class Accessor>
+mdarray(const mdspan<ElementType, Extents, Layout, Accessor>&, Container&& = vector<ElementType>())
+  -> mdarray<ElementType,
+             Extents,
+             Layout,
+             remove_const_t<remove_reference_t<Container>>>;
+```
+
 :::
 
 ## `Extents` design reused


### PR DESCRIPTION
We discussed it over email a while ago.

Not sure if the alternate constructor design in the right place in the document.

Also, I didn't know what to do with the deduction guides, as the original ones are wrong for a variety of reasons:

* Guides 1 and 4 are marked `explicit`, but the corresponding constructor is implicit.
* Guides 2 and 3 are ambiguous with respect to each other, because `Mapping` and `Extents` are both unconstrained template parameters.  Same thing with guides 5 and 6, 8 and 9, 10 and 11.

