### PR TITLE
P1673: Fix "alias"

### DIFF
--- a/D1673/D1673R13-running-revision.html
+++ b/D1673/D1673R13-running-revision.html
@@ -4,17 +4,17 @@
   <meta charset="utf-8" />
   <meta name="generator" content="mpark/wg21" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <meta name="dcterms.date" content="2023-09-20" />
+  <meta name="dcterms.date" content="2023-09-25" />
   <title>A free function linear algebra interface based on the BLAS</title>
   <style>
-      code{white-space: pre-wrap;}
-      span.smallcaps{font-variant: small-caps;}
-      span.underline{text-decoration: underline;}
-      div.column{display: inline-block; vertical-align: top; width: 50%;}
-  </style>
+code{white-space: pre-wrap;}
+span.smallcaps{font-variant: small-caps;}
+span.underline{text-decoration: underline;}
+div.column{display: inline-block; vertical-align: top; width: 50%;}
+</style>
   <style>
 pre > code.sourceCode { white-space: pre; position: relative; }
-pre > code.sourceCode > span { display: inline-block; line-height: 1.25; }
+pre > code.sourceCode > span { line-height: 1.25; }
 pre > code.sourceCode > span:empty { height: 1.2em; }
 .sourceCode { overflow: visible; }
 code.sourceCode > span { color: inherit; text-decoration: inherit; }
@@ -28,60 +28,60 @@ pre > code.sourceCode { white-space: pre-wrap; }
 pre > code.sourceCode > span { text-indent: -5em; padding-left: 5em; }
 }
 pre.numberSource code
-  { counter-reset: source-line 0; }
+{ counter-reset: source-line 0; }
 pre.numberSource code > span
-  { position: relative; left: -4em; counter-increment: source-line; }
+{ position: relative; left: -4em; counter-increment: source-line; }
 pre.numberSource code > span > a:first-child::before
-  { content: counter(source-line);
-    position: relative; left: -1em; text-align: right; vertical-align: baseline;
-    border: none; display: inline-block;
-    -webkit-touch-callout: none; -webkit-user-select: none;
-    -khtml-user-select: none; -moz-user-select: none;
-    -ms-user-select: none; user-select: none;
-    padding: 0 4px; width: 4em;
-    color: #aaaaaa;
-  }
-pre.numberSource { margin-left: 3em; border-left: 1px solid #aaaaaa;  padding-left: 4px; }
+{ content: counter(source-line);
+position: relative; left: -1em; text-align: right; vertical-align: baseline;
+border: none; display: inline-block;
+-webkit-touch-callout: none; -webkit-user-select: none;
+-khtml-user-select: none; -moz-user-select: none;
+-ms-user-select: none; user-select: none;
+padding: 0 4px; width: 4em;
+color: #aaaaaa;
+}
+pre.numberSource { margin-left: 3em; border-left: 1px solid #aaaaaa; padding-left: 4px; }
 div.sourceCode
-  {  background-color: #f6f8fa; }
+{ background-color: #f6f8fa; }
 @media screen {
 pre > code.sourceCode > span > a:first-child::before { text-decoration: underline; }
 }
-code span { } /* Normal */
-code span.al { color: #ff0000; } /* Alert */
-code span.an { } /* Annotation */
-code span.at { } /* Attribute */
-code span.bn { color: #9f6807; } /* BaseN */
-code span.bu { color: #9f6807; } /* BuiltIn */
-code span.cf { color: #00607c; } /* ControlFlow */
-code span.ch { color: #9f6807; } /* Char */
-code span.cn { } /* Constant */
-code span.co { color: #008000; font-style: italic; } /* Comment */
-code span.cv { color: #008000; font-style: italic; } /* CommentVar */
-code span.do { color: #008000; } /* Documentation */
-code span.dt { color: #00607c; } /* DataType */
-code span.dv { color: #9f6807; } /* DecVal */
-code span.er { color: #ff0000; font-weight: bold; } /* Error */
-code span.ex { } /* Extension */
-code span.fl { color: #9f6807; } /* Float */
-code span.fu { } /* Function */
-code span.im { } /* Import */
-code span.in { color: #008000; } /* Information */
-code span.kw { color: #00607c; } /* Keyword */
-code span.op { color: #af1915; } /* Operator */
-code span.ot { } /* Other */
-code span.pp { color: #6f4e37; } /* Preprocessor */
-code span.re { } /* RegionMarker */
-code span.sc { color: #9f6807; } /* SpecialChar */
-code span.ss { color: #9f6807; } /* SpecialString */
-code span.st { color: #9f6807; } /* String */
-code span.va { } /* Variable */
-code span.vs { color: #9f6807; } /* VerbatimString */
-code span.wa { color: #008000; font-weight: bold; } /* Warning */
+code span { } 
+code span.al { color: #ff0000; } 
+code span.an { } 
+code span.at { } 
+code span.bn { color: #9f6807; } 
+code span.bu { color: #9f6807; } 
+code span.cf { color: #00607c; } 
+code span.ch { color: #9f6807; } 
+code span.cn { } 
+code span.co { color: #008000; font-style: italic; } 
+code span.cv { color: #008000; font-style: italic; } 
+code span.do { color: #008000; } 
+code span.dt { color: #00607c; } 
+code span.dv { color: #9f6807; } 
+code span.er { color: #ff0000; font-weight: bold; } 
+code span.ex { } 
+code span.fl { color: #9f6807; } 
+code span.fu { } 
+code span.im { } 
+code span.in { color: #008000; } 
+code span.kw { color: #00607c; } 
+code span.op { color: #af1915; } 
+code span.ot { } 
+code span.pp { color: #6f4e37; } 
+code span.re { } 
+code span.sc { color: #9f6807; } 
+code span.ss { color: #9f6807; } 
+code span.st { color: #9f6807; } 
+code span.va { } 
+code span.vs { color: #9f6807; } 
+code span.wa { color: #008000; font-weight: bold; } 
 code.diff {color: #898887}
 code.diff span.va {color: #00AA00}
 code.diff span.st {color: #bf0303}
-  </style>
+</style>
   <style type="text/css">
 body {
 margin: 5em;
@@ -425,7 +425,7 @@ algebra interface based on the BLAS</h1>
   </tr>
   <tr>
     <td>Date: </td>
-    <td>2023-09-20</td>
+    <td>2023-09-25</td>
   </tr>
   <tr>
     <td style="vertical-align:top">Project: </td>
@@ -458,268 +458,236 @@ algebra interface based on the BLAS</h1>
 <div id="TOC" role="doc-toc">
 <h1 id="toctitle">Contents</h1>
 <ul>
-<li><a href="#authors-and-contributors"><span class="toc-section-number">1</span> Authors and
-contributors<span></span></a>
+<li><a href="#authors-and-contributors" id="toc-authors-and-contributors"><span class="toc-section-number">1</span> Authors and contributors</a>
 <ul>
-<li><a href="#authors"><span class="toc-section-number">1.1</span>
-Authors<span></span></a></li>
-<li><a href="#contributors"><span class="toc-section-number">1.2</span>
-Contributors<span></span></a></li>
+<li><a href="#authors" id="toc-authors"><span class="toc-section-number">1.1</span> Authors</a></li>
+<li><a href="#contributors" id="toc-contributors"><span class="toc-section-number">1.2</span> Contributors</a></li>
 </ul></li>
-<li><a href="#revision-history"><span class="toc-section-number">2</span> Revision
-history<span></span></a></li>
-<li><a href="#purpose-of-this-paper"><span class="toc-section-number">3</span> Purpose of this
-paper<span></span></a></li>
-<li><a href="#overview-of-contents"><span class="toc-section-number">4</span> Overview of
-contents<span></span></a></li>
-<li><a href="#why-include-dense-linear-algebra-in-the-c-standard-library"><span class="toc-section-number">5</span> Why include dense linear algebra in
-the C++ Standard Library?<span></span></a></li>
-<li><a href="#why-base-a-c-linear-algebra-library-on-the-blas"><span class="toc-section-number">6</span> Why base a C++ linear algebra
-library on the BLAS?<span></span></a></li>
-<li><a href="#criteria-for-including-algorithms"><span class="toc-section-number">7</span> Criteria for including
-algorithms<span></span></a>
+<li><a href="#revision-history" id="toc-revision-history"><span class="toc-section-number">2</span> Revision history</a></li>
+<li><a href="#purpose-of-this-paper" id="toc-purpose-of-this-paper"><span class="toc-section-number">3</span>
+Purpose of this paper</a></li>
+<li><a href="#overview-of-contents" id="toc-overview-of-contents"><span class="toc-section-number">4</span> Overview of contents</a></li>
+<li><a href="#why-include-dense-linear-algebra-in-the-c-standard-library" id="toc-why-include-dense-linear-algebra-in-the-c-standard-library"><span class="toc-section-number">5</span> Why include dense linear algebra in
+the C++ Standard Library?</a></li>
+<li><a href="#why-base-a-c-linear-algebra-library-on-the-blas" id="toc-why-base-a-c-linear-algebra-library-on-the-blas"><span class="toc-section-number">6</span> Why base a C++ linear algebra
+library on the BLAS?</a></li>
+<li><a href="#criteria-for-including-algorithms" id="toc-criteria-for-including-algorithms"><span class="toc-section-number">7</span> Criteria for including
+algorithms</a>
 <ul>
-<li><a href="#criteria-for-all-the-algorithms"><span class="toc-section-number">7.1</span> Criteria for all the
-algorithms<span></span></a></li>
-<li><a href="#criteria-for-including-blas-1-algorithms-coexistence-with-ranges"><span class="toc-section-number">7.2</span> Criteria for including BLAS 1
-algorithms; coexistence with ranges<span></span></a>
+<li><a href="#criteria-for-all-the-algorithms" id="toc-criteria-for-all-the-algorithms"><span class="toc-section-number">7.1</span> Criteria for all the
+algorithms</a></li>
+<li><a href="#criteria-for-including-blas-1-algorithms-coexistence-with-ranges" id="toc-criteria-for-including-blas-1-algorithms-coexistence-with-ranges"><span class="toc-section-number">7.2</span> Criteria for including BLAS 1
+algorithms; coexistence with ranges</a>
 <ul>
-<li><a href="#low-risk-of-syntactic-collision-with-ranges"><span class="toc-section-number">7.2.1</span> Low risk of syntactic collision
-with ranges<span></span></a></li>
-<li><a href="#minimal-overlap-with-ranges-is-justified-by-user-convenience"><span class="toc-section-number">7.2.2</span> Minimal overlap with ranges is
-justified by user convenience<span></span></a></li>
+<li><a href="#low-risk-of-syntactic-collision-with-ranges" id="toc-low-risk-of-syntactic-collision-with-ranges"><span class="toc-section-number">7.2.1</span> Low risk of syntactic collision
+with ranges</a></li>
+<li><a href="#minimal-overlap-with-ranges-is-justified-by-user-convenience" id="toc-minimal-overlap-with-ranges-is-justified-by-user-convenience"><span class="toc-section-number">7.2.2</span> Minimal overlap with ranges is
+justified by user convenience</a></li>
 </ul></li>
 </ul></li>
-<li><a href="#notation-and-conventions"><span class="toc-section-number">8</span> Notation and
-conventions<span></span></a>
+<li><a href="#notation-and-conventions" id="toc-notation-and-conventions"><span class="toc-section-number">8</span> Notation and conventions</a>
 <ul>
-<li><a href="#the-blas-uses-fortran-terms"><span class="toc-section-number">8.1</span> The BLAS uses Fortran
-terms<span></span></a></li>
-<li><a href="#we-call-subroutines-functions"><span class="toc-section-number">8.2</span> We call “subroutines”
-functions<span></span></a></li>
-<li><a href="#element-types-and-blas-function-name-prefix"><span class="toc-section-number">8.3</span> Element types and BLAS function
-name prefix<span></span></a></li>
+<li><a href="#the-blas-uses-fortran-terms" id="toc-the-blas-uses-fortran-terms"><span class="toc-section-number">8.1</span> The BLAS uses Fortran
+terms</a></li>
+<li><a href="#we-call-subroutines-functions" id="toc-we-call-subroutines-functions"><span class="toc-section-number">8.2</span> We call “subroutines”
+functions</a></li>
+<li><a href="#element-types-and-blas-function-name-prefix" id="toc-element-types-and-blas-function-name-prefix"><span class="toc-section-number">8.3</span> Element types and BLAS function
+name prefix</a></li>
 </ul></li>
-<li><a href="#what-we-exclude-from-the-design"><span class="toc-section-number">9</span> What we exclude from the
-design<span></span></a>
+<li><a href="#what-we-exclude-from-the-design" id="toc-what-we-exclude-from-the-design"><span class="toc-section-number">9</span> What we exclude from the design</a>
 <ul>
-<li><a href="#most-functions-not-in-the-reference-blas"><span class="toc-section-number">9.1</span> Most functions not in the
-Reference BLAS<span></span></a></li>
-<li><a href="#lapack-or-related-functionality"><span class="toc-section-number">9.2</span> LAPACK or related
-functionality<span></span></a></li>
-<li><a href="#extended-precision-blas"><span class="toc-section-number">9.3</span> Extended-precision
-BLAS<span></span></a></li>
-<li><a href="#arithmetic-operators-and-associated-expression-templates"><span class="toc-section-number">9.4</span> Arithmetic operators and
-associated expression templates<span></span></a></li>
-<li><a href="#banded-matrix-layouts"><span class="toc-section-number">9.5</span> Banded matrix
-layouts<span></span></a></li>
-<li><a href="#tensors"><span class="toc-section-number">9.6</span>
-Tensors<span></span></a></li>
-<li><a href="#explicit-support-for-asynchronous-return-of-scalar-values"><span class="toc-section-number">9.7</span> Explicit support for asynchronous
-return of scalar values<span></span></a></li>
+<li><a href="#most-functions-not-in-the-reference-blas" id="toc-most-functions-not-in-the-reference-blas"><span class="toc-section-number">9.1</span> Most functions not in the
+Reference BLAS</a></li>
+<li><a href="#lapack-or-related-functionality" id="toc-lapack-or-related-functionality"><span class="toc-section-number">9.2</span> LAPACK or related
+functionality</a></li>
+<li><a href="#extended-precision-blas" id="toc-extended-precision-blas"><span class="toc-section-number">9.3</span> Extended-precision BLAS</a></li>
+<li><a href="#arithmetic-operators-and-associated-expression-templates" id="toc-arithmetic-operators-and-associated-expression-templates"><span class="toc-section-number">9.4</span> Arithmetic operators and
+associated expression templates</a></li>
+<li><a href="#banded-matrix-layouts" id="toc-banded-matrix-layouts"><span class="toc-section-number">9.5</span> Banded matrix layouts</a></li>
+<li><a href="#tensors" id="toc-tensors"><span class="toc-section-number">9.6</span> Tensors</a></li>
+<li><a href="#explicit-support-for-asynchronous-return-of-scalar-values" id="toc-explicit-support-for-asynchronous-return-of-scalar-values"><span class="toc-section-number">9.7</span> Explicit support for asynchronous
+return of scalar values</a></li>
 </ul></li>
-<li><a href="#design-justification"><span class="toc-section-number">10</span> Design
-justification<span></span></a>
+<li><a href="#design-justification" id="toc-design-justification"><span class="toc-section-number">10</span> Design justification</a>
 <ul>
-<li><a href="#we-do-not-require-using-the-blas-library-or-any-particular-back-end"><span class="toc-section-number">10.1</span> We do not require using the BLAS
-library or any particular “back-end”<span></span></a></li>
-<li><a href="#why-use-mdspan"><span class="toc-section-number">10.2</span> Why use
-<code>mdspan</code>?<span></span></a>
+<li><a href="#we-do-not-require-using-the-blas-library-or-any-particular-back-end" id="toc-we-do-not-require-using-the-blas-library-or-any-particular-back-end"><span class="toc-section-number">10.1</span> We do not require using the BLAS
+library or any particular “back-end”</a></li>
+<li><a href="#why-use-mdspan" id="toc-why-use-mdspan"><span class="toc-section-number">10.2</span> Why use <code>mdspan</code>?</a>
 <ul>
-<li><a href="#view-of-a-multidimensional-array"><span class="toc-section-number">10.2.1</span> View of a multidimensional
-array<span></span></a></li>
-<li><a href="#ease-of-use"><span class="toc-section-number">10.2.2</span> Ease of
-use<span></span></a></li>
-<li><a href="#blas-and-mdspan-are-low-level"><span class="toc-section-number">10.2.3</span> BLAS and <code>mdspan</code>
-are low level<span></span></a></li>
-<li><a href="#hook-for-future-expansion"><span class="toc-section-number">10.2.4</span> Hook for future
-expansion<span></span></a></li>
-<li><a href="#generic-enough-to-replace-a-multidimensional-array-concept"><span class="toc-section-number">10.2.5</span> Generic enough to replace a
-“multidimensional array concept”<span></span></a></li>
+<li><a href="#view-of-a-multidimensional-array" id="toc-view-of-a-multidimensional-array"><span class="toc-section-number">10.2.1</span> View of a multidimensional
+array</a></li>
+<li><a href="#ease-of-use" id="toc-ease-of-use"><span class="toc-section-number">10.2.2</span> Ease of use</a></li>
+<li><a href="#blas-and-mdspan-are-low-level" id="toc-blas-and-mdspan-are-low-level"><span class="toc-section-number">10.2.3</span> BLAS and <code>mdspan</code>
+are low level</a></li>
+<li><a href="#hook-for-future-expansion" id="toc-hook-for-future-expansion"><span class="toc-section-number">10.2.4</span> Hook for future
+expansion</a></li>
+<li><a href="#generic-enough-to-replace-a-multidimensional-array-concept" id="toc-generic-enough-to-replace-a-multidimensional-array-concept"><span class="toc-section-number">10.2.5</span> Generic enough to replace a
+“multidimensional array concept”</a></li>
 </ul></li>
-<li><a href="#function-argument-aliasing-and-zero-scalar-multipliers"><span class="toc-section-number">10.3</span> Function argument aliasing and
-zero scalar multipliers<span></span></a></li>
-<li><a href="#support-for-different-matrix-layouts"><span class="toc-section-number">10.4</span> Support for different matrix
-layouts<span></span></a></li>
-<li><a href="#interpretation-of-lower-upper-triangular"><span class="toc-section-number">10.5</span> Interpretation of “lower / upper
-triangular”<span></span></a>
+<li><a href="#function-argument-aliasing-and-zero-scalar-multipliers" id="toc-function-argument-aliasing-and-zero-scalar-multipliers"><span class="toc-section-number">10.3</span> Function argument aliasing and
+zero scalar multipliers</a></li>
+<li><a href="#support-for-different-matrix-layouts" id="toc-support-for-different-matrix-layouts"><span class="toc-section-number">10.4</span> Support for different matrix
+layouts</a></li>
+<li><a href="#interpretation-of-lower-upper-triangular" id="toc-interpretation-of-lower-upper-triangular"><span class="toc-section-number">10.5</span> Interpretation of “lower / upper
+triangular”</a>
 <ul>
-<li><a href="#triangle-refers-to-what-part-of-the-matrix-is-accessed"><span class="toc-section-number">10.5.1</span> Triangle refers to what part of
-the matrix is accessed<span></span></a></li>
-<li><a href="#blas-applies-uplo-to-original-matrix-we-apply-triangle-to-transformed-matrix"><span class="toc-section-number">10.5.2</span> BLAS applies UPLO to original
-matrix; we apply Triangle to transformed matrix<span></span></a></li>
-<li><a href="#summary"><span class="toc-section-number">10.5.3</span>
-Summary<span></span></a></li>
+<li><a href="#triangle-refers-to-what-part-of-the-matrix-is-accessed" id="toc-triangle-refers-to-what-part-of-the-matrix-is-accessed"><span class="toc-section-number">10.5.1</span> Triangle refers to what part of
+the matrix is accessed</a></li>
+<li><a href="#blas-applies-uplo-to-original-matrix-we-apply-triangle-to-transformed-matrix" id="toc-blas-applies-uplo-to-original-matrix-we-apply-triangle-to-transformed-matrix"><span class="toc-section-number">10.5.2</span> BLAS applies UPLO to original
+matrix; we apply Triangle to transformed matrix</a></li>
+<li><a href="#summary" id="toc-summary"><span class="toc-section-number">10.5.3</span> Summary</a></li>
 </ul></li>
-<li><a href="#norms-and-infinity-norms-for-vectors-and-matrices-of-complex-numbers"><span class="toc-section-number">10.6</span> 1-norms and infinity-norms for
-vectors and matrices of complex numbers<span></span></a>
+<li><a href="#norms-and-infinity-norms-for-vectors-and-matrices-of-complex-numbers" id="toc-norms-and-infinity-norms-for-vectors-and-matrices-of-complex-numbers"><span class="toc-section-number">10.6</span> 1-norms and infinity-norms for
+vectors and matrices of complex numbers</a>
 <ul>
-<li><a href="#summary-1"><span class="toc-section-number">10.6.1</span>
-Summary<span></span></a></li>
-<li><a href="#vectors"><span class="toc-section-number">10.6.2</span>
-Vectors<span></span></a></li>
-<li><a href="#matrices"><span class="toc-section-number">10.6.3</span>
-Matrices<span></span></a></li>
+<li><a href="#summary-1" id="toc-summary-1"><span class="toc-section-number">10.6.1</span> Summary</a></li>
+<li><a href="#vectors" id="toc-vectors"><span class="toc-section-number">10.6.2</span> Vectors</a></li>
+<li><a href="#matrices" id="toc-matrices"><span class="toc-section-number">10.6.3</span> Matrices</a></li>
 </ul></li>
-<li><a href="#over--and-underflow-wording-for-vector-2-norm"><span class="toc-section-number">10.7</span> Over- and underflow wording for
-vector 2-norm<span></span></a></li>
-<li><a href="#constraining-matrix-and-vector-element-types-and-scalars"><span class="toc-section-number">10.8</span> Constraining matrix and vector
-element types and scalars<span></span></a>
+<li><a href="#over--and-underflow-wording-for-vector-2-norm" id="toc-over--and-underflow-wording-for-vector-2-norm"><span class="toc-section-number">10.7</span> Over- and underflow wording for
+vector 2-norm</a></li>
+<li><a href="#constraining-matrix-and-vector-element-types-and-scalars" id="toc-constraining-matrix-and-vector-element-types-and-scalars"><span class="toc-section-number">10.8</span> Constraining matrix and vector
+element types and scalars</a>
 <ul>
-<li><a href="#introduction"><span class="toc-section-number">10.8.1</span>
-Introduction<span></span></a></li>
-<li><a href="#value-type-constraints-do-not-suffice-to-describe-algorithm-behavior"><span class="toc-section-number">10.8.2</span> Value type constraints do not
-suffice to describe algorithm behavior<span></span></a></li>
-<li><a href="#associativity-is-too-strict"><span class="toc-section-number">10.8.3</span> Associativity is too
-strict<span></span></a></li>
-<li><a href="#generalizing-associativity-helps-little"><span class="toc-section-number">10.8.4</span> Generalizing associativity
-helps little<span></span></a></li>
-<li><a href="#categories-of-qoi-enhancements"><span class="toc-section-number">10.8.5</span> Categories of QoI
-enhancements<span></span></a></li>
-<li><a href="#properties-of-textbook-algorithm-descriptions"><span class="toc-section-number">10.8.6</span> Properties of textbook
-algorithm descriptions<span></span></a></li>
-<li><a href="#reordering-sums-and-creating-temporaries"><span class="toc-section-number">10.8.7</span> Reordering sums and creating
-temporaries<span></span></a></li>
-<li><a href="#textbook-algorithm-description-in-semiring-terms"><span class="toc-section-number">10.8.8</span> “Textbook” algorithm
-description in semiring terms<span></span></a></li>
-<li><a href="#summary-2"><span class="toc-section-number">10.8.9</span>
-Summary<span></span></a></li>
+<li><a href="#introduction" id="toc-introduction"><span class="toc-section-number">10.8.1</span> Introduction</a></li>
+<li><a href="#value-type-constraints-do-not-suffice-to-describe-algorithm-behavior" id="toc-value-type-constraints-do-not-suffice-to-describe-algorithm-behavior"><span class="toc-section-number">10.8.2</span> Value type constraints do not
+suffice to describe algorithm behavior</a></li>
+<li><a href="#associativity-is-too-strict" id="toc-associativity-is-too-strict"><span class="toc-section-number">10.8.3</span> Associativity is too
+strict</a></li>
+<li><a href="#generalizing-associativity-helps-little" id="toc-generalizing-associativity-helps-little"><span class="toc-section-number">10.8.4</span> Generalizing associativity
+helps little</a></li>
+<li><a href="#categories-of-qoi-enhancements" id="toc-categories-of-qoi-enhancements"><span class="toc-section-number">10.8.5</span> Categories of QoI
+enhancements</a></li>
+<li><a href="#properties-of-textbook-algorithm-descriptions" id="toc-properties-of-textbook-algorithm-descriptions"><span class="toc-section-number">10.8.6</span> Properties of textbook
+algorithm descriptions</a></li>
+<li><a href="#reordering-sums-and-creating-temporaries" id="toc-reordering-sums-and-creating-temporaries"><span class="toc-section-number">10.8.7</span> Reordering sums and creating
+temporaries</a></li>
+<li><a href="#textbook-algorithm-description-in-semiring-terms" id="toc-textbook-algorithm-description-in-semiring-terms"><span class="toc-section-number">10.8.8</span> “Textbook” algorithm
+description in semiring terms</a></li>
+<li><a href="#summary-2" id="toc-summary-2"><span class="toc-section-number">10.8.9</span> Summary</a></li>
 </ul></li>
-<li><a href="#fix-issues-with-complex-and-support-user-defined-complex-number-types"><span class="toc-section-number">10.9</span> Fix issues with
-<code>complex</code>, and support user-defined complex number
-types<span></span></a>
+<li><a href="#fix-issues-with-complex-and-support-user-defined-complex-number-types" id="toc-fix-issues-with-complex-and-support-user-defined-complex-number-types"><span class="toc-section-number">10.9</span> Fix issues with
+<code>complex</code>, and support user-defined complex number types</a>
 <ul>
-<li><a href="#motivation-and-summary-of-solution"><span class="toc-section-number">10.9.1</span> Motivation and summary of
-solution<span></span></a></li>
-<li><a href="#why-users-define-their-own-complex-number-types"><span class="toc-section-number">10.9.2</span> Why users define their own
-complex number types<span></span></a></li>
-<li><a href="#why-users-want-to-conjugate-matrices-of-real-numbers"><span class="toc-section-number">10.9.3</span> Why users want to “conjugate”
-matrices of real numbers<span></span></a></li>
-<li><a href="#effects-of-conjs-real-to-complex-change"><span class="toc-section-number">10.9.4</span> Effects of <code>conj</code>’s
-real-to-complex change<span></span></a></li>
-<li><a href="#lewg-feedback-on-r8-solution"><span class="toc-section-number">10.9.5</span> LEWG feedback on R8
-solution<span></span></a></li>
-<li><a href="#sg6s-response-to-lewgs-r8-feedback"><span class="toc-section-number">10.9.6</span> SG6’s response to LEWG’s R8
-feedback<span></span></a></li>
-<li><a href="#current-solution"><span class="toc-section-number">10.9.7</span> Current
-solution<span></span></a></li>
+<li><a href="#motivation-and-summary-of-solution" id="toc-motivation-and-summary-of-solution"><span class="toc-section-number">10.9.1</span> Motivation and summary of
+solution</a></li>
+<li><a href="#why-users-define-their-own-complex-number-types" id="toc-why-users-define-their-own-complex-number-types"><span class="toc-section-number">10.9.2</span> Why users define their own
+complex number types</a></li>
+<li><a href="#why-users-want-to-conjugate-matrices-of-real-numbers" id="toc-why-users-want-to-conjugate-matrices-of-real-numbers"><span class="toc-section-number">10.9.3</span> Why users want to “conjugate”
+matrices of real numbers</a></li>
+<li><a href="#effects-of-conjs-real-to-complex-change" id="toc-effects-of-conjs-real-to-complex-change"><span class="toc-section-number">10.9.4</span> Effects of <code>conj</code>’s
+real-to-complex change</a></li>
+<li><a href="#lewg-feedback-on-r8-solution" id="toc-lewg-feedback-on-r8-solution"><span class="toc-section-number">10.9.5</span> LEWG feedback on R8
+solution</a></li>
+<li><a href="#sg6s-response-to-lewgs-r8-feedback" id="toc-sg6s-response-to-lewgs-r8-feedback"><span class="toc-section-number">10.9.6</span> SG6’s response to LEWG’s R8
+feedback</a></li>
+<li><a href="#current-solution" id="toc-current-solution"><span class="toc-section-number">10.9.7</span> Current solution</a></li>
 </ul></li>
-<li><a href="#support-for-division-with-noncommutative-multiplication"><span class="toc-section-number">10.10</span> Support for division with
-noncommutative multiplication<span></span></a></li>
+<li><a href="#support-for-division-with-noncommutative-multiplication" id="toc-support-for-division-with-noncommutative-multiplication"><span class="toc-section-number">10.10</span> Support for division with
+noncommutative multiplication</a></li>
 </ul></li>
-<li><a href="#future-work"><span class="toc-section-number">11</span>
-Future work<span></span></a>
+<li><a href="#future-work" id="toc-future-work"><span class="toc-section-number">11</span> Future work</a>
 <ul>
-<li><a href="#batched-linear-algebra"><span class="toc-section-number">11.1</span> Batched linear
-algebra<span></span></a></li>
+<li><a href="#batched-linear-algebra" id="toc-batched-linear-algebra"><span class="toc-section-number">11.1</span> Batched linear algebra</a></li>
 </ul></li>
-<li><a href="#data-structures-and-utilities-borrowed-from-other-proposals"><span class="toc-section-number">12</span> Data structures and utilities
-borrowed from other proposals<span></span></a>
+<li><a href="#data-structures-and-utilities-borrowed-from-other-proposals" id="toc-data-structures-and-utilities-borrowed-from-other-proposals"><span class="toc-section-number">12</span> Data structures and utilities
+borrowed from other proposals</a>
 <ul>
-<li><a href="#mdspan"><span class="toc-section-number">12.1</span>
-<code>mdspan</code><span></span></a></li>
-<li><a href="#new-mdspan-layouts-in-this-proposal"><span class="toc-section-number">12.2</span> New <code>mdspan</code> layouts
-in this proposal<span></span></a></li>
+<li><a href="#mdspan" id="toc-mdspan"><span class="toc-section-number">12.1</span> <code>mdspan</code></a></li>
+<li><a href="#new-mdspan-layouts-in-this-proposal" id="toc-new-mdspan-layouts-in-this-proposal"><span class="toc-section-number">12.2</span> New <code>mdspan</code> layouts
+in this proposal</a></li>
 </ul></li>
-<li><a href="#implementation-experience"><span class="toc-section-number">13</span> Implementation
-experience<span></span></a></li>
-<li><a href="#interoperable-with-other-linear-algebra-proposals"><span class="toc-section-number">14</span> Interoperable with other linear
-algebra proposals<span></span></a></li>
-<li><a href="#acknowledgments"><span class="toc-section-number">15</span>
-Acknowledgments<span></span></a></li>
-<li><a href="#references"><span class="toc-section-number">16</span>
-References<span></span></a>
+<li><a href="#implementation-experience" id="toc-implementation-experience"><span class="toc-section-number">13</span> Implementation experience</a></li>
+<li><a href="#interoperable-with-other-linear-algebra-proposals" id="toc-interoperable-with-other-linear-algebra-proposals"><span class="toc-section-number">14</span> Interoperable with other linear
+algebra proposals</a></li>
+<li><a href="#acknowledgments" id="toc-acknowledgments"><span class="toc-section-number">15</span> Acknowledgments</a></li>
+<li><a href="#references" id="toc-references"><span class="toc-section-number">16</span> References</a>
 <ul>
-<li><a href="#references-by-coathors"><span class="toc-section-number">16.1</span> References by
-coathors<span></span></a></li>
-<li><a href="#other-references"><span class="toc-section-number">16.2</span> Other
-references<span></span></a></li>
+<li><a href="#references-by-coathors" id="toc-references-by-coathors"><span class="toc-section-number">16.1</span> References by coathors</a></li>
+<li><a href="#other-references" id="toc-other-references"><span class="toc-section-number">16.2</span> Other references</a></li>
 </ul></li>
-<li><a href="#dummy-heading-to-align-wording-numbering"><span class="toc-section-number">17</span> Dummy Heading To Align Wording
-Numbering<span></span></a></li>
-<li><a href="#dummy-heading-to-align-wording-numbering-1"><span class="toc-section-number">18</span> Dummy Heading To Align Wording
-Numbering<span></span></a></li>
-<li><a href="#dummy-heading-to-align-wording-numbering-2"><span class="toc-section-number">19</span> Dummy Heading To Align Wording
-Numbering<span></span></a></li>
-<li><a href="#dummy-heading-to-align-wording-numbering-3"><span class="toc-section-number">20</span> Dummy Heading To Align Wording
-Numbering<span></span></a></li>
-<li><a href="#dummy-heading-to-align-wording-numbering-4"><span class="toc-section-number">21</span> Dummy Heading To Align Wording
-Numbering<span></span></a></li>
-<li><a href="#dummy-heading-to-align-wording-numbering-5"><span class="toc-section-number">22</span> Dummy Heading To Align Wording
-Numbering<span></span></a></li>
-<li><a href="#dummy-heading-to-align-wording-numbering-6"><span class="toc-section-number">23</span> Dummy Heading To Align Wording
-Numbering<span></span></a></li>
-<li><a href="#dummy-heading-to-align-wording-numbering-7"><span class="toc-section-number">24</span> Dummy Heading To Align Wording
-Numbering<span></span></a></li>
-<li><a href="#dummy-heading-to-align-wording-numbering-8"><span class="toc-section-number">25</span> Dummy Heading To Align Wording
-Numbering<span></span></a></li>
-<li><a href="#dummy-heading-to-align-wording-numbering-9"><span class="toc-section-number">26</span> Dummy Heading To Align Wording
-Numbering<span></span></a></li>
-<li><a href="#dummy-heading-to-align-wording-numbering-10"><span class="toc-section-number">27</span> Dummy Heading To Align Wording
-Numbering<span></span></a></li>
-<li><a href="#dummy-heading-to-align-wording-numbering-11"><span class="toc-section-number">28</span> Dummy Heading To Align Wording
-Numbering<span></span></a>
+<li><a href="#dummy-heading-to-align-wording-numbering" id="toc-dummy-heading-to-align-wording-numbering"><span class="toc-section-number">17</span> Dummy Heading To Align Wording
+Numbering</a></li>
+<li><a href="#dummy-heading-to-align-wording-numbering-1" id="toc-dummy-heading-to-align-wording-numbering-1"><span class="toc-section-number">18</span> Dummy Heading To Align Wording
+Numbering</a></li>
+<li><a href="#dummy-heading-to-align-wording-numbering-2" id="toc-dummy-heading-to-align-wording-numbering-2"><span class="toc-section-number">19</span> Dummy Heading To Align Wording
+Numbering</a></li>
+<li><a href="#dummy-heading-to-align-wording-numbering-3" id="toc-dummy-heading-to-align-wording-numbering-3"><span class="toc-section-number">20</span> Dummy Heading To Align Wording
+Numbering</a></li>
+<li><a href="#dummy-heading-to-align-wording-numbering-4" id="toc-dummy-heading-to-align-wording-numbering-4"><span class="toc-section-number">21</span> Dummy Heading To Align Wording
+Numbering</a></li>
+<li><a href="#dummy-heading-to-align-wording-numbering-5" id="toc-dummy-heading-to-align-wording-numbering-5"><span class="toc-section-number">22</span> Dummy Heading To Align Wording
+Numbering</a></li>
+<li><a href="#dummy-heading-to-align-wording-numbering-6" id="toc-dummy-heading-to-align-wording-numbering-6"><span class="toc-section-number">23</span> Dummy Heading To Align Wording
+Numbering</a></li>
+<li><a href="#dummy-heading-to-align-wording-numbering-7" id="toc-dummy-heading-to-align-wording-numbering-7"><span class="toc-section-number">24</span> Dummy Heading To Align Wording
+Numbering</a></li>
+<li><a href="#dummy-heading-to-align-wording-numbering-8" id="toc-dummy-heading-to-align-wording-numbering-8"><span class="toc-section-number">25</span> Dummy Heading To Align Wording
+Numbering</a></li>
+<li><a href="#dummy-heading-to-align-wording-numbering-9" id="toc-dummy-heading-to-align-wording-numbering-9"><span class="toc-section-number">26</span> Dummy Heading To Align Wording
+Numbering</a></li>
+<li><a href="#dummy-heading-to-align-wording-numbering-10" id="toc-dummy-heading-to-align-wording-numbering-10"><span class="toc-section-number">27</span> Dummy Heading To Align Wording
+Numbering</a></li>
+<li><a href="#dummy-heading-to-align-wording-numbering-11" id="toc-dummy-heading-to-align-wording-numbering-11"><span class="toc-section-number">28</span> Dummy Heading To Align Wording
+Numbering</a>
 <ul>
-<li><a href="#dummy-heading-to-align-wording-numbering-12"><span class="toc-section-number">28.1</span> Dummy Heading To Align Wording
-Numbering<span></span></a></li>
-<li><a href="#dummy-heading-to-align-wording-numbering-13"><span class="toc-section-number">28.2</span> Dummy Heading To Align Wording
-Numbering<span></span></a></li>
-<li><a href="#dummy-heading-to-align-wording-numbering-14"><span class="toc-section-number">28.3</span> Dummy Heading To Align Wording
-Numbering<span></span></a></li>
-<li><a href="#dummy-heading-to-align-wording-numbering-15"><span class="toc-section-number">28.4</span> Dummy Heading To Align Wording
-Numbering<span></span></a></li>
-<li><a href="#dummy-heading-to-align-wording-numbering-16"><span class="toc-section-number">28.5</span> Dummy Heading To Align Wording
-Numbering<span></span></a></li>
-<li><a href="#dummy-heading-to-align-wording-numbering-17"><span class="toc-section-number">28.6</span> Dummy Heading To Align Wording
-Numbering<span></span></a></li>
-<li><a href="#dummy-heading-to-align-wording-numbering-18"><span class="toc-section-number">28.7</span> Dummy Heading To Align Wording
-Numbering<span></span></a></li>
-<li><a href="#wording"><span class="toc-section-number">28.8</span>
-Wording<span></span></a></li>
-<li><a href="#basic-linear-algebra-algorithms-linalg"><span class="toc-section-number">28.9</span> Basic linear algebra algorithms
-[linalg]<span></span></a>
+<li><a href="#dummy-heading-to-align-wording-numbering-12" id="toc-dummy-heading-to-align-wording-numbering-12"><span class="toc-section-number">28.1</span> Dummy Heading To Align Wording
+Numbering</a></li>
+<li><a href="#dummy-heading-to-align-wording-numbering-13" id="toc-dummy-heading-to-align-wording-numbering-13"><span class="toc-section-number">28.2</span> Dummy Heading To Align Wording
+Numbering</a></li>
+<li><a href="#dummy-heading-to-align-wording-numbering-14" id="toc-dummy-heading-to-align-wording-numbering-14"><span class="toc-section-number">28.3</span> Dummy Heading To Align Wording
+Numbering</a></li>
+<li><a href="#dummy-heading-to-align-wording-numbering-15" id="toc-dummy-heading-to-align-wording-numbering-15"><span class="toc-section-number">28.4</span> Dummy Heading To Align Wording
+Numbering</a></li>
+<li><a href="#dummy-heading-to-align-wording-numbering-16" id="toc-dummy-heading-to-align-wording-numbering-16"><span class="toc-section-number">28.5</span> Dummy Heading To Align Wording
+Numbering</a></li>
+<li><a href="#dummy-heading-to-align-wording-numbering-17" id="toc-dummy-heading-to-align-wording-numbering-17"><span class="toc-section-number">28.6</span> Dummy Heading To Align Wording
+Numbering</a></li>
+<li><a href="#dummy-heading-to-align-wording-numbering-18" id="toc-dummy-heading-to-align-wording-numbering-18"><span class="toc-section-number">28.7</span> Dummy Heading To Align Wording
+Numbering</a></li>
+<li><a href="#wording" id="toc-wording"><span class="toc-section-number">28.8</span> Wording</a></li>
+<li><a href="#basic-linear-algebra-algorithms-linalg" id="toc-basic-linear-algebra-algorithms-linalg"><span class="toc-section-number">28.9</span> Basic linear algebra algorithms
+[linalg]</a>
 <ul>
-<li><a href="#overview-linalg.overview"><span class="toc-section-number">28.9.1</span> Overview
-[linalg.overview]<span></span></a></li>
-<li><a href="#header-linalg-synopsis-linalg.syn"><span class="toc-section-number">28.9.2</span> Header
-<code>&lt;linalg&gt;</code> synopsis [linalg.syn]<span></span></a></li>
-<li><a href="#general-linalg.general"><span class="toc-section-number">28.9.3</span> General
-[linalg.general]<span></span></a></li>
-<li><a href="#requirements-linalg.reqs"><span class="toc-section-number">28.9.4</span> Requirements
-[linalg.reqs]<span></span></a></li>
-<li><a href="#tag-classes-linalg.tags"><span class="toc-section-number">28.9.5</span> Tag classes
-[linalg.tags]<span></span></a></li>
-<li><a href="#layouts-for-packed-matrix-types-linalg.layouts"><span class="toc-section-number">28.9.6</span> Layouts for packed matrix types
-[linalg.layouts]<span></span></a></li>
-<li><a href="#exposition-only-helpers-linalg.helpers"><span class="toc-section-number">28.9.7</span> Exposition-only helpers
-[linalg.helpers]<span></span></a></li>
-<li><a href="#scaled-in-place-transformation-linalg.scaled"><span class="toc-section-number">28.9.8</span> Scaled in-place transformation
-[linalg.scaled]<span></span></a></li>
-<li><a href="#conjugated-in-place-transformation-linalg.conj"><span class="toc-section-number">28.9.9</span> Conjugated in-place
-transformation [linalg.conj]<span></span></a></li>
-<li><a href="#transpose-in-place-transformation-linalg.transp"><span class="toc-section-number">28.9.10</span> Transpose in-place
-transformation [linalg.transp]<span></span></a></li>
-<li><a href="#conjugate-transpose-transform-linalg.conjtransposed"><span class="toc-section-number">28.9.11</span> Conjugate transpose transform
-[linalg.conjtransposed]<span></span></a></li>
-<li><a href="#algorithm-requirements-based-on-template-parameter-name-linalg.algs.reqs"><span class="toc-section-number">28.9.12</span> Algorithm Requirements based
-on template parameter name [linalg.algs.reqs]<span></span></a></li>
-<li><a href="#blas-1-algorithms-linalg.algs.blas1"><span class="toc-section-number">28.9.13</span> BLAS 1 algorithms
-[linalg.algs.blas1]<span></span></a></li>
-<li><a href="#blas-2-algorithms-linalg.algs.blas2"><span class="toc-section-number">28.9.14</span> BLAS 2 algorithms
-[linalg.algs.blas2]<span></span></a></li>
-<li><a href="#blas-3-algorithms-linalg.algs.blas3"><span class="toc-section-number">28.9.15</span> BLAS 3 algorithms
-[linalg.algs.blas3]<span></span></a></li>
+<li><a href="#overview-linalg.overview" id="toc-overview-linalg.overview"><span class="toc-section-number">28.9.1</span> Overview
+[linalg.overview]</a></li>
+<li><a href="#header-linalg-synopsis-linalg.syn" id="toc-header-linalg-synopsis-linalg.syn"><span class="toc-section-number">28.9.2</span> Header
+<code>&lt;linalg&gt;</code> synopsis [linalg.syn]</a></li>
+<li><a href="#general-linalg.general" id="toc-general-linalg.general"><span class="toc-section-number">28.9.3</span> General
+[linalg.general]</a></li>
+<li><a href="#requirements-linalg.reqs" id="toc-requirements-linalg.reqs"><span class="toc-section-number">28.9.4</span> Requirements
+[linalg.reqs]</a></li>
+<li><a href="#tag-classes-linalg.tags" id="toc-tag-classes-linalg.tags"><span class="toc-section-number">28.9.5</span> Tag classes
+[linalg.tags]</a></li>
+<li><a href="#layouts-for-packed-matrix-types-linalg.layouts" id="toc-layouts-for-packed-matrix-types-linalg.layouts"><span class="toc-section-number">28.9.6</span> Layouts for packed matrix types
+[linalg.layouts]</a></li>
+<li><a href="#exposition-only-helpers-linalg.helpers" id="toc-exposition-only-helpers-linalg.helpers"><span class="toc-section-number">28.9.7</span> Exposition-only helpers
+[linalg.helpers]</a></li>
+<li><a href="#scaled-in-place-transformation-linalg.scaled" id="toc-scaled-in-place-transformation-linalg.scaled"><span class="toc-section-number">28.9.8</span> Scaled in-place transformation
+[linalg.scaled]</a></li>
+<li><a href="#conjugated-in-place-transformation-linalg.conj" id="toc-conjugated-in-place-transformation-linalg.conj"><span class="toc-section-number">28.9.9</span> Conjugated in-place
+transformation [linalg.conj]</a></li>
+<li><a href="#transpose-in-place-transformation-linalg.transp" id="toc-transpose-in-place-transformation-linalg.transp"><span class="toc-section-number">28.9.10</span> Transpose in-place
+transformation [linalg.transp]</a></li>
+<li><a href="#conjugate-transpose-transform-linalg.conjtransposed" id="toc-conjugate-transpose-transform-linalg.conjtransposed"><span class="toc-section-number">28.9.11</span> Conjugate transpose transform
+[linalg.conjtransposed]</a></li>
+<li><a href="#algorithm-requirements-based-on-template-parameter-name-linalg.algs.reqs" id="toc-algorithm-requirements-based-on-template-parameter-name-linalg.algs.reqs"><span class="toc-section-number">28.9.12</span> Algorithm Requirements based
+on template parameter name [linalg.algs.reqs]</a></li>
+<li><a href="#blas-1-algorithms-linalg.algs.blas1" id="toc-blas-1-algorithms-linalg.algs.blas1"><span class="toc-section-number">28.9.13</span> BLAS 1 algorithms
+[linalg.algs.blas1]</a></li>
+<li><a href="#blas-2-algorithms-linalg.algs.blas2" id="toc-blas-2-algorithms-linalg.algs.blas2"><span class="toc-section-number">28.9.14</span> BLAS 2 algorithms
+[linalg.algs.blas2]</a></li>
+<li><a href="#blas-3-algorithms-linalg.algs.blas3" id="toc-blas-3-algorithms-linalg.algs.blas3"><span class="toc-section-number">28.9.15</span> BLAS 3 algorithms
+[linalg.algs.blas3]</a></li>
 </ul></li>
 </ul></li>
-<li><a href="#examples"><span class="toc-section-number">29</span>
-Examples<span></span></a>
+<li><a href="#examples" id="toc-examples"><span class="toc-section-number">29</span> Examples</a>
 <ul>
-<li><a href="#cholesky-factorization"><span class="toc-section-number">29.1</span> Cholesky
-factorization<span></span></a></li>
-<li><a href="#solve-linear-system-using-cholesky-factorization"><span class="toc-section-number">29.2</span> Solve linear system using
-Cholesky factorization<span></span></a></li>
-<li><a href="#compute-qr-factorization-of-a-tall-skinny-matrix"><span class="toc-section-number">29.3</span> Compute QR factorization of a
-tall skinny matrix<span></span></a></li>
+<li><a href="#cholesky-factorization" id="toc-cholesky-factorization"><span class="toc-section-number">29.1</span> Cholesky factorization</a></li>
+<li><a href="#solve-linear-system-using-cholesky-factorization" id="toc-solve-linear-system-using-cholesky-factorization"><span class="toc-section-number">29.2</span> Solve linear system using
+Cholesky factorization</a></li>
+<li><a href="#compute-qr-factorization-of-a-tall-skinny-matrix" id="toc-compute-qr-factorization-of-a-tall-skinny-matrix"><span class="toc-section-number">29.3</span> Compute QR factorization of a
+tall skinny matrix</a></li>
 </ul></li>
 </ul>
 </div>
@@ -1338,6 +1306,11 @@ preconditions and apply it to gemv</p></li>
 <li><p>Redo <code>conjugated</code> to simply rely on deduction guide
 for <code>mdspan</code></p></li>
 <li><p>fix numbering via dummy sections</p></li>
+<li><p>Define what it means for two mdspan to “overlap” each other.
+Replace “shall view a disjoint set of elements of” wording (was
+[linalg.concepts] 3 in R12) with “shall not overlap.” “Alias” retains
+its R12 meaning (view the same elements in the same order). This lets us
+retain existing use of “alias” in describing algorithms.</p></li>
 </ul></li>
 </ul>
 <h1 data-number="3" id="purpose-of-this-paper"><span class="header-section-number">3</span> Purpose of this paper<a href="#purpose-of-this-paper" class="self-link"></a></h1>
@@ -6036,7 +6009,26 @@ starts with <code>symmetric</code>, or</p></li>
 </ul>
 <p>[<em>Example:</em> Small vector product accessing only specified
 triangle. It would not be a precondition violation for the non-accessed
-matrix element to be non-zero.]</p>
+matrix element to be non-zero.</p>
+<div class="sourceCode" id="cb8"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
+<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_vector_2x2_product<span class="op">(</span></span>
+<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a>       mdspan<span class="op">&lt;</span><span class="kw">const</span> <span class="dt">float</span>, extents<span class="op">&lt;</span><span class="dt">int</span>, <span class="dv">2</span>, <span class="dv">2</span><span class="op">&gt;&gt;</span> m,</span>
+<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a>       Triangle t,</span>
+<span id="cb8-5"><a href="#cb8-5" aria-hidden="true" tabindex="-1"></a>       mdspan<span class="op">&lt;</span><span class="kw">const</span> <span class="dt">float</span>, extents<span class="op">&lt;</span><span class="dt">int</span>, <span class="dv">2</span><span class="op">&gt;&gt;</span> x,</span>
+<span id="cb8-6"><a href="#cb8-6" aria-hidden="true" tabindex="-1"></a>       mdspan<span class="op">&lt;</span><span class="dt">float</span>, extents<span class="op">&lt;</span><span class="dt">int</span>, <span class="dv">2</span><span class="op">&gt;&gt;</span> y<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb8-7"><a href="#cb8-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb8-8"><a href="#cb8-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">static_assert</span><span class="op">(</span>is_same_v<span class="op">&lt;</span>Triangle, lower_triangle_t<span class="op">&gt;</span> <span class="op">||</span></span>
+<span id="cb8-9"><a href="#cb8-9" aria-hidden="true" tabindex="-1"></a>                is_same_v<span class="op">&lt;</span>Triangle, upper_triangle_t<span class="op">&gt;)</span>;</span>
+<span id="cb8-10"><a href="#cb8-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb8-11"><a href="#cb8-11" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="kw">constexpr</span> <span class="op">(</span>is_same_v<span class="op">&lt;</span>Triangle, lower_triangle_t<span class="op">&gt;)</span> <span class="op">{</span></span>
+<span id="cb8-12"><a href="#cb8-12" aria-hidden="true" tabindex="-1"></a>    y<span class="op">[</span><span class="dv">0</span><span class="op">]</span> <span class="op">=</span> m<span class="op">[</span><span class="dv">0</span>,<span class="dv">0</span><span class="op">]</span> <span class="op">*</span> x<span class="op">[</span><span class="dv">0</span><span class="op">]</span>; <span class="co">// + 0 * x[1]</span></span>
+<span id="cb8-13"><a href="#cb8-13" aria-hidden="true" tabindex="-1"></a>    y<span class="op">[</span><span class="dv">1</span><span class="op">]</span> <span class="op">=</span> m<span class="op">[</span><span class="dv">1</span>,<span class="dv">0</span><span class="op">]</span> <span class="op">*</span> x<span class="op">[</span><span class="dv">0</span><span class="op">]</span> <span class="op">+</span> m<span class="op">[</span><span class="dv">1</span>,<span class="dv">1</span><span class="op">]</span> <span class="op">*</span> x<span class="op">[</span><span class="dv">1</span><span class="op">]</span>;</span>
+<span id="cb8-14"><a href="#cb8-14" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span> <span class="cf">else</span> <span class="op">{</span> <span class="co">// upper_triangle_t</span></span>
+<span id="cb8-15"><a href="#cb8-15" aria-hidden="true" tabindex="-1"></a>    y<span class="op">[</span><span class="dv">0</span><span class="op">]</span> <span class="op">=</span> m<span class="op">[</span><span class="dv">0</span>,<span class="dv">0</span><span class="op">]</span> <span class="op">*</span> x<span class="op">[</span><span class="dv">0</span><span class="op">]</span> <span class="op">+</span> m<span class="op">[</span><span class="dv">0</span>,<span class="dv">1</span><span class="op">]</span> <span class="op">*</span> x<span class="op">[</span><span class="dv">1</span><span class="op">]</span>;</span>
+<span id="cb8-16"><a href="#cb8-16" aria-hidden="true" tabindex="-1"></a>    y<span class="op">[</span><span class="dv">1</span><span class="op">]</span> <span class="op">=</span> <span class="co">/* 0 * x[0] + */</span> m<span class="op">[</span><span class="dv">1</span>,<span class="dv">1</span><span class="op">]</span> <span class="op">*</span> x<span class="op">[</span><span class="dv">1</span><span class="op">]</span>;</span>
+<span id="cb8-17"><a href="#cb8-17" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb8-18"><a href="#cb8-18" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<p>]</p>
 <p><span class="marginalizedparent"><a class="marginalized">4</a></span>
 For any function <code>F</code> that takes a
 <code>DiagonalStorage d</code> parameter, <code>d</code> applies to
@@ -6061,10 +6053,21 @@ Within all the functions in [linalg], any calls to <code>abs</code>,
 unqualified.</p>
 <p><span class="marginalizedparent"><a class="marginalized">6</a></span>
 Two <code>mdspan</code> <code>x</code> and <code>y</code> <em>alias</em>
-each other, if there exist packs of integers <code>i</code> and
-<code>j</code> which are multidimensional indices into <code>e</code>,
-such that <code>x[i...]</code> and <code>y[j...]</code> refer to the
-same element.</p>
+each other, if they have the same extents <code>e</code>, and for any
+pack of integers <code>i</code> which is a multidimensional index in
+<code>e</code>, <code>x[i...]</code> and <code>y[i...]</code> refer to
+the same element. <i>[Note:</i> This means that the two
+<code>mdspan</code> view the same elements in the same order. <i>– end
+note]</i></p>
+<p><span class="marginalizedparent"><a class="marginalized">7</a></span>
+Two <code>mdspan</code> <code>x</code> and <code>y</code>
+<em>overlap</em> each other, if for some pack of integers <code>i</code>
+that is a multidimensional index in <code>x.extents()</code>, there
+exists a pack of integers <code>j</code> that is a multidimensional
+index in <code>y.extents()</code>, such that <code>x[i...]</code> and
+<code>y[j...]</code> refer to the same element. <i>[Note:</i> Aliasing
+is a special case of overlapping. Two <code>mdspan</code> that do not
+overlap also do not alias each other. <i>– end note]</i></p>
 <h3 data-number="28.9.4" id="requirements-linalg.reqs"><span class="header-section-number">28.9.4</span> Requirements [linalg.reqs]<a href="#requirements-linalg.reqs" class="self-link"></a></h3>
 <h4 data-number="28.9.4.1" id="linear-algebra-value-types-linalg.reqs.val"><span class="header-section-number">28.9.4.1</span> Linear algebra value types
 [linalg.reqs.val]<a href="#linear-algebra-value-types-linalg.reqs.val" class="self-link"></a></h4>
@@ -6157,7 +6160,27 @@ their accuracy. <i>– end note]</i></p>
 <p><i>[Note:</i> For all functions in [linalg], suppose that all input
 and output <code>mdspan</code> have as <code>value_type</code> a
 floating-point type, and any <code>Scalar</code> template argument has a
-floating-point type.]</i></p>
+floating-point type.</p>
+<p>Then, functions may do all of the following:</p>
+<ul>
+<li><p>compute floating-point sums in any way that improves their
+accuracy for arbitrary input;</p></li>
+<li><p>perform additional arithmetic operations (other than those
+specified by the function’s wording and
+<strong>[linalg.reqs.alg]</strong>) in order to improve performance or
+accuracy; and</p></li>
+<li><p>use approximations (that might not be exact even if computing
+with real numbers), instead of computations that would be exact if it
+were possible to compute without rounding error;</p></li>
+</ul>
+<p>as long as</p>
+<ul>
+<li><p>the function satisfies the complexity requirements; and</p></li>
+<li><p>the function is <em>logarithmically stable</em>, as defined in
+Demmel 2007. Strassen’s algorithm for matrix-matrix multiply is an
+example of a logarithmically stable algorithm. <i>– end
+note]</i></p></li>
+</ul>
 <h3 data-number="28.9.5" id="tag-classes-linalg.tags"><span class="header-section-number">28.9.5</span> Tag classes [linalg.tags]<a href="#tag-classes-linalg.tags" class="self-link"></a></h3>
 <h4 data-number="28.9.5.1" id="storage-order-tags-linalg.tags.order"><span class="header-section-number">28.9.5.1</span> Storage order tags
 [linalg.tags.order]<a href="#storage-order-tags-linalg.tags.order" class="self-link"></a></h4>
@@ -6165,29 +6188,29 @@ floating-point type.]</i></p>
 The storage order tags describe the order of elements in an
 <code>mdspan</code> with <code>layout_blas_packed</code>
 (<em>[linalg.layouts.packed]</em>) layout.</p>
-<div class="sourceCode" id="cb8"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> column_major_t <span class="op">{</span></span>
-<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">explicit</span> column_major_t<span class="op">()</span> <span class="op">=</span> <span class="cf">default</span>;</span>
-<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
-<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a><span class="kw">inline</span> <span class="kw">constexpr</span> column_major_t column_major <span class="op">=</span> <span class="op">{</span> <span class="op">}</span>;</span>
-<span id="cb8-5"><a href="#cb8-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb8-6"><a href="#cb8-6" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> row_major_t <span class="op">{</span></span>
-<span id="cb8-7"><a href="#cb8-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">explicit</span> row_major_t<span class="op">()</span> <span class="op">=</span> <span class="cf">default</span>;</span>
-<span id="cb8-8"><a href="#cb8-8" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
-<span id="cb8-9"><a href="#cb8-9" aria-hidden="true" tabindex="-1"></a><span class="kw">inline</span> <span class="kw">constexpr</span> row_major_t row_major <span class="op">=</span> <span class="op">{</span> <span class="op">}</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb9"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> column_major_t <span class="op">{</span></span>
+<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">explicit</span> column_major_t<span class="op">()</span> <span class="op">=</span> <span class="cf">default</span>;</span>
+<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
+<span id="cb9-4"><a href="#cb9-4" aria-hidden="true" tabindex="-1"></a><span class="kw">inline</span> <span class="kw">constexpr</span> column_major_t column_major <span class="op">=</span> <span class="op">{</span> <span class="op">}</span>;</span>
+<span id="cb9-5"><a href="#cb9-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb9-6"><a href="#cb9-6" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> row_major_t <span class="op">{</span></span>
+<span id="cb9-7"><a href="#cb9-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">explicit</span> row_major_t<span class="op">()</span> <span class="op">=</span> <span class="cf">default</span>;</span>
+<span id="cb9-8"><a href="#cb9-8" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
+<span id="cb9-9"><a href="#cb9-9" aria-hidden="true" tabindex="-1"></a><span class="kw">inline</span> <span class="kw">constexpr</span> row_major_t row_major <span class="op">=</span> <span class="op">{</span> <span class="op">}</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">2</a></span>
 <code>column_major_t</code> indicates a column-major order, and
 <code>row_major_t</code> indicates a row-major order.</p>
 <h4 data-number="28.9.5.2" id="triangle-tags-linalg.tags.triangle"><span class="header-section-number">28.9.5.2</span> Triangle tags
 [linalg.tags.triangle]<a href="#triangle-tags-linalg.tags.triangle" class="self-link"></a></h4>
-<div class="sourceCode" id="cb9"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> upper_triangle_t <span class="op">{</span></span>
-<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">explicit</span> upper_triangle_t<span class="op">()</span> <span class="op">=</span> <span class="cf">default</span>;</span>
-<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
-<span id="cb9-4"><a href="#cb9-4" aria-hidden="true" tabindex="-1"></a><span class="kw">inline</span> <span class="kw">constexpr</span> upper_triangle_t upper_triangle <span class="op">=</span> <span class="op">{</span> <span class="op">}</span>;</span>
-<span id="cb9-5"><a href="#cb9-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb9-6"><a href="#cb9-6" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> lower_triangle_t <span class="op">{</span></span>
-<span id="cb9-7"><a href="#cb9-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">explicit</span> lower_triangle_t<span class="op">()</span> <span class="op">=</span> <span class="cf">default</span>;</span>
-<span id="cb9-8"><a href="#cb9-8" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
-<span id="cb9-9"><a href="#cb9-9" aria-hidden="true" tabindex="-1"></a><span class="kw">inline</span> <span class="kw">constexpr</span> lower_triangle_t lower_triangle <span class="op">=</span> <span class="op">{</span> <span class="op">}</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb10"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> upper_triangle_t <span class="op">{</span></span>
+<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">explicit</span> upper_triangle_t<span class="op">()</span> <span class="op">=</span> <span class="cf">default</span>;</span>
+<span id="cb10-3"><a href="#cb10-3" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
+<span id="cb10-4"><a href="#cb10-4" aria-hidden="true" tabindex="-1"></a><span class="kw">inline</span> <span class="kw">constexpr</span> upper_triangle_t upper_triangle <span class="op">=</span> <span class="op">{</span> <span class="op">}</span>;</span>
+<span id="cb10-5"><a href="#cb10-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb10-6"><a href="#cb10-6" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> lower_triangle_t <span class="op">{</span></span>
+<span id="cb10-7"><a href="#cb10-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">explicit</span> lower_triangle_t<span class="op">()</span> <span class="op">=</span> <span class="cf">default</span>;</span>
+<span id="cb10-8"><a href="#cb10-8" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
+<span id="cb10-9"><a href="#cb10-9" aria-hidden="true" tabindex="-1"></a><span class="kw">inline</span> <span class="kw">constexpr</span> lower_triangle_t lower_triangle <span class="op">=</span> <span class="op">{</span> <span class="op">}</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 These tag classes specify whether algorithms and other users of a matrix
 (represented as an <code>mdspan</code>) should access the upper triangle
@@ -6210,16 +6233,16 @@ which refers to the pre-transformed "original" matrix.
 -->
 <h4 data-number="28.9.5.3" id="diagonal-tags-linalg.tags.diagonal"><span class="header-section-number">28.9.5.3</span> Diagonal tags
 [linalg.tags.diagonal]<a href="#diagonal-tags-linalg.tags.diagonal" class="self-link"></a></h4>
-<div class="sourceCode" id="cb10"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> implicit_unit_diagonal_t <span class="op">{</span></span>
-<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">explicit</span> implicit_unit_diagonal_t<span class="op">()</span> <span class="op">=</span> <span class="cf">default</span>;</span>
-<span id="cb10-3"><a href="#cb10-3" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
-<span id="cb10-4"><a href="#cb10-4" aria-hidden="true" tabindex="-1"></a><span class="kw">inline</span> <span class="kw">constexpr</span> implicit_unit_diagonal_t</span>
-<span id="cb10-5"><a href="#cb10-5" aria-hidden="true" tabindex="-1"></a>  implicit_unit_diagonal <span class="op">=</span> <span class="op">{</span> <span class="op">}</span>;</span>
-<span id="cb10-6"><a href="#cb10-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb10-7"><a href="#cb10-7" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> explicit_diagonal_t <span class="op">{</span></span>
-<span id="cb10-8"><a href="#cb10-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">explicit</span> explicit_diagonal_t<span class="op">()</span> <span class="op">=</span> <span class="cf">default</span>;</span>
-<span id="cb10-9"><a href="#cb10-9" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
-<span id="cb10-10"><a href="#cb10-10" aria-hidden="true" tabindex="-1"></a><span class="kw">inline</span> <span class="kw">constexpr</span> explicit_diagonal_t explicit_diagonal <span class="op">=</span> <span class="op">{</span> <span class="op">}</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb11"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> implicit_unit_diagonal_t <span class="op">{</span></span>
+<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">explicit</span> implicit_unit_diagonal_t<span class="op">()</span> <span class="op">=</span> <span class="cf">default</span>;</span>
+<span id="cb11-3"><a href="#cb11-3" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
+<span id="cb11-4"><a href="#cb11-4" aria-hidden="true" tabindex="-1"></a><span class="kw">inline</span> <span class="kw">constexpr</span> implicit_unit_diagonal_t</span>
+<span id="cb11-5"><a href="#cb11-5" aria-hidden="true" tabindex="-1"></a>  implicit_unit_diagonal <span class="op">=</span> <span class="op">{</span> <span class="op">}</span>;</span>
+<span id="cb11-6"><a href="#cb11-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb11-7"><a href="#cb11-7" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> explicit_diagonal_t <span class="op">{</span></span>
+<span id="cb11-8"><a href="#cb11-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">explicit</span> explicit_diagonal_t<span class="op">()</span> <span class="op">=</span> <span class="cf">default</span>;</span>
+<span id="cb11-9"><a href="#cb11-9" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
+<span id="cb11-10"><a href="#cb11-10" aria-hidden="true" tabindex="-1"></a><span class="kw">inline</span> <span class="kw">constexpr</span> explicit_diagonal_t explicit_diagonal <span class="op">=</span> <span class="op">{</span> <span class="op">}</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 These tag classes specify whether algorithms should access the matrix’s
 diagonal entries, and if not, then how algorithms should interpret the
@@ -6256,63 +6279,63 @@ row-major ordering. This packs matrix elements starting with the topmost
 <p><i>[Note:</i> <code>layout_blas_packed</code> describes the data
 layout used by the BLAS’ Symmetric Packed (SP), Hermitian Packed (HP),
 and Triangular Packed (TP) matrix types. <i>– end note]</i></p>
-<div class="sourceCode" id="cb11"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Triangle,</span>
-<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> StorageOrder<span class="op">&gt;</span></span>
-<span id="cb11-3"><a href="#cb11-3" aria-hidden="true" tabindex="-1"></a><span class="kw">class</span> layout_blas_packed <span class="op">{</span></span>
-<span id="cb11-4"><a href="#cb11-4" aria-hidden="true" tabindex="-1"></a><span class="kw">public</span><span class="op">:</span></span>
-<span id="cb11-5"><a href="#cb11-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Extents<span class="op">&gt;</span></span>
-<span id="cb11-6"><a href="#cb11-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">struct</span> mapping <span class="op">{</span></span>
-<span id="cb11-7"><a href="#cb11-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">public</span><span class="op">:</span></span>
-<span id="cb11-8"><a href="#cb11-8" aria-hidden="true" tabindex="-1"></a>    <span class="kw">using</span> extents_type <span class="op">=</span> Extents;</span>
-<span id="cb11-9"><a href="#cb11-9" aria-hidden="true" tabindex="-1"></a>    <span class="kw">using</span> index_type <span class="op">=</span> <span class="kw">typename</span> extents_type<span class="op">::</span>index_type;</span>
-<span id="cb11-10"><a href="#cb11-10" aria-hidden="true" tabindex="-1"></a>    <span class="kw">using</span> size_type <span class="op">=</span> <span class="kw">typename</span> extents_type<span class="op">::</span>size_type;</span>
-<span id="cb11-11"><a href="#cb11-11" aria-hidden="true" tabindex="-1"></a>    <span class="kw">using</span> rank_type <span class="op">=</span> <span class="kw">typename</span> extents_type<span class="op">::</span>rank_type;</span>
-<span id="cb11-12"><a href="#cb11-12" aria-hidden="true" tabindex="-1"></a>    <span class="kw">using</span> layout_type <span class="op">=</span> layout_blas_packed<span class="op">&lt;</span>Triangle, StorageOrder<span class="op">&gt;</span>;</span>
-<span id="cb11-13"><a href="#cb11-13" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb11-14"><a href="#cb11-14" aria-hidden="true" tabindex="-1"></a>  <span class="kw">private</span><span class="op">:</span></span>
-<span id="cb11-15"><a href="#cb11-15" aria-hidden="true" tabindex="-1"></a>    Extents <em>the-extents</em><span class="op">{}</span>; <span class="co">// exposition only</span></span>
-<span id="cb11-16"><a href="#cb11-16" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb11-17"><a href="#cb11-17" aria-hidden="true" tabindex="-1"></a>  <span class="kw">public</span><span class="op">:</span></span>
-<span id="cb11-18"><a href="#cb11-18" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mapping<span class="op">()</span> <span class="kw">noexcept</span> <span class="op">=</span> <span class="cf">default</span>;</span>
-<span id="cb11-19"><a href="#cb11-19" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mapping<span class="op">(</span><span class="kw">const</span> mapping<span class="op">&amp;)</span> <span class="kw">noexcept</span> <span class="op">=</span> <span class="cf">default</span>;</span>
-<span id="cb11-20"><a href="#cb11-20" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mapping<span class="op">(</span><span class="kw">const</span> extents_type<span class="op">&amp;</span> e<span class="op">)</span> <span class="kw">noexcept</span>;</span>
-<span id="cb11-21"><a href="#cb11-21" aria-hidden="true" tabindex="-1"></a>    <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherExtents<span class="op">&gt;</span></span>
-<span id="cb11-22"><a href="#cb11-22" aria-hidden="true" tabindex="-1"></a>      <span class="kw">constexpr</span> <span class="kw">explicit</span><span class="op">(!</span> is_convertible_v<span class="op">&lt;</span>OtherExtents, extents_type<span class="op">&gt;)</span></span>
-<span id="cb11-23"><a href="#cb11-23" aria-hidden="true" tabindex="-1"></a>        mapping<span class="op">(</span><span class="kw">const</span> mapping<span class="op">&lt;</span>OtherExtents<span class="op">&gt;&amp;</span> other<span class="op">)</span> <span class="kw">noexcept</span>;</span>
-<span id="cb11-24"><a href="#cb11-24" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb11-25"><a href="#cb11-25" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mapping<span class="op">&amp;</span> <span class="kw">operator</span><span class="op">=(</span><span class="kw">const</span> mapping<span class="op">&amp;)</span> <span class="kw">noexcept</span> <span class="op">=</span> <span class="cf">default</span>;</span>
-<span id="cb11-26"><a href="#cb11-26" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb11-27"><a href="#cb11-27" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> extents_type extents<span class="op">()</span> <span class="kw">const</span> <span class="kw">noexcept</span> <span class="op">{</span> <span class="cf">return</span> <em>the-extents</em>; <span class="op">}</span></span>
-<span id="cb11-28"><a href="#cb11-28" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb11-29"><a href="#cb11-29" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> size_type required_span_size<span class="op">()</span> <span class="kw">const</span> <span class="kw">noexcept</span>;</span>
-<span id="cb11-30"><a href="#cb11-30" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb11-31"><a href="#cb11-31" aria-hidden="true" tabindex="-1"></a>    <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span><span class="op">...</span> Indices<span class="op">&gt;</span></span>
-<span id="cb11-32"><a href="#cb11-32" aria-hidden="true" tabindex="-1"></a>      <span class="kw">constexpr</span> index_type <span class="kw">operator</span><span class="op">()</span> <span class="op">(</span>Indices<span class="op">...)</span> <span class="kw">const</span> <span class="kw">noexcept</span>;</span>
-<span id="cb11-33"><a href="#cb11-33" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb11-34"><a href="#cb11-34" aria-hidden="true" tabindex="-1"></a>    <span class="kw">static</span> <span class="kw">constexpr</span> <span class="dt">bool</span> is_always_unique<span class="op">()</span> <span class="op">{</span></span>
-<span id="cb11-35"><a href="#cb11-35" aria-hidden="true" tabindex="-1"></a>      <span class="cf">return</span> extents_type<span class="op">::</span>static_extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">!=</span> dynamic_extent <span class="op">&amp;&amp;</span></span>
-<span id="cb11-36"><a href="#cb11-36" aria-hidden="true" tabindex="-1"></a>        extents_type<span class="op">::</span>static_extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">&lt;</span> <span class="dv">2</span>;</span>
-<span id="cb11-37"><a href="#cb11-37" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
-<span id="cb11-38"><a href="#cb11-38" aria-hidden="true" tabindex="-1"></a>    <span class="kw">static</span> <span class="kw">constexpr</span> <span class="dt">bool</span> is_always_exhaustive<span class="op">()</span> <span class="op">{</span> <span class="cf">return</span> <span class="kw">true</span>; <span class="op">}</span></span>
-<span id="cb11-39"><a href="#cb11-39" aria-hidden="true" tabindex="-1"></a>    <span class="kw">static</span> <span class="kw">constexpr</span> <span class="dt">bool</span> is_always_strided<span class="op">()</span> <span class="op">{</span></span>
-<span id="cb11-40"><a href="#cb11-40" aria-hidden="true" tabindex="-1"></a>      <span class="cf">return</span> extents_type<span class="op">::</span>static_extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">!=</span> dynamic_extent <span class="op">&amp;&amp;</span></span>
-<span id="cb11-41"><a href="#cb11-41" aria-hidden="true" tabindex="-1"></a>        extents_type<span class="op">::</span>static_extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">&lt;</span> <span class="dv">2</span>;</span>
-<span id="cb11-42"><a href="#cb11-42" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
-<span id="cb11-43"><a href="#cb11-43" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb11-44"><a href="#cb11-44" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> <span class="dt">bool</span> is_unique<span class="op">()</span> <span class="kw">const</span> <span class="kw">noexcept</span> <span class="op">{</span></span>
-<span id="cb11-45"><a href="#cb11-45" aria-hidden="true" tabindex="-1"></a>      <span class="cf">return</span> extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">&lt;</span> <span class="dv">2</span>;</span>
-<span id="cb11-46"><a href="#cb11-46" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
-<span id="cb11-47"><a href="#cb11-47" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> <span class="dt">bool</span> is_exhaustive<span class="op">()</span> <span class="kw">const</span> <span class="kw">noexcept</span> <span class="op">{</span> <span class="cf">return</span> <span class="kw">true</span>; <span class="op">}</span></span>
-<span id="cb11-48"><a href="#cb11-48" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> <span class="dt">bool</span> is_strided<span class="op">()</span> <span class="kw">const</span> <span class="kw">noexcept</span> <span class="op">{</span></span>
-<span id="cb11-49"><a href="#cb11-49" aria-hidden="true" tabindex="-1"></a>      <span class="cf">return</span> extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">&lt;</span> <span class="dv">2</span>;</span>
-<span id="cb11-50"><a href="#cb11-50" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
-<span id="cb11-51"><a href="#cb11-51" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb11-52"><a href="#cb11-52" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> index_type stride<span class="op">(</span>rank_type<span class="op">)</span> <span class="kw">const</span> <span class="kw">noexcept</span>;</span>
-<span id="cb11-53"><a href="#cb11-53" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb11-54"><a href="#cb11-54" aria-hidden="true" tabindex="-1"></a>    <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherExtents<span class="op">&gt;</span></span>
-<span id="cb11-55"><a href="#cb11-55" aria-hidden="true" tabindex="-1"></a>      <span class="kw">friend</span> <span class="kw">constexpr</span> <span class="dt">bool</span></span>
-<span id="cb11-56"><a href="#cb11-56" aria-hidden="true" tabindex="-1"></a>        <span class="kw">operator</span><span class="op">==(</span><span class="kw">const</span> mapping<span class="op">&amp;</span>, <span class="kw">const</span> mapping<span class="op">&lt;</span>OtherExtents<span class="op">&gt;&amp;)</span> <span class="kw">noexcept</span>;</span>
-<span id="cb11-57"><a href="#cb11-57" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb12"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Triangle,</span>
+<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> StorageOrder<span class="op">&gt;</span></span>
+<span id="cb12-3"><a href="#cb12-3" aria-hidden="true" tabindex="-1"></a><span class="kw">class</span> layout_blas_packed <span class="op">{</span></span>
+<span id="cb12-4"><a href="#cb12-4" aria-hidden="true" tabindex="-1"></a><span class="kw">public</span><span class="op">:</span></span>
+<span id="cb12-5"><a href="#cb12-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Extents<span class="op">&gt;</span></span>
+<span id="cb12-6"><a href="#cb12-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">struct</span> mapping <span class="op">{</span></span>
+<span id="cb12-7"><a href="#cb12-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">public</span><span class="op">:</span></span>
+<span id="cb12-8"><a href="#cb12-8" aria-hidden="true" tabindex="-1"></a>    <span class="kw">using</span> extents_type <span class="op">=</span> Extents;</span>
+<span id="cb12-9"><a href="#cb12-9" aria-hidden="true" tabindex="-1"></a>    <span class="kw">using</span> index_type <span class="op">=</span> <span class="kw">typename</span> extents_type<span class="op">::</span>index_type;</span>
+<span id="cb12-10"><a href="#cb12-10" aria-hidden="true" tabindex="-1"></a>    <span class="kw">using</span> size_type <span class="op">=</span> <span class="kw">typename</span> extents_type<span class="op">::</span>size_type;</span>
+<span id="cb12-11"><a href="#cb12-11" aria-hidden="true" tabindex="-1"></a>    <span class="kw">using</span> rank_type <span class="op">=</span> <span class="kw">typename</span> extents_type<span class="op">::</span>rank_type;</span>
+<span id="cb12-12"><a href="#cb12-12" aria-hidden="true" tabindex="-1"></a>    <span class="kw">using</span> layout_type <span class="op">=</span> layout_blas_packed<span class="op">&lt;</span>Triangle, StorageOrder<span class="op">&gt;</span>;</span>
+<span id="cb12-13"><a href="#cb12-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb12-14"><a href="#cb12-14" aria-hidden="true" tabindex="-1"></a>  <span class="kw">private</span><span class="op">:</span></span>
+<span id="cb12-15"><a href="#cb12-15" aria-hidden="true" tabindex="-1"></a>    Extents <em>the-extents</em><span class="op">{}</span>; <span class="co">// exposition only</span></span>
+<span id="cb12-16"><a href="#cb12-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb12-17"><a href="#cb12-17" aria-hidden="true" tabindex="-1"></a>  <span class="kw">public</span><span class="op">:</span></span>
+<span id="cb12-18"><a href="#cb12-18" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mapping<span class="op">()</span> <span class="kw">noexcept</span> <span class="op">=</span> <span class="cf">default</span>;</span>
+<span id="cb12-19"><a href="#cb12-19" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mapping<span class="op">(</span><span class="kw">const</span> mapping<span class="op">&amp;)</span> <span class="kw">noexcept</span> <span class="op">=</span> <span class="cf">default</span>;</span>
+<span id="cb12-20"><a href="#cb12-20" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mapping<span class="op">(</span><span class="kw">const</span> extents_type<span class="op">&amp;</span> e<span class="op">)</span> <span class="kw">noexcept</span>;</span>
+<span id="cb12-21"><a href="#cb12-21" aria-hidden="true" tabindex="-1"></a>    <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherExtents<span class="op">&gt;</span></span>
+<span id="cb12-22"><a href="#cb12-22" aria-hidden="true" tabindex="-1"></a>      <span class="kw">constexpr</span> <span class="kw">explicit</span><span class="op">(!</span> is_convertible_v<span class="op">&lt;</span>OtherExtents, extents_type<span class="op">&gt;)</span></span>
+<span id="cb12-23"><a href="#cb12-23" aria-hidden="true" tabindex="-1"></a>        mapping<span class="op">(</span><span class="kw">const</span> mapping<span class="op">&lt;</span>OtherExtents<span class="op">&gt;&amp;</span> other<span class="op">)</span> <span class="kw">noexcept</span>;</span>
+<span id="cb12-24"><a href="#cb12-24" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb12-25"><a href="#cb12-25" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mapping<span class="op">&amp;</span> <span class="kw">operator</span><span class="op">=(</span><span class="kw">const</span> mapping<span class="op">&amp;)</span> <span class="kw">noexcept</span> <span class="op">=</span> <span class="cf">default</span>;</span>
+<span id="cb12-26"><a href="#cb12-26" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb12-27"><a href="#cb12-27" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> extents_type extents<span class="op">()</span> <span class="kw">const</span> <span class="kw">noexcept</span> <span class="op">{</span> <span class="cf">return</span> <em>the-extents</em>; <span class="op">}</span></span>
+<span id="cb12-28"><a href="#cb12-28" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb12-29"><a href="#cb12-29" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> size_type required_span_size<span class="op">()</span> <span class="kw">const</span> <span class="kw">noexcept</span>;</span>
+<span id="cb12-30"><a href="#cb12-30" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb12-31"><a href="#cb12-31" aria-hidden="true" tabindex="-1"></a>    <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span><span class="op">...</span> Indices<span class="op">&gt;</span></span>
+<span id="cb12-32"><a href="#cb12-32" aria-hidden="true" tabindex="-1"></a>      <span class="kw">constexpr</span> index_type <span class="kw">operator</span><span class="op">()</span> <span class="op">(</span>Indices<span class="op">...)</span> <span class="kw">const</span> <span class="kw">noexcept</span>;</span>
+<span id="cb12-33"><a href="#cb12-33" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb12-34"><a href="#cb12-34" aria-hidden="true" tabindex="-1"></a>    <span class="kw">static</span> <span class="kw">constexpr</span> <span class="dt">bool</span> is_always_unique<span class="op">()</span> <span class="op">{</span></span>
+<span id="cb12-35"><a href="#cb12-35" aria-hidden="true" tabindex="-1"></a>      <span class="cf">return</span> extents_type<span class="op">::</span>static_extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">!=</span> dynamic_extent <span class="op">&amp;&amp;</span></span>
+<span id="cb12-36"><a href="#cb12-36" aria-hidden="true" tabindex="-1"></a>        extents_type<span class="op">::</span>static_extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">&lt;</span> <span class="dv">2</span>;</span>
+<span id="cb12-37"><a href="#cb12-37" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb12-38"><a href="#cb12-38" aria-hidden="true" tabindex="-1"></a>    <span class="kw">static</span> <span class="kw">constexpr</span> <span class="dt">bool</span> is_always_exhaustive<span class="op">()</span> <span class="op">{</span> <span class="cf">return</span> <span class="kw">true</span>; <span class="op">}</span></span>
+<span id="cb12-39"><a href="#cb12-39" aria-hidden="true" tabindex="-1"></a>    <span class="kw">static</span> <span class="kw">constexpr</span> <span class="dt">bool</span> is_always_strided<span class="op">()</span> <span class="op">{</span></span>
+<span id="cb12-40"><a href="#cb12-40" aria-hidden="true" tabindex="-1"></a>      <span class="cf">return</span> extents_type<span class="op">::</span>static_extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">!=</span> dynamic_extent <span class="op">&amp;&amp;</span></span>
+<span id="cb12-41"><a href="#cb12-41" aria-hidden="true" tabindex="-1"></a>        extents_type<span class="op">::</span>static_extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">&lt;</span> <span class="dv">2</span>;</span>
+<span id="cb12-42"><a href="#cb12-42" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb12-43"><a href="#cb12-43" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb12-44"><a href="#cb12-44" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> <span class="dt">bool</span> is_unique<span class="op">()</span> <span class="kw">const</span> <span class="kw">noexcept</span> <span class="op">{</span></span>
+<span id="cb12-45"><a href="#cb12-45" aria-hidden="true" tabindex="-1"></a>      <span class="cf">return</span> extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">&lt;</span> <span class="dv">2</span>;</span>
+<span id="cb12-46"><a href="#cb12-46" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb12-47"><a href="#cb12-47" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> <span class="dt">bool</span> is_exhaustive<span class="op">()</span> <span class="kw">const</span> <span class="kw">noexcept</span> <span class="op">{</span> <span class="cf">return</span> <span class="kw">true</span>; <span class="op">}</span></span>
+<span id="cb12-48"><a href="#cb12-48" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> <span class="dt">bool</span> is_strided<span class="op">()</span> <span class="kw">const</span> <span class="kw">noexcept</span> <span class="op">{</span></span>
+<span id="cb12-49"><a href="#cb12-49" aria-hidden="true" tabindex="-1"></a>      <span class="cf">return</span> extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">&lt;</span> <span class="dv">2</span>;</span>
+<span id="cb12-50"><a href="#cb12-50" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb12-51"><a href="#cb12-51" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb12-52"><a href="#cb12-52" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> index_type stride<span class="op">(</span>rank_type<span class="op">)</span> <span class="kw">const</span> <span class="kw">noexcept</span>;</span>
+<span id="cb12-53"><a href="#cb12-53" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb12-54"><a href="#cb12-54" aria-hidden="true" tabindex="-1"></a>    <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherExtents<span class="op">&gt;</span></span>
+<span id="cb12-55"><a href="#cb12-55" aria-hidden="true" tabindex="-1"></a>      <span class="kw">friend</span> <span class="kw">constexpr</span> <span class="dt">bool</span></span>
+<span id="cb12-56"><a href="#cb12-56" aria-hidden="true" tabindex="-1"></a>        <span class="kw">operator</span><span class="op">==(</span><span class="kw">const</span> mapping<span class="op">&amp;</span>, <span class="kw">const</span> mapping<span class="op">&lt;</span>OtherExtents<span class="op">&gt;&amp;)</span> <span class="kw">noexcept</span>;</span>
+<span id="cb12-57"><a href="#cb12-57" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">4</a></span>
 <em>Constraints:</em></p>
 <ul>
@@ -6328,7 +6351,7 @@ and Triangular Packed (TP) matrix types. <i>– end note]</i></p>
 <li><p><span class="marginalizedparent"><a class="marginalized">(4.4)</a></span>
 <code>Extents::rank()</code> equals 2.</p></li>
 </ul>
-<div class="sourceCode" id="cb12"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> mapping<span class="op">(</span><span class="kw">const</span> extents_type<span class="op">&amp;</span> e<span class="op">)</span> <span class="kw">noexcept</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb13"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> mapping<span class="op">(</span><span class="kw">const</span> extents_type<span class="op">&amp;</span> e<span class="op">)</span> <span class="kw">noexcept</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">5</a></span>
 <em>Preconditions:</em></p>
 <ul>
@@ -6342,9 +6365,9 @@ as a value of type <code>index_type</code>
 <p><span class="marginalizedparent"><a class="marginalized">6</a></span>
 <em>Effects:</em> Direct-non-list-initializes
 <em><code>the-extents</code></em> with <code>e</code>.</p>
-<div class="sourceCode" id="cb13"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherExtents<span class="op">&gt;</span></span>
-<span id="cb13-2"><a href="#cb13-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">explicit</span><span class="op">(!</span> is_convertible_v<span class="op">&lt;</span>OtherExtents, extents_type<span class="op">&gt;)</span></span>
-<span id="cb13-3"><a href="#cb13-3" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mapping<span class="op">(</span><span class="kw">const</span> mapping<span class="op">&lt;</span>OtherExtents<span class="op">&gt;&amp;</span> other<span class="op">)</span> <span class="kw">noexcept</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb14"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherExtents<span class="op">&gt;</span></span>
+<span id="cb14-2"><a href="#cb14-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">explicit</span><span class="op">(!</span> is_convertible_v<span class="op">&lt;</span>OtherExtents, extents_type<span class="op">&gt;)</span></span>
+<span id="cb14-3"><a href="#cb14-3" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mapping<span class="op">(</span><span class="kw">const</span> mapping<span class="op">&lt;</span>OtherExtents<span class="op">&gt;&amp;</span> other<span class="op">)</span> <span class="kw">noexcept</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">7</a></span>
 <em>Constraints:</em>
 <code>is_constructible_v&lt;extents_type, OtherExtents&gt;</code> is
@@ -6356,13 +6379,13 @@ representable as a value of type <code>index_type</code>
 <p><span class="marginalizedparent"><a class="marginalized">9</a></span>
 <em>Effects:</em> Direct-non-list-initializes
 <em><code>the-extents</code></em> with <code>other.extents()</code>.</p>
-<div class="sourceCode" id="cb14"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> index_type required_span_size<span class="op">()</span> <span class="kw">const</span> <span class="kw">noexcept</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb15"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> index_type required_span_size<span class="op">()</span> <span class="kw">const</span> <span class="kw">noexcept</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">10</a></span>
 <em>Returns:</em> <code>extent(0)</code> * (<code>extent(0)</code> +
 1)/2. <i>[Note:</i> For example, a 5 x 5 packed matrix only stores 15
 matrix elements. <i>– end note]</i></p>
-<div class="sourceCode" id="cb15"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> <span class="op">...</span> Indices<span class="op">&gt;</span></span>
-<span id="cb15-2"><a href="#cb15-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> index_type <span class="kw">operator</span><span class="op">()</span> <span class="op">(</span>Indices<span class="op">...</span> k<span class="op">)</span> <span class="kw">const</span> <span class="kw">noexcept</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb16"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> <span class="op">...</span> Indices<span class="op">&gt;</span></span>
+<span id="cb16-2"><a href="#cb16-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> index_type <span class="kw">operator</span><span class="op">()</span> <span class="op">(</span>Indices<span class="op">...</span> k<span class="op">)</span> <span class="kw">const</span> <span class="kw">noexcept</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">11</a></span>
 <em>Constraints</em>:</p>
 <ul>
@@ -6422,9 +6445,9 @@ access for all multidimensional indices in the cross product of the
 extents, so the above definition cannot exclude indices outside the
 matrix’s triangle. Instead, it interprets such indices as if the matrix
 were symmetric. <i>– end note]</i></p>
-<div class="sourceCode" id="cb16"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherExtents<span class="op">&gt;</span></span>
-<span id="cb16-2"><a href="#cb16-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">friend</span> <span class="kw">constexpr</span> <span class="dt">bool</span></span>
-<span id="cb16-3"><a href="#cb16-3" aria-hidden="true" tabindex="-1"></a>    <span class="kw">operator</span><span class="op">==(</span><span class="kw">const</span> mapping<span class="op">&amp;</span>, <span class="kw">const</span> mapping<span class="op">&lt;</span>OtherExtents<span class="op">&gt;&amp;)</span> <span class="kw">noexcept</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb17"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb17-1"><a href="#cb17-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherExtents<span class="op">&gt;</span></span>
+<span id="cb17-2"><a href="#cb17-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">friend</span> <span class="kw">constexpr</span> <span class="dt">bool</span></span>
+<span id="cb17-3"><a href="#cb17-3" aria-hidden="true" tabindex="-1"></a>    <span class="kw">operator</span><span class="op">==(</span><span class="kw">const</span> mapping<span class="op">&amp;</span>, <span class="kw">const</span> mapping<span class="op">&lt;</span>OtherExtents<span class="op">&gt;&amp;)</span> <span class="kw">noexcept</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">14</a></span>
 <em>Constraints:</em> <code>OtherExtents::rank()</code> equals
 <code>rank()</code>.</p>
@@ -6432,7 +6455,7 @@ were symmetric. <i>– end note]</i></p>
 <em>Returns:</em> <code>true</code> if and only if for 0 ≤
 <code>r</code> &lt; <code>rank()</code>, <code>m.extent(r)</code> equals
 <code>extent(r)</code>.</p>
-<div class="sourceCode" id="cb17"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb17-1"><a href="#cb17-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> index_type stride<span class="op">(</span>rank_type<span class="op">)</span> <span class="kw">const</span> <span class="kw">noexcept</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb18"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> index_type stride<span class="op">(</span>rank_type<span class="op">)</span> <span class="kw">const</span> <span class="kw">noexcept</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">16</a></span>
 <em>Returns:</em> 1 if <code>extent(0)</code> is less than 2, else
 0.</p>
@@ -6546,75 +6569,75 @@ concepts [linalg.helpers.concepts]<a href="#linear-algebra-argument-concepts-lin
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 The exposition-only concepts defined in this section constrain the
 algorithms in <em>[linalg.algs]</em>.</p>
-<div class="sourceCode" id="cb18"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb18-2"><a href="#cb18-2" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> <em>is-mdspan</em> <span class="op">:</span> false_type <span class="op">{}</span>; <span class="co">// exposition only</span></span>
-<span id="cb18-3"><a href="#cb18-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb18-4"><a href="#cb18-4" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ElementType, <span class="kw">class</span> Extents, <span class="kw">class</span> Layout, <span class="kw">class</span> Accessor<span class="op">&gt;</span></span>
-<span id="cb18-5"><a href="#cb18-5" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> <em>is-mdspan</em><span class="op">&lt;</span>mdspan<span class="op">&lt;</span>ElementType, Extents, Layout, Accessor<span class="op">&gt;&gt;</span> <span class="op">:</span> true_type <span class="op">{}</span>; <span class="co">// exposition only</span></span>
-<span id="cb18-6"><a href="#cb18-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb18-7"><a href="#cb18-7" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb18-8"><a href="#cb18-8" aria-hidden="true" tabindex="-1"></a><span class="kw">concept</span> <em>in-vector</em> <span class="op">=</span> <span class="co">// exposition only</span></span>
-<span id="cb18-9"><a href="#cb18-9" aria-hidden="true" tabindex="-1"></a>  <em>is-mdspan</em><span class="op">&lt;</span>T<span class="op">&gt;::</span>value <span class="op">&amp;&amp;</span></span>
-<span id="cb18-10"><a href="#cb18-10" aria-hidden="true" tabindex="-1"></a>  T<span class="op">::</span>rank<span class="op">()</span> <span class="op">==</span> <span class="dv">1</span>;</span>
-<span id="cb18-11"><a href="#cb18-11" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb18-12"><a href="#cb18-12" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb18-13"><a href="#cb18-13" aria-hidden="true" tabindex="-1"></a><span class="kw">concept</span> <em>out-vector</em> <span class="op">=</span> <span class="co">// exposition only</span></span>
-<span id="cb18-14"><a href="#cb18-14" aria-hidden="true" tabindex="-1"></a>  <em>is-mdspan</em><span class="op">&lt;</span>T<span class="op">&gt;::</span>value <span class="op">&amp;&amp;</span></span>
-<span id="cb18-15"><a href="#cb18-15" aria-hidden="true" tabindex="-1"></a>  T<span class="op">::</span>rank<span class="op">()</span> <span class="op">==</span> <span class="dv">1</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb18-16"><a href="#cb18-16" aria-hidden="true" tabindex="-1"></a>  is_assignable_v<span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">::</span>reference, <span class="kw">typename</span> T<span class="op">::</span>element_type<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb18-17"><a href="#cb18-17" aria-hidden="true" tabindex="-1"></a>  T<span class="op">::</span>is_always_unique<span class="op">()</span>;</span>
-<span id="cb18-18"><a href="#cb18-18" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb18-19"><a href="#cb18-19" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb18-20"><a href="#cb18-20" aria-hidden="true" tabindex="-1"></a><span class="kw">concept</span> <em>inout-vector</em> <span class="op">=</span> <span class="co">// exposition only</span></span>
-<span id="cb18-21"><a href="#cb18-21" aria-hidden="true" tabindex="-1"></a>  <em>is-mdspan</em><span class="op">&lt;</span>T<span class="op">&gt;::</span>value <span class="op">&amp;&amp;</span></span>
-<span id="cb18-22"><a href="#cb18-22" aria-hidden="true" tabindex="-1"></a>  T<span class="op">::</span>rank<span class="op">()</span> <span class="op">==</span> <span class="dv">1</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb18-23"><a href="#cb18-23" aria-hidden="true" tabindex="-1"></a>  is_assignable_v<span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">::</span>reference, <span class="kw">typename</span> T<span class="op">::</span>element_type<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb18-24"><a href="#cb18-24" aria-hidden="true" tabindex="-1"></a>  T<span class="op">::</span>is_always_unique<span class="op">()</span>;</span>
-<span id="cb18-25"><a href="#cb18-25" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb18-26"><a href="#cb18-26" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb18-27"><a href="#cb18-27" aria-hidden="true" tabindex="-1"></a><span class="kw">concept</span> <em>in-matrix</em> <span class="op">=</span> <span class="co">// exposition only</span></span>
-<span id="cb18-28"><a href="#cb18-28" aria-hidden="true" tabindex="-1"></a>  <em>is-mdspan</em><span class="op">&lt;</span>T<span class="op">&gt;::</span>value <span class="op">&amp;&amp;</span></span>
-<span id="cb18-29"><a href="#cb18-29" aria-hidden="true" tabindex="-1"></a>  T<span class="op">::</span>rank<span class="op">()</span> <span class="op">==</span> <span class="dv">2</span>;</span>
-<span id="cb18-30"><a href="#cb18-30" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb18-31"><a href="#cb18-31" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb18-32"><a href="#cb18-32" aria-hidden="true" tabindex="-1"></a><span class="kw">concept</span> <em>out-matrix</em> <span class="op">=</span> <span class="co">// exposition only</span></span>
-<span id="cb18-33"><a href="#cb18-33" aria-hidden="true" tabindex="-1"></a>  <em>is-mdspan</em><span class="op">&lt;</span>T<span class="op">&gt;::</span>value <span class="op">&amp;&amp;</span></span>
-<span id="cb18-34"><a href="#cb18-34" aria-hidden="true" tabindex="-1"></a>  T<span class="op">::</span>rank<span class="op">()</span> <span class="op">==</span> <span class="dv">2</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb18-35"><a href="#cb18-35" aria-hidden="true" tabindex="-1"></a>  is_assignable_v<span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">::</span>reference, <span class="kw">typename</span> T<span class="op">::</span>element_type<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb18-36"><a href="#cb18-36" aria-hidden="true" tabindex="-1"></a>  T<span class="op">::</span>is_always_unique<span class="op">()</span>;</span>
-<span id="cb18-37"><a href="#cb18-37" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb18-38"><a href="#cb18-38" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb18-39"><a href="#cb18-39" aria-hidden="true" tabindex="-1"></a><span class="kw">concept</span> <em>inout-matrix</em> <span class="op">=</span> <span class="co">// exposition only</span></span>
-<span id="cb18-40"><a href="#cb18-40" aria-hidden="true" tabindex="-1"></a>  <em>is-mdspan</em><span class="op">&lt;</span>T<span class="op">&gt;::</span>value <span class="op">&amp;&amp;</span></span>
-<span id="cb18-41"><a href="#cb18-41" aria-hidden="true" tabindex="-1"></a>  T<span class="op">::</span>rank<span class="op">()</span> <span class="op">==</span> <span class="dv">2</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb18-42"><a href="#cb18-42" aria-hidden="true" tabindex="-1"></a>  is_assignable_v<span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">::</span>reference, <span class="kw">typename</span> T<span class="op">::</span>element_type<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb18-43"><a href="#cb18-43" aria-hidden="true" tabindex="-1"></a>  T<span class="op">::</span>is_always_unique<span class="op">()</span>;</span>
-<span id="cb18-44"><a href="#cb18-44" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb18-45"><a href="#cb18-45" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb18-46"><a href="#cb18-46" aria-hidden="true" tabindex="-1"></a><span class="kw">concept</span> <em>possibly-packed-inout-matrix</em> <span class="op">=</span> <span class="co">// exposition only</span></span>
-<span id="cb18-47"><a href="#cb18-47" aria-hidden="true" tabindex="-1"></a>  <em>is-mdspan</em><span class="op">&lt;</span>T<span class="op">&gt;::</span>value <span class="op">&amp;&amp;</span></span>
-<span id="cb18-48"><a href="#cb18-48" aria-hidden="true" tabindex="-1"></a>  T<span class="op">::</span>rank<span class="op">()</span> <span class="op">==</span> <span class="dv">2</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb18-49"><a href="#cb18-49" aria-hidden="true" tabindex="-1"></a>  is_assignable_v<span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">::</span>reference, <span class="kw">typename</span> T<span class="op">::</span>element_type<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb18-50"><a href="#cb18-50" aria-hidden="true" tabindex="-1"></a>  <span class="op">(</span>T<span class="op">::</span>is_always_unique<span class="op">()</span> <span class="op">||</span> is_same_v<span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">::</span>layout_type, layout_blas_packed<span class="op">&gt;)</span>;</span>
-<span id="cb18-51"><a href="#cb18-51" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb18-52"><a href="#cb18-52" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb18-53"><a href="#cb18-53" aria-hidden="true" tabindex="-1"></a><span class="kw">concept</span> <em>in-object</em> <span class="op">=</span> <span class="co">// exposition only</span></span>
-<span id="cb18-54"><a href="#cb18-54" aria-hidden="true" tabindex="-1"></a>  <em>is-mdspan</em><span class="op">&lt;</span>T<span class="op">&gt;::</span>value <span class="op">&amp;&amp;</span></span>
-<span id="cb18-55"><a href="#cb18-55" aria-hidden="true" tabindex="-1"></a>  <span class="op">(</span>T<span class="op">::</span>rank<span class="op">()</span> <span class="op">==</span> <span class="dv">1</span> <span class="op">||</span> T<span class="op">::</span>rank<span class="op">()</span> <span class="op">==</span> <span class="dv">2</span><span class="op">)</span>;</span>
-<span id="cb18-56"><a href="#cb18-56" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb18-57"><a href="#cb18-57" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb18-58"><a href="#cb18-58" aria-hidden="true" tabindex="-1"></a><span class="kw">concept</span> <em>out-object</em> <span class="op">=</span> <span class="co">// exposition only</span></span>
-<span id="cb18-59"><a href="#cb18-59" aria-hidden="true" tabindex="-1"></a>  <em>is-mdspan</em><span class="op">&lt;</span>T<span class="op">&gt;::</span>value <span class="op">&amp;&amp;</span></span>
-<span id="cb18-60"><a href="#cb18-60" aria-hidden="true" tabindex="-1"></a>  <span class="op">(</span>T<span class="op">::</span>rank<span class="op">()</span> <span class="op">==</span> <span class="dv">1</span> <span class="op">||</span> T<span class="op">::</span>rank<span class="op">()</span> <span class="op">==</span> <span class="dv">2</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb18-61"><a href="#cb18-61" aria-hidden="true" tabindex="-1"></a>  is_assignable_v<span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">::</span>reference, <span class="kw">typename</span> T<span class="op">::</span>element_type<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb18-62"><a href="#cb18-62" aria-hidden="true" tabindex="-1"></a>  T<span class="op">::</span>is_always_unique<span class="op">()</span>;</span>
-<span id="cb18-63"><a href="#cb18-63" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb18-64"><a href="#cb18-64" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb18-65"><a href="#cb18-65" aria-hidden="true" tabindex="-1"></a><span class="kw">concept</span> <em>inout-object</em> <span class="op">=</span> <span class="co">// exposition only</span></span>
-<span id="cb18-66"><a href="#cb18-66" aria-hidden="true" tabindex="-1"></a>  <em>is-mdspan</em><span class="op">&lt;</span>T<span class="op">&gt;::</span>value <span class="op">&amp;&amp;</span></span>
-<span id="cb18-67"><a href="#cb18-67" aria-hidden="true" tabindex="-1"></a>  <span class="op">(</span>T<span class="op">::</span>rank<span class="op">()</span> <span class="op">==</span> <span class="dv">1</span> <span class="op">||</span> T<span class="op">::</span>rank<span class="op">()</span> <span class="op">==</span> <span class="dv">2</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb18-68"><a href="#cb18-68" aria-hidden="true" tabindex="-1"></a>  is_assignable_v<span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">::</span>reference, <span class="kw">typename</span> T<span class="op">::</span>element_type<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb18-69"><a href="#cb18-69" aria-hidden="true" tabindex="-1"></a>  T<span class="op">::</span>is_always_unique<span class="op">()</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb19"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb19-1"><a href="#cb19-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb19-2"><a href="#cb19-2" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> <em>is-mdspan</em> <span class="op">:</span> false_type <span class="op">{}</span>; <span class="co">// exposition only</span></span>
+<span id="cb19-3"><a href="#cb19-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb19-4"><a href="#cb19-4" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ElementType, <span class="kw">class</span> Extents, <span class="kw">class</span> Layout, <span class="kw">class</span> Accessor<span class="op">&gt;</span></span>
+<span id="cb19-5"><a href="#cb19-5" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> <em>is-mdspan</em><span class="op">&lt;</span>mdspan<span class="op">&lt;</span>ElementType, Extents, Layout, Accessor<span class="op">&gt;&gt;</span> <span class="op">:</span> true_type <span class="op">{}</span>; <span class="co">// exposition only</span></span>
+<span id="cb19-6"><a href="#cb19-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb19-7"><a href="#cb19-7" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb19-8"><a href="#cb19-8" aria-hidden="true" tabindex="-1"></a><span class="kw">concept</span> <em>in-vector</em> <span class="op">=</span> <span class="co">// exposition only</span></span>
+<span id="cb19-9"><a href="#cb19-9" aria-hidden="true" tabindex="-1"></a>  <em>is-mdspan</em><span class="op">&lt;</span>T<span class="op">&gt;::</span>value <span class="op">&amp;&amp;</span></span>
+<span id="cb19-10"><a href="#cb19-10" aria-hidden="true" tabindex="-1"></a>  T<span class="op">::</span>rank<span class="op">()</span> <span class="op">==</span> <span class="dv">1</span>;</span>
+<span id="cb19-11"><a href="#cb19-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb19-12"><a href="#cb19-12" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb19-13"><a href="#cb19-13" aria-hidden="true" tabindex="-1"></a><span class="kw">concept</span> <em>out-vector</em> <span class="op">=</span> <span class="co">// exposition only</span></span>
+<span id="cb19-14"><a href="#cb19-14" aria-hidden="true" tabindex="-1"></a>  <em>is-mdspan</em><span class="op">&lt;</span>T<span class="op">&gt;::</span>value <span class="op">&amp;&amp;</span></span>
+<span id="cb19-15"><a href="#cb19-15" aria-hidden="true" tabindex="-1"></a>  T<span class="op">::</span>rank<span class="op">()</span> <span class="op">==</span> <span class="dv">1</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb19-16"><a href="#cb19-16" aria-hidden="true" tabindex="-1"></a>  is_assignable_v<span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">::</span>reference, <span class="kw">typename</span> T<span class="op">::</span>element_type<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb19-17"><a href="#cb19-17" aria-hidden="true" tabindex="-1"></a>  T<span class="op">::</span>is_always_unique<span class="op">()</span>;</span>
+<span id="cb19-18"><a href="#cb19-18" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb19-19"><a href="#cb19-19" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb19-20"><a href="#cb19-20" aria-hidden="true" tabindex="-1"></a><span class="kw">concept</span> <em>inout-vector</em> <span class="op">=</span> <span class="co">// exposition only</span></span>
+<span id="cb19-21"><a href="#cb19-21" aria-hidden="true" tabindex="-1"></a>  <em>is-mdspan</em><span class="op">&lt;</span>T<span class="op">&gt;::</span>value <span class="op">&amp;&amp;</span></span>
+<span id="cb19-22"><a href="#cb19-22" aria-hidden="true" tabindex="-1"></a>  T<span class="op">::</span>rank<span class="op">()</span> <span class="op">==</span> <span class="dv">1</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb19-23"><a href="#cb19-23" aria-hidden="true" tabindex="-1"></a>  is_assignable_v<span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">::</span>reference, <span class="kw">typename</span> T<span class="op">::</span>element_type<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb19-24"><a href="#cb19-24" aria-hidden="true" tabindex="-1"></a>  T<span class="op">::</span>is_always_unique<span class="op">()</span>;</span>
+<span id="cb19-25"><a href="#cb19-25" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb19-26"><a href="#cb19-26" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb19-27"><a href="#cb19-27" aria-hidden="true" tabindex="-1"></a><span class="kw">concept</span> <em>in-matrix</em> <span class="op">=</span> <span class="co">// exposition only</span></span>
+<span id="cb19-28"><a href="#cb19-28" aria-hidden="true" tabindex="-1"></a>  <em>is-mdspan</em><span class="op">&lt;</span>T<span class="op">&gt;::</span>value <span class="op">&amp;&amp;</span></span>
+<span id="cb19-29"><a href="#cb19-29" aria-hidden="true" tabindex="-1"></a>  T<span class="op">::</span>rank<span class="op">()</span> <span class="op">==</span> <span class="dv">2</span>;</span>
+<span id="cb19-30"><a href="#cb19-30" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb19-31"><a href="#cb19-31" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb19-32"><a href="#cb19-32" aria-hidden="true" tabindex="-1"></a><span class="kw">concept</span> <em>out-matrix</em> <span class="op">=</span> <span class="co">// exposition only</span></span>
+<span id="cb19-33"><a href="#cb19-33" aria-hidden="true" tabindex="-1"></a>  <em>is-mdspan</em><span class="op">&lt;</span>T<span class="op">&gt;::</span>value <span class="op">&amp;&amp;</span></span>
+<span id="cb19-34"><a href="#cb19-34" aria-hidden="true" tabindex="-1"></a>  T<span class="op">::</span>rank<span class="op">()</span> <span class="op">==</span> <span class="dv">2</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb19-35"><a href="#cb19-35" aria-hidden="true" tabindex="-1"></a>  is_assignable_v<span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">::</span>reference, <span class="kw">typename</span> T<span class="op">::</span>element_type<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb19-36"><a href="#cb19-36" aria-hidden="true" tabindex="-1"></a>  T<span class="op">::</span>is_always_unique<span class="op">()</span>;</span>
+<span id="cb19-37"><a href="#cb19-37" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb19-38"><a href="#cb19-38" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb19-39"><a href="#cb19-39" aria-hidden="true" tabindex="-1"></a><span class="kw">concept</span> <em>inout-matrix</em> <span class="op">=</span> <span class="co">// exposition only</span></span>
+<span id="cb19-40"><a href="#cb19-40" aria-hidden="true" tabindex="-1"></a>  <em>is-mdspan</em><span class="op">&lt;</span>T<span class="op">&gt;::</span>value <span class="op">&amp;&amp;</span></span>
+<span id="cb19-41"><a href="#cb19-41" aria-hidden="true" tabindex="-1"></a>  T<span class="op">::</span>rank<span class="op">()</span> <span class="op">==</span> <span class="dv">2</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb19-42"><a href="#cb19-42" aria-hidden="true" tabindex="-1"></a>  is_assignable_v<span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">::</span>reference, <span class="kw">typename</span> T<span class="op">::</span>element_type<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb19-43"><a href="#cb19-43" aria-hidden="true" tabindex="-1"></a>  T<span class="op">::</span>is_always_unique<span class="op">()</span>;</span>
+<span id="cb19-44"><a href="#cb19-44" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb19-45"><a href="#cb19-45" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb19-46"><a href="#cb19-46" aria-hidden="true" tabindex="-1"></a><span class="kw">concept</span> <em>possibly-packed-inout-matrix</em> <span class="op">=</span> <span class="co">// exposition only</span></span>
+<span id="cb19-47"><a href="#cb19-47" aria-hidden="true" tabindex="-1"></a>  <em>is-mdspan</em><span class="op">&lt;</span>T<span class="op">&gt;::</span>value <span class="op">&amp;&amp;</span></span>
+<span id="cb19-48"><a href="#cb19-48" aria-hidden="true" tabindex="-1"></a>  T<span class="op">::</span>rank<span class="op">()</span> <span class="op">==</span> <span class="dv">2</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb19-49"><a href="#cb19-49" aria-hidden="true" tabindex="-1"></a>  is_assignable_v<span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">::</span>reference, <span class="kw">typename</span> T<span class="op">::</span>element_type<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb19-50"><a href="#cb19-50" aria-hidden="true" tabindex="-1"></a>  <span class="op">(</span>T<span class="op">::</span>is_always_unique<span class="op">()</span> <span class="op">||</span> is_same_v<span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">::</span>layout_type, layout_blas_packed<span class="op">&gt;)</span>;</span>
+<span id="cb19-51"><a href="#cb19-51" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb19-52"><a href="#cb19-52" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb19-53"><a href="#cb19-53" aria-hidden="true" tabindex="-1"></a><span class="kw">concept</span> <em>in-object</em> <span class="op">=</span> <span class="co">// exposition only</span></span>
+<span id="cb19-54"><a href="#cb19-54" aria-hidden="true" tabindex="-1"></a>  <em>is-mdspan</em><span class="op">&lt;</span>T<span class="op">&gt;::</span>value <span class="op">&amp;&amp;</span></span>
+<span id="cb19-55"><a href="#cb19-55" aria-hidden="true" tabindex="-1"></a>  <span class="op">(</span>T<span class="op">::</span>rank<span class="op">()</span> <span class="op">==</span> <span class="dv">1</span> <span class="op">||</span> T<span class="op">::</span>rank<span class="op">()</span> <span class="op">==</span> <span class="dv">2</span><span class="op">)</span>;</span>
+<span id="cb19-56"><a href="#cb19-56" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb19-57"><a href="#cb19-57" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb19-58"><a href="#cb19-58" aria-hidden="true" tabindex="-1"></a><span class="kw">concept</span> <em>out-object</em> <span class="op">=</span> <span class="co">// exposition only</span></span>
+<span id="cb19-59"><a href="#cb19-59" aria-hidden="true" tabindex="-1"></a>  <em>is-mdspan</em><span class="op">&lt;</span>T<span class="op">&gt;::</span>value <span class="op">&amp;&amp;</span></span>
+<span id="cb19-60"><a href="#cb19-60" aria-hidden="true" tabindex="-1"></a>  <span class="op">(</span>T<span class="op">::</span>rank<span class="op">()</span> <span class="op">==</span> <span class="dv">1</span> <span class="op">||</span> T<span class="op">::</span>rank<span class="op">()</span> <span class="op">==</span> <span class="dv">2</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb19-61"><a href="#cb19-61" aria-hidden="true" tabindex="-1"></a>  is_assignable_v<span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">::</span>reference, <span class="kw">typename</span> T<span class="op">::</span>element_type<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb19-62"><a href="#cb19-62" aria-hidden="true" tabindex="-1"></a>  T<span class="op">::</span>is_always_unique<span class="op">()</span>;</span>
+<span id="cb19-63"><a href="#cb19-63" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb19-64"><a href="#cb19-64" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb19-65"><a href="#cb19-65" aria-hidden="true" tabindex="-1"></a><span class="kw">concept</span> <em>inout-object</em> <span class="op">=</span> <span class="co">// exposition only</span></span>
+<span id="cb19-66"><a href="#cb19-66" aria-hidden="true" tabindex="-1"></a>  <em>is-mdspan</em><span class="op">&lt;</span>T<span class="op">&gt;::</span>value <span class="op">&amp;&amp;</span></span>
+<span id="cb19-67"><a href="#cb19-67" aria-hidden="true" tabindex="-1"></a>  <span class="op">(</span>T<span class="op">::</span>rank<span class="op">()</span> <span class="op">==</span> <span class="dv">1</span> <span class="op">||</span> T<span class="op">::</span>rank<span class="op">()</span> <span class="op">==</span> <span class="dv">2</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb19-68"><a href="#cb19-68" aria-hidden="true" tabindex="-1"></a>  is_assignable_v<span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">::</span>reference, <span class="kw">typename</span> T<span class="op">::</span>element_type<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb19-69"><a href="#cb19-69" aria-hidden="true" tabindex="-1"></a>  T<span class="op">::</span>is_always_unique<span class="op">()</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">2</a></span>
 If a function in <em>[linalg.algs]</em> accesses the elements of a
 parameter constraint by <em><code>in-vector</code></em>,
@@ -6625,8 +6648,8 @@ Unless explicitly permitted, any <em><code>inout-vector</code></em>,
 <em><code>inout-matrix</code></em>, <em><code>inout-object</code></em>,
 <em><code>out-vector</code></em>, <em><code>out-matrix</code></em>, or
 <em><code>out-object</code></em> parameter of a function in
-<em>[linalg.algs]</em> shall view a disjoint set of elements of any
-other <code>mdspan</code> parameter of the function.</p>
+<em>[linalg.algs]</em> shall not overlap any other <code>mdspan</code>
+parameter of the function.</p>
 <h4 data-number="28.9.7.6" id="helpers-for-algorithm-mandates-linalg.helpers.mandates"><span class="header-section-number">28.9.7.6</span> Helpers for algorithm
 mandates [linalg.helpers.mandates]<a href="#helpers-for-algorithm-mandates-linalg.helpers.mandates" class="self-link"></a></h4>
 <p><i>[Note:</i> These helpers use the less constraining input concepts
@@ -6634,44 +6657,44 @@ even for the output arguments, because the additional constraint for
 assignability of elements is not necessary, and they are sometimes used
 in a context where the third argument is an input type too. <i>- end
 Note.]</i></p>
-<div class="sourceCode" id="cb19"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb19-1"><a href="#cb19-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> MDS1, <span class="kw">class</span> MDS2<span class="op">&gt;</span></span>
-<span id="cb19-2"><a href="#cb19-2" aria-hidden="true" tabindex="-1"></a><span class="kw">requires</span><span class="op">(</span><em>is-mdspan</em><span class="op">&lt;</span>MDS1<span class="op">&gt;::</span>value <span class="op">&amp;&amp;</span> <em>is-mdspan</em><span class="op">&lt;</span>MDS2<span class="op">&gt;::</span>value<span class="op">)</span> </span>
-<span id="cb19-3"><a href="#cb19-3" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> <em>compatible-static-extents</em><span class="op">(</span><span class="dt">size_t</span> r1, <span class="dt">size_t</span> r2<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb19-4"><a href="#cb19-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> MDS1<span class="op">::</span>static_extent<span class="op">(</span>r1<span class="op">)</span> <span class="op">==</span> dynamic_extent <span class="op">||</span></span>
-<span id="cb19-5"><a href="#cb19-5" aria-hidden="true" tabindex="-1"></a>         MDS2<span class="op">::</span>static_extent<span class="op">(</span>r2<span class="op">)</span> <span class="op">==</span> dynamic_extent <span class="op">||</span> </span>
-<span id="cb19-6"><a href="#cb19-6" aria-hidden="true" tabindex="-1"></a>         MDS1<span class="op">::</span>static_extent<span class="op">(</span>r1<span class="op">)</span> <span class="op">==</span> MDS2<span class="op">::</span>static_extent<span class="op">(</span>r2<span class="op">))</span>;</span>
-<span id="cb19-7"><a href="#cb19-7" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
-<div class="sourceCode" id="cb20"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb20-1"><a href="#cb20-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-vector</em> In1, <em>in-vector</em> In2, <em>in-vector</em> Out<span class="op">&gt;</span></span>
-<span id="cb20-2"><a href="#cb20-2" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> <em>possibly-addable</em><span class="op">()</span> <span class="op">{</span></span>
-<span id="cb20-3"><a href="#cb20-3" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <em>compatible-static-extents</em><span class="op">&lt;</span>Out, In1<span class="op">&gt;(</span><span class="dv">0</span>, <span class="dv">0</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb20-4"><a href="#cb20-4" aria-hidden="true" tabindex="-1"></a>         <em>compatible-static-extents</em><span class="op">&lt;</span>Out, In2<span class="op">&gt;(</span><span class="dv">0</span>, <span class="dv">0</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb20-5"><a href="#cb20-5" aria-hidden="true" tabindex="-1"></a>         <em>compatible-static-extents</em><span class="op">&lt;</span>In1, In2<span class="op">&gt;(</span><span class="dv">0</span>, <span class="dv">0</span><span class="op">)</span>;</span>
-<span id="cb20-6"><a href="#cb20-6" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
-<div class="sourceCode" id="cb21"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb21-1"><a href="#cb21-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> In1, <em>in-matrix</em> In2, <em>in-matrix</em> Out<span class="op">&gt;</span></span>
+<div class="sourceCode" id="cb20"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb20-1"><a href="#cb20-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> MDS1, <span class="kw">class</span> MDS2<span class="op">&gt;</span></span>
+<span id="cb20-2"><a href="#cb20-2" aria-hidden="true" tabindex="-1"></a><span class="kw">requires</span><span class="op">(</span><em>is-mdspan</em><span class="op">&lt;</span>MDS1<span class="op">&gt;::</span>value <span class="op">&amp;&amp;</span> <em>is-mdspan</em><span class="op">&lt;</span>MDS2<span class="op">&gt;::</span>value<span class="op">)</span> </span>
+<span id="cb20-3"><a href="#cb20-3" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> <em>compatible-static-extents</em><span class="op">(</span><span class="dt">size_t</span> r1, <span class="dt">size_t</span> r2<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb20-4"><a href="#cb20-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> MDS1<span class="op">::</span>static_extent<span class="op">(</span>r1<span class="op">)</span> <span class="op">==</span> dynamic_extent <span class="op">||</span></span>
+<span id="cb20-5"><a href="#cb20-5" aria-hidden="true" tabindex="-1"></a>         MDS2<span class="op">::</span>static_extent<span class="op">(</span>r2<span class="op">)</span> <span class="op">==</span> dynamic_extent <span class="op">||</span> </span>
+<span id="cb20-6"><a href="#cb20-6" aria-hidden="true" tabindex="-1"></a>         MDS1<span class="op">::</span>static_extent<span class="op">(</span>r1<span class="op">)</span> <span class="op">==</span> MDS2<span class="op">::</span>static_extent<span class="op">(</span>r2<span class="op">))</span>;</span>
+<span id="cb20-7"><a href="#cb20-7" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb21"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb21-1"><a href="#cb21-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-vector</em> In1, <em>in-vector</em> In2, <em>in-vector</em> Out<span class="op">&gt;</span></span>
 <span id="cb21-2"><a href="#cb21-2" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> <em>possibly-addable</em><span class="op">()</span> <span class="op">{</span></span>
 <span id="cb21-3"><a href="#cb21-3" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <em>compatible-static-extents</em><span class="op">&lt;</span>Out, In1<span class="op">&gt;(</span><span class="dv">0</span>, <span class="dv">0</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb21-4"><a href="#cb21-4" aria-hidden="true" tabindex="-1"></a>         <em>compatible-static-extents</em><span class="op">&lt;</span>Out, In1<span class="op">&gt;(</span><span class="dv">1</span>, <span class="dv">1</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb21-5"><a href="#cb21-5" aria-hidden="true" tabindex="-1"></a>         <em>compatible-static-extents</em><span class="op">&lt;</span>Out, In2<span class="op">&gt;(</span><span class="dv">0</span>, <span class="dv">0</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb21-6"><a href="#cb21-6" aria-hidden="true" tabindex="-1"></a>         <em>compatible-static-extents</em><span class="op">&lt;</span>Out, In2<span class="op">&gt;(</span><span class="dv">1</span>, <span class="dv">1</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb21-7"><a href="#cb21-7" aria-hidden="true" tabindex="-1"></a>         <em>compatible-static-extents</em><span class="op">&lt;</span>In1, In2<span class="op">&gt;(</span><span class="dv">0</span>, <span class="dv">0</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb21-8"><a href="#cb21-8" aria-hidden="true" tabindex="-1"></a>         <em>compatible-static-extents</em><span class="op">&lt;</span>In1, In2<span class="op">&gt;(</span><span class="dv">1</span>, <span class="dv">1</span><span class="op">)</span>;</span>
-<span id="cb21-9"><a href="#cb21-9" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
-<div class="sourceCode" id="cb22"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb22-1"><a href="#cb22-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat, <em>in-vector</em> InVec, <em>in-vector</em> OutVec<span class="op">&gt;</span></span>
-<span id="cb22-2"><a href="#cb22-2" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> <em>possibly-multiplyable</em><span class="op">()</span> <span class="op">{</span></span>
-<span id="cb22-3"><a href="#cb22-3" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <em>compatible-static-extents</em><span class="op">&lt;</span>OutVec, InMat<span class="op">&gt;(</span><span class="dv">0</span>, <span class="dv">0</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb22-4"><a href="#cb22-4" aria-hidden="true" tabindex="-1"></a>         <em>compatible-static-extents</em><span class="op">&lt;</span>InMat, InVec<span class="op">&gt;(</span><span class="dv">1</span>, <span class="dv">0</span><span class="op">)</span>;</span>
-<span id="cb22-5"><a href="#cb22-5" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
-<div class="sourceCode" id="cb23"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb23-1"><a href="#cb23-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-vector</em> InVec, <em>in-matrix</em> InMat, <em>in-vector</em> OutVec<span class="op">&gt;</span></span>
+<span id="cb21-4"><a href="#cb21-4" aria-hidden="true" tabindex="-1"></a>         <em>compatible-static-extents</em><span class="op">&lt;</span>Out, In2<span class="op">&gt;(</span><span class="dv">0</span>, <span class="dv">0</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb21-5"><a href="#cb21-5" aria-hidden="true" tabindex="-1"></a>         <em>compatible-static-extents</em><span class="op">&lt;</span>In1, In2<span class="op">&gt;(</span><span class="dv">0</span>, <span class="dv">0</span><span class="op">)</span>;</span>
+<span id="cb21-6"><a href="#cb21-6" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb22"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb22-1"><a href="#cb22-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> In1, <em>in-matrix</em> In2, <em>in-matrix</em> Out<span class="op">&gt;</span></span>
+<span id="cb22-2"><a href="#cb22-2" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> <em>possibly-addable</em><span class="op">()</span> <span class="op">{</span></span>
+<span id="cb22-3"><a href="#cb22-3" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <em>compatible-static-extents</em><span class="op">&lt;</span>Out, In1<span class="op">&gt;(</span><span class="dv">0</span>, <span class="dv">0</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb22-4"><a href="#cb22-4" aria-hidden="true" tabindex="-1"></a>         <em>compatible-static-extents</em><span class="op">&lt;</span>Out, In1<span class="op">&gt;(</span><span class="dv">1</span>, <span class="dv">1</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb22-5"><a href="#cb22-5" aria-hidden="true" tabindex="-1"></a>         <em>compatible-static-extents</em><span class="op">&lt;</span>Out, In2<span class="op">&gt;(</span><span class="dv">0</span>, <span class="dv">0</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb22-6"><a href="#cb22-6" aria-hidden="true" tabindex="-1"></a>         <em>compatible-static-extents</em><span class="op">&lt;</span>Out, In2<span class="op">&gt;(</span><span class="dv">1</span>, <span class="dv">1</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb22-7"><a href="#cb22-7" aria-hidden="true" tabindex="-1"></a>         <em>compatible-static-extents</em><span class="op">&lt;</span>In1, In2<span class="op">&gt;(</span><span class="dv">0</span>, <span class="dv">0</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb22-8"><a href="#cb22-8" aria-hidden="true" tabindex="-1"></a>         <em>compatible-static-extents</em><span class="op">&lt;</span>In1, In2<span class="op">&gt;(</span><span class="dv">1</span>, <span class="dv">1</span><span class="op">)</span>;</span>
+<span id="cb22-9"><a href="#cb22-9" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb23"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb23-1"><a href="#cb23-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat, <em>in-vector</em> InVec, <em>in-vector</em> OutVec<span class="op">&gt;</span></span>
 <span id="cb23-2"><a href="#cb23-2" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> <em>possibly-multiplyable</em><span class="op">()</span> <span class="op">{</span></span>
-<span id="cb23-3"><a href="#cb23-3" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <em>compatible-static-extents</em><span class="op">&lt;</span>OutVec, InMat<span class="op">&gt;(</span><span class="dv">0</span>, <span class="dv">1</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb23-4"><a href="#cb23-4" aria-hidden="true" tabindex="-1"></a>         <em>compatible-static-extents</em><span class="op">&lt;</span>InMat, InVec<span class="op">&gt;(</span><span class="dv">0</span>, <span class="dv">0</span><span class="op">)</span>;</span>
+<span id="cb23-3"><a href="#cb23-3" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <em>compatible-static-extents</em><span class="op">&lt;</span>OutVec, InMat<span class="op">&gt;(</span><span class="dv">0</span>, <span class="dv">0</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb23-4"><a href="#cb23-4" aria-hidden="true" tabindex="-1"></a>         <em>compatible-static-extents</em><span class="op">&lt;</span>InMat, InVec<span class="op">&gt;(</span><span class="dv">1</span>, <span class="dv">0</span><span class="op">)</span>;</span>
 <span id="cb23-5"><a href="#cb23-5" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
-<div class="sourceCode" id="cb24"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb24-1"><a href="#cb24-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1, <em>in-matrix</em> InMat2, <em>in-matrix</em><span class="op">&amp;</span> OutMat<span class="op">&gt;</span></span>
+<div class="sourceCode" id="cb24"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb24-1"><a href="#cb24-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-vector</em> InVec, <em>in-matrix</em> InMat, <em>in-vector</em> OutVec<span class="op">&gt;</span></span>
 <span id="cb24-2"><a href="#cb24-2" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> <em>possibly-multiplyable</em><span class="op">()</span> <span class="op">{</span></span>
-<span id="cb24-3"><a href="#cb24-3" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <em>compatible-static-extents</em><span class="op">&lt;</span>OutMat, InMat1<span class="op">&gt;(</span><span class="dv">0</span>, <span class="dv">0</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb24-4"><a href="#cb24-4" aria-hidden="true" tabindex="-1"></a>         <em>compatible-static-extents</em><span class="op">&lt;</span>OutMat, InMat2<span class="op">&gt;(</span><span class="dv">1</span>, <span class="dv">1</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb24-5"><a href="#cb24-5" aria-hidden="true" tabindex="-1"></a>         <em>compatible-static-extents</em><span class="op">&lt;</span>InMat1, InMat2<span class="op">&gt;(</span><span class="dv">1</span>, <span class="dv">0</span><span class="op">)</span>;</span>
-<span id="cb24-6"><a href="#cb24-6" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<span id="cb24-3"><a href="#cb24-3" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <em>compatible-static-extents</em><span class="op">&lt;</span>OutVec, InMat<span class="op">&gt;(</span><span class="dv">0</span>, <span class="dv">1</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb24-4"><a href="#cb24-4" aria-hidden="true" tabindex="-1"></a>         <em>compatible-static-extents</em><span class="op">&lt;</span>InMat, InVec<span class="op">&gt;(</span><span class="dv">0</span>, <span class="dv">0</span><span class="op">)</span>;</span>
+<span id="cb24-5"><a href="#cb24-5" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb25"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb25-1"><a href="#cb25-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1, <em>in-matrix</em> InMat2, <em>in-matrix</em><span class="op">&amp;</span> OutMat<span class="op">&gt;</span></span>
+<span id="cb25-2"><a href="#cb25-2" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> <em>possibly-multiplyable</em><span class="op">()</span> <span class="op">{</span></span>
+<span id="cb25-3"><a href="#cb25-3" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <em>compatible-static-extents</em><span class="op">&lt;</span>OutMat, InMat1<span class="op">&gt;(</span><span class="dv">0</span>, <span class="dv">0</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb25-4"><a href="#cb25-4" aria-hidden="true" tabindex="-1"></a>         <em>compatible-static-extents</em><span class="op">&lt;</span>OutMat, InMat2<span class="op">&gt;(</span><span class="dv">1</span>, <span class="dv">1</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb25-5"><a href="#cb25-5" aria-hidden="true" tabindex="-1"></a>         <em>compatible-static-extents</em><span class="op">&lt;</span>InMat1, InMat2<span class="op">&gt;(</span><span class="dv">1</span>, <span class="dv">0</span><span class="op">)</span>;</span>
+<span id="cb25-6"><a href="#cb25-6" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <h4 data-number="28.9.7.7" id="checks-for-algorithm-preconditions-linalg.helpers.precond"><span class="header-section-number">28.9.7.7</span> Checks for algorithm
 preconditions [linalg.helpers.precond]<a href="#checks-for-algorithm-preconditions-linalg.helpers.precond" class="self-link"></a></h4>
 <p><i>[Note:</i> These helpers use the less constraining input concepts
@@ -6679,34 +6702,34 @@ even for the output arguments, because the additional constraint for
 assignability of elements is not necessary, and they are sometimes used
 in a context where the third argument is an input type too. <i>end
 Note.</i></p>
-<div class="sourceCode" id="cb25"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb25-1"><a href="#cb25-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> <em>addable</em><span class="op">(</span></span>
-<span id="cb25-2"><a href="#cb25-2" aria-hidden="true" tabindex="-1"></a>    <span class="kw">const</span> <em>in-vector</em> <span class="kw">auto</span><span class="op">&amp;</span> in1, <span class="kw">const</span> <em>in-vector</em> <span class="kw">auto</span><span class="op">&amp;</span> in2, <span class="kw">const</span> <em>in-vector</em> <span class="kw">auto</span><span class="op">&amp;</span> out<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb25-3"><a href="#cb25-3" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> out<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">==</span> in1<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb25-4"><a href="#cb25-4" aria-hidden="true" tabindex="-1"></a>         out<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">==</span> in2<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span>;</span>
-<span id="cb25-5"><a href="#cb25-5" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <div class="sourceCode" id="cb26"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb26-1"><a href="#cb26-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> <em>addable</em><span class="op">(</span></span>
-<span id="cb26-2"><a href="#cb26-2" aria-hidden="true" tabindex="-1"></a>    <span class="kw">const</span> <em>in-matrix</em><span class="op">&amp;</span> in1, <span class="kw">const</span> <em>in-matrix</em> <span class="kw">auto</span><span class="op">&amp;</span> in2, <span class="kw">const</span> <em>in-matrix</em> <span class="kw">auto</span><span class="op">&amp;</span> out<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb26-2"><a href="#cb26-2" aria-hidden="true" tabindex="-1"></a>    <span class="kw">const</span> <em>in-vector</em> <span class="kw">auto</span><span class="op">&amp;</span> in1, <span class="kw">const</span> <em>in-vector</em> <span class="kw">auto</span><span class="op">&amp;</span> in2, <span class="kw">const</span> <em>in-vector</em> <span class="kw">auto</span><span class="op">&amp;</span> out<span class="op">)</span> <span class="op">{</span></span>
 <span id="cb26-3"><a href="#cb26-3" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> out<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">==</span> in1<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb26-4"><a href="#cb26-4" aria-hidden="true" tabindex="-1"></a>         out<span class="op">.</span>extent<span class="op">(</span><span class="dv">1</span><span class="op">)</span> <span class="op">==</span> in1<span class="op">.</span>extent<span class="op">(</span><span class="dv">1</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb26-5"><a href="#cb26-5" aria-hidden="true" tabindex="-1"></a>         out<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">==</span> in2<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb26-6"><a href="#cb26-6" aria-hidden="true" tabindex="-1"></a>         out<span class="op">.</span>extent<span class="op">(</span><span class="dv">1</span><span class="op">)</span> <span class="op">==</span> in2<span class="op">.</span>extent<span class="op">(</span><span class="dv">1</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb26-7"><a href="#cb26-7" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
-<div class="sourceCode" id="cb27"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb27-1"><a href="#cb27-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> <em>multiplyable</em><span class="op">(</span></span>
-<span id="cb27-2"><a href="#cb27-2" aria-hidden="true" tabindex="-1"></a>    <span class="kw">const</span> <em>in-matrix</em><span class="op">&amp;</span> in_mat, <span class="kw">const</span> <em>in-vector</em> in_vec, <span class="kw">const</span> <em>in-vector</em><span class="op">&amp;</span> out_vec<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb27-3"><a href="#cb27-3" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> out_vec<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">==</span> in_mat<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb27-4"><a href="#cb27-4" aria-hidden="true" tabindex="-1"></a>         in_mat<span class="op">.</span>extent<span class="op">(</span><span class="dv">1</span><span class="op">)</span> <span class="op">==</span> in_vec<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span>;</span>
-<span id="cb27-5"><a href="#cb27-5" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<span id="cb26-4"><a href="#cb26-4" aria-hidden="true" tabindex="-1"></a>         out<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">==</span> in2<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span>;</span>
+<span id="cb26-5"><a href="#cb26-5" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb27"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb27-1"><a href="#cb27-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> <em>addable</em><span class="op">(</span></span>
+<span id="cb27-2"><a href="#cb27-2" aria-hidden="true" tabindex="-1"></a>    <span class="kw">const</span> <em>in-matrix</em><span class="op">&amp;</span> in1, <span class="kw">const</span> <em>in-matrix</em> <span class="kw">auto</span><span class="op">&amp;</span> in2, <span class="kw">const</span> <em>in-matrix</em> <span class="kw">auto</span><span class="op">&amp;</span> out<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb27-3"><a href="#cb27-3" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> out<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">==</span> in1<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb27-4"><a href="#cb27-4" aria-hidden="true" tabindex="-1"></a>         out<span class="op">.</span>extent<span class="op">(</span><span class="dv">1</span><span class="op">)</span> <span class="op">==</span> in1<span class="op">.</span>extent<span class="op">(</span><span class="dv">1</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb27-5"><a href="#cb27-5" aria-hidden="true" tabindex="-1"></a>         out<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">==</span> in2<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb27-6"><a href="#cb27-6" aria-hidden="true" tabindex="-1"></a>         out<span class="op">.</span>extent<span class="op">(</span><span class="dv">1</span><span class="op">)</span> <span class="op">==</span> in2<span class="op">.</span>extent<span class="op">(</span><span class="dv">1</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb27-7"><a href="#cb27-7" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <div class="sourceCode" id="cb28"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb28-1"><a href="#cb28-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> <em>multiplyable</em><span class="op">(</span></span>
-<span id="cb28-2"><a href="#cb28-2" aria-hidden="true" tabindex="-1"></a>    <span class="kw">const</span> <em>in-vector</em><span class="op">&amp;</span> in_vec, <span class="kw">const</span> <em>in-matrix</em> in_mat, <span class="kw">const</span> <em>in-vector</em><span class="op">&amp;</span> out_vec<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb28-3"><a href="#cb28-3" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> out_vec<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">==</span> in_mat<span class="op">.</span>extent<span class="op">(</span><span class="dv">1</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb28-4"><a href="#cb28-4" aria-hidden="true" tabindex="-1"></a>         in_mat<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">==</span> in_vec<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span>;</span>
+<span id="cb28-2"><a href="#cb28-2" aria-hidden="true" tabindex="-1"></a>    <span class="kw">const</span> <em>in-matrix</em><span class="op">&amp;</span> in_mat, <span class="kw">const</span> <em>in-vector</em> in_vec, <span class="kw">const</span> <em>in-vector</em><span class="op">&amp;</span> out_vec<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb28-3"><a href="#cb28-3" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> out_vec<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">==</span> in_mat<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb28-4"><a href="#cb28-4" aria-hidden="true" tabindex="-1"></a>         in_mat<span class="op">.</span>extent<span class="op">(</span><span class="dv">1</span><span class="op">)</span> <span class="op">==</span> in_vec<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span>;</span>
 <span id="cb28-5"><a href="#cb28-5" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <div class="sourceCode" id="cb29"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb29-1"><a href="#cb29-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> <em>multiplyable</em><span class="op">(</span></span>
-<span id="cb29-2"><a href="#cb29-2" aria-hidden="true" tabindex="-1"></a>    <span class="kw">const</span> <em>in-matrix</em><span class="op">&amp;</span> in_mat1, <span class="kw">const</span> <em>in-matrix</em> in_mat2, <span class="kw">const</span> <em>in-matrix</em><span class="op">&amp;</span> out_mat<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb29-3"><a href="#cb29-3" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> out_mat<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">==</span> in_mat1<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb29-4"><a href="#cb29-4" aria-hidden="true" tabindex="-1"></a>         out_mat<span class="op">.</span>extent<span class="op">(</span><span class="dv">1</span><span class="op">)</span> <span class="op">==</span> in_mat2<span class="op">.</span>extent<span class="op">(</span><span class="dv">1</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb29-5"><a href="#cb29-5" aria-hidden="true" tabindex="-1"></a>         in1_mat<span class="op">.</span>extent<span class="op">(</span><span class="dv">1</span><span class="op">)</span> <span class="op">==</span> in_mat2<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span>;</span>
-<span id="cb29-6"><a href="#cb29-6" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<span id="cb29-2"><a href="#cb29-2" aria-hidden="true" tabindex="-1"></a>    <span class="kw">const</span> <em>in-vector</em><span class="op">&amp;</span> in_vec, <span class="kw">const</span> <em>in-matrix</em> in_mat, <span class="kw">const</span> <em>in-vector</em><span class="op">&amp;</span> out_vec<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb29-3"><a href="#cb29-3" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> out_vec<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">==</span> in_mat<span class="op">.</span>extent<span class="op">(</span><span class="dv">1</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb29-4"><a href="#cb29-4" aria-hidden="true" tabindex="-1"></a>         in_mat<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">==</span> in_vec<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span>;</span>
+<span id="cb29-5"><a href="#cb29-5" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb30"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb30-1"><a href="#cb30-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> <em>multiplyable</em><span class="op">(</span></span>
+<span id="cb30-2"><a href="#cb30-2" aria-hidden="true" tabindex="-1"></a>    <span class="kw">const</span> <em>in-matrix</em><span class="op">&amp;</span> in_mat1, <span class="kw">const</span> <em>in-matrix</em> in_mat2, <span class="kw">const</span> <em>in-matrix</em><span class="op">&amp;</span> out_mat<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb30-3"><a href="#cb30-3" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> out_mat<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">==</span> in_mat1<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb30-4"><a href="#cb30-4" aria-hidden="true" tabindex="-1"></a>         out_mat<span class="op">.</span>extent<span class="op">(</span><span class="dv">1</span><span class="op">)</span> <span class="op">==</span> in_mat2<span class="op">.</span>extent<span class="op">(</span><span class="dv">1</span><span class="op">)</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb30-5"><a href="#cb30-5" aria-hidden="true" tabindex="-1"></a>         in1_mat<span class="op">.</span>extent<span class="op">(</span><span class="dv">1</span><span class="op">)</span> <span class="op">==</span> in_mat2<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span>;</span>
+<span id="cb30-6"><a href="#cb30-6" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <h3 data-number="28.9.8" id="scaled-in-place-transformation-linalg.scaled"><span class="header-section-number">28.9.8</span> Scaled in-place
 transformation [linalg.scaled]<a href="#scaled-in-place-transformation-linalg.scaled" class="self-link"></a></h3>
 <h4 data-number="28.9.8.1" id="introduction-linalg.scaled.intro"><span class="header-section-number">28.9.8.1</span> Introduction
@@ -6716,7 +6739,27 @@ The <code>scaled</code> function takes a value <code>alpha</code> and an
 <code>mdspan</code> <code>x</code>, and returns a new read-only
 <code>mdspan</code> that represents the elementwise product of
 <code>alpha</code> with each element of <code>x</code>.</p>
-<p>[<em>Example:</em>]</p>
+<p>[<em>Example:</em></p>
+<div class="sourceCode" id="cb31"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb31-1"><a href="#cb31-1" aria-hidden="true" tabindex="-1"></a><span class="kw">using</span> Vec <span class="op">=</span> mdspan<span class="op">&lt;</span><span class="dt">double</span>, dextents<span class="op">&lt;</span><span class="dt">size_t</span>, <span class="dv">1</span><span class="op">&gt;&gt;</span>;</span>
+<span id="cb31-2"><a href="#cb31-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb31-3"><a href="#cb31-3" aria-hidden="true" tabindex="-1"></a><span class="co">// z = alpha * x + y</span></span>
+<span id="cb31-4"><a href="#cb31-4" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> z_equals_alpha_times_x_plus_y<span class="op">(</span></span>
+<span id="cb31-5"><a href="#cb31-5" aria-hidden="true" tabindex="-1"></a>  <span class="dt">double</span> alpha, Vec x,</span>
+<span id="cb31-6"><a href="#cb31-6" aria-hidden="true" tabindex="-1"></a>  Vec y,</span>
+<span id="cb31-7"><a href="#cb31-7" aria-hidden="true" tabindex="-1"></a>  Vec z<span class="op">)</span></span>
+<span id="cb31-8"><a href="#cb31-8" aria-hidden="true" tabindex="-1"></a><span class="op">{</span></span>
+<span id="cb31-9"><a href="#cb31-9" aria-hidden="true" tabindex="-1"></a>  add<span class="op">(</span>scaled<span class="op">(</span>alpha, x<span class="op">)</span>, y, z<span class="op">)</span>;</span>
+<span id="cb31-10"><a href="#cb31-10" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
+<span id="cb31-11"><a href="#cb31-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb31-12"><a href="#cb31-12" aria-hidden="true" tabindex="-1"></a><span class="co">// z = alpha * x + beta * y</span></span>
+<span id="cb31-13"><a href="#cb31-13" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> z_equals_alpha_times_x_plus_beta_times_y<span class="op">(</span></span>
+<span id="cb31-14"><a href="#cb31-14" aria-hidden="true" tabindex="-1"></a>  <span class="dt">double</span> alpha, Vec x,</span>
+<span id="cb31-15"><a href="#cb31-15" aria-hidden="true" tabindex="-1"></a>  <span class="dt">double</span> beta, Vec y,</span>
+<span id="cb31-16"><a href="#cb31-16" aria-hidden="true" tabindex="-1"></a>  Vec z<span class="op">)</span></span>
+<span id="cb31-17"><a href="#cb31-17" aria-hidden="true" tabindex="-1"></a><span class="op">{</span></span>
+<span id="cb31-18"><a href="#cb31-18" aria-hidden="true" tabindex="-1"></a>  add<span class="op">(</span>scaled<span class="op">(</span>alpha, x<span class="op">)</span>, scaled<span class="op">(</span>beta, y<span class="op">)</span>, z<span class="op">)</span>;</span>
+<span id="cb31-19"><a href="#cb31-19" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<p>–<em>end example</em>]</p>
 <!--
 An implementation could dispatch to a function
 in the BLAS library, by noticing that the first argument
@@ -6735,34 +6778,34 @@ product of a fixed value (the “scaling factor”) and its nested
 <code>mdspan</code> accessor’s reference. It is part of the
 implementation of <code>scaled</code>
 <strong>[linalg.scaled.scaled]</strong>.</p>
-<div class="sourceCode" id="cb30"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb30-1"><a href="#cb30-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ScalingFactor,</span>
-<span id="cb30-2"><a href="#cb30-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> NestedAccessor<span class="op">&gt;</span></span>
-<span id="cb30-3"><a href="#cb30-3" aria-hidden="true" tabindex="-1"></a><span class="kw">class</span> scaled_accessor <span class="op">{</span></span>
-<span id="cb30-4"><a href="#cb30-4" aria-hidden="true" tabindex="-1"></a><span class="kw">public</span><span class="op">:</span></span>
-<span id="cb30-5"><a href="#cb30-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> element_type <span class="op">=</span> add_const_t<span class="op">&lt;</span><span class="kw">decltype</span><span class="op">(</span>declval<span class="op">&lt;</span>ScalingFactor<span class="op">&gt;()</span> <span class="op">*</span> declval<span class="op">&lt;</span>NestedAccessor<span class="op">::</span>element_type<span class="op">&gt;())&gt;</span>;</span>
-<span id="cb30-6"><a href="#cb30-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> reference <span class="op">=</span> remove_const_t<span class="op">&lt;</span>element_type<span class="op">&gt;</span>;</span>
-<span id="cb30-7"><a href="#cb30-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> data_handle_type <span class="op">=</span> NestedAccessor<span class="op">::</span>data_handle_type;</span>
-<span id="cb30-8"><a href="#cb30-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> offset_policy <span class="op">=</span> scaled_accessor<span class="op">&lt;</span>ScalingFactor, NestedAccessor<span class="op">::</span>offset_policy<span class="op">&gt;</span>;</span>
-<span id="cb30-9"><a href="#cb30-9" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb30-10"><a href="#cb30-10" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> scaled_accessor<span class="op">()</span> <span class="op">=</span> <span class="cf">default</span>;</span>
-<span id="cb30-11"><a href="#cb30-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherNestedAccessor<span class="op">&gt;</span></span>
-<span id="cb30-12"><a href="#cb30-12" aria-hidden="true" tabindex="-1"></a>    <span class="kw">explicit</span><span class="op">(!</span>is_convertible_v<span class="op">&lt;</span>OtherNestedAccessor, NestedAccessor<span class="op">&gt;)</span></span>
-<span id="cb30-13"><a href="#cb30-13" aria-hidden="true" tabindex="-1"></a>      <span class="kw">constexpr</span> scaled_accessor<span class="op">(</span><span class="kw">const</span> scaled_accessor<span class="op">&lt;</span>ScalingFactor, OtherNestedAccessor<span class="op">&gt;&amp;</span> other<span class="op">)</span>;</span>
-<span id="cb30-14"><a href="#cb30-14" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> scaled_accessor<span class="op">(</span><span class="kw">const</span> ScalingFactor<span class="op">&amp;</span> s, <span class="kw">const</span> NestedAccessor<span class="op">&amp;</span> a<span class="op">)</span>;</span>
-<span id="cb30-15"><a href="#cb30-15" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb30-16"><a href="#cb30-16" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> reference access<span class="op">(</span>data_handle_type p, <span class="dt">size_t</span> i<span class="op">)</span> <span class="kw">const</span></span>
-<span id="cb30-17"><a href="#cb30-17" aria-hidden="true" tabindex="-1"></a>    <span class="kw">noexcept</span><span class="op">(</span><em>see below</em><span class="op">)</span>;</span>
-<span id="cb30-18"><a href="#cb30-18" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> offset_policy<span class="op">::</span>data_handle_type</span>
-<span id="cb30-19"><a href="#cb30-19" aria-hidden="true" tabindex="-1"></a>    offset<span class="op">(</span>data_handle_type p, <span class="dt">size_t</span> i<span class="op">)</span> <span class="kw">const</span></span>
-<span id="cb30-20"><a href="#cb30-20" aria-hidden="true" tabindex="-1"></a>      <span class="kw">noexcept</span><span class="op">(</span><span class="kw">noexcept</span><span class="op">(</span><em>nested-accessor</em><span class="op">.</span>offset<span class="op">(</span>p, i<span class="op">)))</span>;</span>
-<span id="cb30-21"><a href="#cb30-21" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb30-22"><a href="#cb30-22" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> <span class="kw">const</span> ScalingFactor<span class="op">&amp;</span> scaling_factor<span class="op">()</span> <span class="kw">const</span> <span class="kw">noexcept</span> <span class="op">{</span> <span class="cf">return</span> <em>scaling-factor</em>; <span class="op">}</span></span>
-<span id="cb30-23"><a href="#cb30-23" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> <span class="kw">const</span> NestedAccessor<span class="op">&amp;</span> nested_accessor<span class="op">()</span> <span class="kw">const</span> <span class="kw">noexcept</span> <span class="op">{</span> <span class="cf">return</span> <em>nested-accessor</em>; <span class="op">}</span></span>
-<span id="cb30-24"><a href="#cb30-24" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb30-25"><a href="#cb30-25" aria-hidden="true" tabindex="-1"></a><span class="kw">private</span><span class="op">:</span></span>
-<span id="cb30-26"><a href="#cb30-26" aria-hidden="true" tabindex="-1"></a>  ScalingFactor <em>scaling-factor</em><span class="op">{}</span>; <span class="co">// exposition only</span></span>
-<span id="cb30-27"><a href="#cb30-27" aria-hidden="true" tabindex="-1"></a>  NestedAccessor <em>nested-accessor</em><span class="op">{}</span>; <span class="co">// exposition only</span></span>
-<span id="cb30-28"><a href="#cb30-28" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb32"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb32-1"><a href="#cb32-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ScalingFactor,</span>
+<span id="cb32-2"><a href="#cb32-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> NestedAccessor<span class="op">&gt;</span></span>
+<span id="cb32-3"><a href="#cb32-3" aria-hidden="true" tabindex="-1"></a><span class="kw">class</span> scaled_accessor <span class="op">{</span></span>
+<span id="cb32-4"><a href="#cb32-4" aria-hidden="true" tabindex="-1"></a><span class="kw">public</span><span class="op">:</span></span>
+<span id="cb32-5"><a href="#cb32-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> element_type <span class="op">=</span> add_const_t<span class="op">&lt;</span><span class="kw">decltype</span><span class="op">(</span>declval<span class="op">&lt;</span>ScalingFactor<span class="op">&gt;()</span> <span class="op">*</span> declval<span class="op">&lt;</span>NestedAccessor<span class="op">::</span>element_type<span class="op">&gt;())&gt;</span>;</span>
+<span id="cb32-6"><a href="#cb32-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> reference <span class="op">=</span> remove_const_t<span class="op">&lt;</span>element_type<span class="op">&gt;</span>;</span>
+<span id="cb32-7"><a href="#cb32-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> data_handle_type <span class="op">=</span> NestedAccessor<span class="op">::</span>data_handle_type;</span>
+<span id="cb32-8"><a href="#cb32-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> offset_policy <span class="op">=</span> scaled_accessor<span class="op">&lt;</span>ScalingFactor, NestedAccessor<span class="op">::</span>offset_policy<span class="op">&gt;</span>;</span>
+<span id="cb32-9"><a href="#cb32-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb32-10"><a href="#cb32-10" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> scaled_accessor<span class="op">()</span> <span class="op">=</span> <span class="cf">default</span>;</span>
+<span id="cb32-11"><a href="#cb32-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherNestedAccessor<span class="op">&gt;</span></span>
+<span id="cb32-12"><a href="#cb32-12" aria-hidden="true" tabindex="-1"></a>    <span class="kw">explicit</span><span class="op">(!</span>is_convertible_v<span class="op">&lt;</span>OtherNestedAccessor, NestedAccessor<span class="op">&gt;)</span></span>
+<span id="cb32-13"><a href="#cb32-13" aria-hidden="true" tabindex="-1"></a>      <span class="kw">constexpr</span> scaled_accessor<span class="op">(</span><span class="kw">const</span> scaled_accessor<span class="op">&lt;</span>ScalingFactor, OtherNestedAccessor<span class="op">&gt;&amp;</span> other<span class="op">)</span>;</span>
+<span id="cb32-14"><a href="#cb32-14" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> scaled_accessor<span class="op">(</span><span class="kw">const</span> ScalingFactor<span class="op">&amp;</span> s, <span class="kw">const</span> NestedAccessor<span class="op">&amp;</span> a<span class="op">)</span>;</span>
+<span id="cb32-15"><a href="#cb32-15" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb32-16"><a href="#cb32-16" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> reference access<span class="op">(</span>data_handle_type p, <span class="dt">size_t</span> i<span class="op">)</span> <span class="kw">const</span></span>
+<span id="cb32-17"><a href="#cb32-17" aria-hidden="true" tabindex="-1"></a>    <span class="kw">noexcept</span><span class="op">(</span><em>see below</em><span class="op">)</span>;</span>
+<span id="cb32-18"><a href="#cb32-18" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> offset_policy<span class="op">::</span>data_handle_type</span>
+<span id="cb32-19"><a href="#cb32-19" aria-hidden="true" tabindex="-1"></a>    offset<span class="op">(</span>data_handle_type p, <span class="dt">size_t</span> i<span class="op">)</span> <span class="kw">const</span></span>
+<span id="cb32-20"><a href="#cb32-20" aria-hidden="true" tabindex="-1"></a>      <span class="kw">noexcept</span><span class="op">(</span><span class="kw">noexcept</span><span class="op">(</span><em>nested-accessor</em><span class="op">.</span>offset<span class="op">(</span>p, i<span class="op">)))</span>;</span>
+<span id="cb32-21"><a href="#cb32-21" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb32-22"><a href="#cb32-22" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> <span class="kw">const</span> ScalingFactor<span class="op">&amp;</span> scaling_factor<span class="op">()</span> <span class="kw">const</span> <span class="kw">noexcept</span> <span class="op">{</span> <span class="cf">return</span> <em>scaling-factor</em>; <span class="op">}</span></span>
+<span id="cb32-23"><a href="#cb32-23" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> <span class="kw">const</span> NestedAccessor<span class="op">&amp;</span> nested_accessor<span class="op">()</span> <span class="kw">const</span> <span class="kw">noexcept</span> <span class="op">{</span> <span class="cf">return</span> <em>nested-accessor</em>; <span class="op">}</span></span>
+<span id="cb32-24"><a href="#cb32-24" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb32-25"><a href="#cb32-25" aria-hidden="true" tabindex="-1"></a><span class="kw">private</span><span class="op">:</span></span>
+<span id="cb32-26"><a href="#cb32-26" aria-hidden="true" tabindex="-1"></a>  ScalingFactor <em>scaling-factor</em><span class="op">{}</span>; <span class="co">// exposition only</span></span>
+<span id="cb32-27"><a href="#cb32-27" aria-hidden="true" tabindex="-1"></a>  NestedAccessor <em>nested-accessor</em><span class="op">{}</span>; <span class="co">// exposition only</span></span>
+<span id="cb32-28"><a href="#cb32-28" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">2</a></span>
 <em>Mandates:</em></p>
 <ul>
@@ -6780,9 +6823,9 @@ implementation of <code>scaled</code>
 <code>NestedAccessor</code> meets the accessor policy requirements
 [mdspan.accessor.reqmts], and</p></li>
 </ul>
-<div class="sourceCode" id="cb31"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb31-1"><a href="#cb31-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherNestedAccessor<span class="op">&gt;</span></span>
-<span id="cb31-2"><a href="#cb31-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">explicit</span><span class="op">(!</span>is_convertible_v<span class="op">&lt;</span>OtherNestedAccessor, NestedAccessor<span class="op">&gt;)</span></span>
-<span id="cb31-3"><a href="#cb31-3" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> scaled_accessor<span class="op">(</span><span class="kw">const</span> scaled_accessor<span class="op">&lt;</span>ScalingFactor, OtherNestedAccessor<span class="op">&gt;&amp;</span> other<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb33"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb33-1"><a href="#cb33-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherNestedAccessor<span class="op">&gt;</span></span>
+<span id="cb33-2"><a href="#cb33-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">explicit</span><span class="op">(!</span>is_convertible_v<span class="op">&lt;</span>OtherNestedAccessor, NestedAccessor<span class="op">&gt;)</span></span>
+<span id="cb33-3"><a href="#cb33-3" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> scaled_accessor<span class="op">(</span><span class="kw">const</span> scaled_accessor<span class="op">&lt;</span>ScalingFactor, OtherNestedAccessor<span class="op">&gt;&amp;</span> other<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">3</a></span>
 <em>Constraints:</em>
 <code>is_constructible_v&lt;NestedAccessor, const OtherNestedAccessor&amp;&gt;</code>
@@ -6797,7 +6840,7 @@ Direct non-list-initializes <em><code>scaling-factor</code></em> with
 direct non-list-initializes <em><code>nested-accessor</code></em> with
 <code>other.nested_accessor()</code>.</p></li>
 </ul>
-<div class="sourceCode" id="cb32"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb32-1"><a href="#cb32-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> scaled_accessor<span class="op">(</span><span class="kw">const</span> ScalingFactor<span class="op">&amp;</span> s, <span class="kw">const</span> NestedAccessor<span class="op">&amp;</span> a<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb34"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb34-1"><a href="#cb34-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> scaled_accessor<span class="op">(</span><span class="kw">const</span> ScalingFactor<span class="op">&amp;</span> s, <span class="kw">const</span> NestedAccessor<span class="op">&amp;</span> a<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">5</a></span>
 <em>Effects:</em></p>
 <ul>
@@ -6808,16 +6851,16 @@ Direct non-list-initializes <em><code>scaling-factor</code></em> with
 direct non-list-initializes <em><code>nested-accessor</code></em> with
 <code>a</code>.</p></li>
 </ul>
-<div class="sourceCode" id="cb33"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb33-1"><a href="#cb33-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> reference access<span class="op">(</span>data_handle_type p, <span class="dt">size_t</span> i<span class="op">)</span> <span class="kw">const</span> <span class="kw">noexcept</span><span class="op">(</span><em>see below</em>;</span></code></pre></div>
+<div class="sourceCode" id="cb35"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb35-1"><a href="#cb35-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> reference access<span class="op">(</span>data_handle_type p, <span class="dt">size_t</span> i<span class="op">)</span> <span class="kw">const</span> <span class="kw">noexcept</span><span class="op">(</span><em>see below</em>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">6</a></span>
 <em>Returns:</em>
 <code>scaling_factor() * NestedAccessor::element_type(</code>
 <em><code>nested-accessor</code></em><code>.access(p, i))</code></p>
 <p><span class="marginalizedparent"><a class="marginalized">7</a></span>
 <em>Remarks:</em> The exception specification is equivalent to:</p>
-<div class="sourceCode" id="cb34"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb34-1"><a href="#cb34-1" aria-hidden="true" tabindex="-1"></a>    <span class="kw">noexcept</span><span class="op">(</span>scaling_factor<span class="op">()</span> <span class="op">*</span> NestedAccessor<span class="op">::</span>element_type<span class="op">(</span><em>nested-accessor</em><span class="op">.</span>access<span class="op">(</span>p, i<span class="op">)))</span></span></code></pre></div>
-<div class="sourceCode" id="cb35"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb35-1"><a href="#cb35-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> offset_policy<span class="op">::</span>data_handle_type</span>
-<span id="cb35-2"><a href="#cb35-2" aria-hidden="true" tabindex="-1"></a>offset<span class="op">(</span>data_handle_type p, <span class="dt">size_t</span> i<span class="op">)</span> <span class="kw">const</span> <span class="kw">noexcept</span><span class="op">(</span><span class="kw">noexcept</span><span class="op">(</span><em>nested-accessor</em><span class="op">.</span>offset<span class="op">(</span>p, i<span class="op">)))</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb36"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb36-1"><a href="#cb36-1" aria-hidden="true" tabindex="-1"></a>    <span class="kw">noexcept</span><span class="op">(</span>scaling_factor<span class="op">()</span> <span class="op">*</span> NestedAccessor<span class="op">::</span>element_type<span class="op">(</span><em>nested-accessor</em><span class="op">.</span>access<span class="op">(</span>p, i<span class="op">)))</span></span></code></pre></div>
+<div class="sourceCode" id="cb37"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb37-1"><a href="#cb37-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> offset_policy<span class="op">::</span>data_handle_type</span>
+<span id="cb37-2"><a href="#cb37-2" aria-hidden="true" tabindex="-1"></a>offset<span class="op">(</span>data_handle_type p, <span class="dt">size_t</span> i<span class="op">)</span> <span class="kw">const</span> <span class="kw">noexcept</span><span class="op">(</span><span class="kw">noexcept</span><span class="op">(</span><em>nested-accessor</em><span class="op">.</span>offset<span class="op">(</span>p, i<span class="op">)))</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">8</a></span>
 <em>Returns:</em>
 <em><code>nested-accessor</code></em><code>.offset(p, i)</code></p>
@@ -6831,14 +6874,14 @@ returns a new read-only <code>mdspan</code> with the same domain as
 <code>alpha</code> with each element of <code>x</code>.</p>
 <p><i>[Note:</i> Terms in this product will not be reordered. <i>– end
 note]</i></p>
-<div class="sourceCode" id="cb36"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb36-1"><a href="#cb36-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ScalingFactor,</span>
-<span id="cb36-2"><a href="#cb36-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> ElementType,</span>
-<span id="cb36-3"><a href="#cb36-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Extents,</span>
-<span id="cb36-4"><a href="#cb36-4" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Layout,</span>
-<span id="cb36-5"><a href="#cb36-5" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Accessor<span class="op">&gt;</span></span>
-<span id="cb36-6"><a href="#cb36-6" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> scaled<span class="op">(</span></span>
-<span id="cb36-7"><a href="#cb36-7" aria-hidden="true" tabindex="-1"></a>  ScalingFactor scaling_factor,</span>
-<span id="cb36-8"><a href="#cb36-8" aria-hidden="true" tabindex="-1"></a>  mdspan<span class="op">&lt;</span>ElementType, Extents, Layout, Accessor<span class="op">&gt;</span> x<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb38"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb38-1"><a href="#cb38-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ScalingFactor,</span>
+<span id="cb38-2"><a href="#cb38-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> ElementType,</span>
+<span id="cb38-3"><a href="#cb38-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Extents,</span>
+<span id="cb38-4"><a href="#cb38-4" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Layout,</span>
+<span id="cb38-5"><a href="#cb38-5" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Accessor<span class="op">&gt;</span></span>
+<span id="cb38-6"><a href="#cb38-6" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> scaled<span class="op">(</span></span>
+<span id="cb38-7"><a href="#cb38-7" aria-hidden="true" tabindex="-1"></a>  ScalingFactor scaling_factor,</span>
+<span id="cb38-8"><a href="#cb38-8" aria-hidden="true" tabindex="-1"></a>  mdspan<span class="op">&lt;</span>ElementType, Extents, Layout, Accessor<span class="op">&gt;</span> x<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">2</a></span>
 Let <code>SA</code> be
 <code>scaled_accessor&lt;ScalingFactor, Accessor&gt;</code></p>
@@ -6857,7 +6900,15 @@ then `scaled(1 << 20, scaled(1 << 20, x))` does not overflow `int`,
 but `scaled((1 << 20) * (1 << 20), x)`
 would overflow `int`.
 -->
-<p>[<em>Example:</em>]</p>
+<p>[<em>Example:</em></p>
+<div class="sourceCode" id="cb39"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb39-1"><a href="#cb39-1" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> test_scaled<span class="op">(</span>mdspan<span class="op">&lt;</span><span class="dt">double</span>, extents<span class="op">&lt;</span><span class="dt">int</span>, <span class="dv">10</span><span class="op">&gt;&gt;</span> x<span class="op">)</span></span>
+<span id="cb39-2"><a href="#cb39-2" aria-hidden="true" tabindex="-1"></a><span class="op">{</span></span>
+<span id="cb39-3"><a href="#cb39-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">auto</span> x_scaled <span class="op">=</span> scaled<span class="op">(</span><span class="fl">5.0</span>, x<span class="op">)</span>;</span>
+<span id="cb39-4"><a href="#cb39-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">for</span><span class="op">(</span><span class="dt">int</span> i <span class="op">=</span> <span class="dv">0</span>; i <span class="op">&lt;</span> x<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span>; <span class="op">++</span>i<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb39-5"><a href="#cb39-5" aria-hidden="true" tabindex="-1"></a>    <span class="ot">assert</span><span class="op">(</span>x_scaled<span class="op">[</span>i<span class="op">]</span> <span class="op">==</span> <span class="fl">5.0</span> <span class="op">*</span> x<span class="op">[</span>i<span class="op">])</span>;</span>
+<span id="cb39-6"><a href="#cb39-6" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb39-7"><a href="#cb39-7" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<p>–<em>end example</em>]</p>
 <h3 data-number="28.9.9" id="conjugated-in-place-transformation-linalg.conj"><span class="header-section-number">28.9.9</span> Conjugated in-place
 transformation [linalg.conj]<a href="#conjugated-in-place-transformation-linalg.conj" class="self-link"></a></h3>
 <h4 data-number="28.9.9.1" id="introduction-linalg.conj.intro"><span class="header-section-number">28.9.9.1</span> Introduction
@@ -6884,30 +6935,30 @@ The class template <code>conjugated_accessor</code> is an
 complex conjugate of its nested <code>mdspan</code> accessor’s
 reference. It is part of the implementation of <code>conjugated</code>
 <strong>[linalg.conj.conjugated]</strong>.</p>
-<div class="sourceCode" id="cb37"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb37-1"><a href="#cb37-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> NestedAccessor<span class="op">&gt;</span></span>
-<span id="cb37-2"><a href="#cb37-2" aria-hidden="true" tabindex="-1"></a><span class="kw">class</span> conjugated_accessor <span class="op">{</span></span>
-<span id="cb37-3"><a href="#cb37-3" aria-hidden="true" tabindex="-1"></a><span class="kw">public</span><span class="op">:</span></span>
-<span id="cb37-4"><a href="#cb37-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> element_type <span class="op">=</span> add_const_t<span class="op">&lt;</span><span class="kw">decltype</span><span class="op">(</span><em>conj-if-needed</em><span class="op">(</span>declval<span class="op">&lt;</span>NestedAccessor<span class="op">::</span>element_type<span class="op">&gt;()))&gt;</span>;</span>
-<span id="cb37-5"><a href="#cb37-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> reference <span class="op">=</span> remove_const_t<span class="op">&lt;</span>element_type<span class="op">&gt;</span>;</span>
-<span id="cb37-6"><a href="#cb37-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> data_handle_type <span class="op">=</span> <span class="kw">typename</span> NestedAccessor<span class="op">::</span>data_handle_type;</span>
-<span id="cb37-7"><a href="#cb37-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> offset_policy <span class="op">=</span> conjugated_accessor<span class="op">&lt;</span>NestedAccessor<span class="op">::</span>offset_policy<span class="op">&gt;</span>;</span>
-<span id="cb37-8"><a href="#cb37-8" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb37-9"><a href="#cb37-9" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> conjugated_accessor<span class="op">()</span> <span class="op">=</span> <span class="cf">default</span>;</span>
-<span id="cb37-10"><a href="#cb37-10" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherNestedAccessor<span class="op">&gt;</span></span>
-<span id="cb37-11"><a href="#cb37-11" aria-hidden="true" tabindex="-1"></a>    <span class="kw">explicit</span><span class="op">(!</span>is_convertible_v<span class="op">&lt;</span>OtherNestedAccessor, NestedAccessor<span class="op">&gt;&gt;)</span></span>
-<span id="cb37-12"><a href="#cb37-12" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> conjugated_accessor<span class="op">(</span><span class="kw">const</span> conjugated_accessor<span class="op">&lt;</span>OtherNestedAccessor<span class="op">&gt;&amp;</span> other<span class="op">)</span>;</span>
-<span id="cb37-13"><a href="#cb37-13" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb37-14"><a href="#cb37-14" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> reference access<span class="op">(</span>data_handle_type p, <span class="dt">size_t</span> i<span class="op">)</span> <span class="kw">const</span> <span class="kw">noexcept</span><span class="op">(</span><em>see below</em><span class="op">)</span>;</span>
-<span id="cb37-15"><a href="#cb37-15" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb37-16"><a href="#cb37-16" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> <span class="kw">typename</span> offset_policy<span class="op">::</span>data_handle_type</span>
-<span id="cb37-17"><a href="#cb37-17" aria-hidden="true" tabindex="-1"></a>    offset<span class="op">(</span>data_handle_type p, <span class="dt">size_t</span> i<span class="op">)</span> <span class="kw">const</span></span>
-<span id="cb37-18"><a href="#cb37-18" aria-hidden="true" tabindex="-1"></a>      <span class="kw">noexcept</span><span class="op">(</span><span class="kw">noexcept</span><span class="op">(</span><em>nested-accessor</em><span class="op">.</span>offset<span class="op">(</span>p, i<span class="op">)))</span>;</span>
-<span id="cb37-19"><a href="#cb37-19" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb37-20"><a href="#cb37-20" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> <span class="kw">const</span> Accessor<span class="op">&amp;</span> nested_accessor<span class="op">()</span> <span class="kw">const</span> <span class="kw">noexcept</span> <span class="op">{</span> <span class="cf">return</span> <em>nested-accessor</em>; <span class="op">}</span></span>
-<span id="cb37-21"><a href="#cb37-21" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb37-22"><a href="#cb37-22" aria-hidden="true" tabindex="-1"></a><span class="kw">private</span><span class="op">:</span></span>
-<span id="cb37-23"><a href="#cb37-23" aria-hidden="true" tabindex="-1"></a>  NestedAccessor <em>nested-accessor</em><span class="op">{}</span>; <span class="co">// exposition only</span></span>
-<span id="cb37-24"><a href="#cb37-24" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb40"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb40-1"><a href="#cb40-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> NestedAccessor<span class="op">&gt;</span></span>
+<span id="cb40-2"><a href="#cb40-2" aria-hidden="true" tabindex="-1"></a><span class="kw">class</span> conjugated_accessor <span class="op">{</span></span>
+<span id="cb40-3"><a href="#cb40-3" aria-hidden="true" tabindex="-1"></a><span class="kw">public</span><span class="op">:</span></span>
+<span id="cb40-4"><a href="#cb40-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> element_type <span class="op">=</span> add_const_t<span class="op">&lt;</span><span class="kw">decltype</span><span class="op">(</span><em>conj-if-needed</em><span class="op">(</span>declval<span class="op">&lt;</span>NestedAccessor<span class="op">::</span>element_type<span class="op">&gt;()))&gt;</span>;</span>
+<span id="cb40-5"><a href="#cb40-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> reference <span class="op">=</span> remove_const_t<span class="op">&lt;</span>element_type<span class="op">&gt;</span>;</span>
+<span id="cb40-6"><a href="#cb40-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> data_handle_type <span class="op">=</span> <span class="kw">typename</span> NestedAccessor<span class="op">::</span>data_handle_type;</span>
+<span id="cb40-7"><a href="#cb40-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> offset_policy <span class="op">=</span> conjugated_accessor<span class="op">&lt;</span>NestedAccessor<span class="op">::</span>offset_policy<span class="op">&gt;</span>;</span>
+<span id="cb40-8"><a href="#cb40-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb40-9"><a href="#cb40-9" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> conjugated_accessor<span class="op">()</span> <span class="op">=</span> <span class="cf">default</span>;</span>
+<span id="cb40-10"><a href="#cb40-10" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherNestedAccessor<span class="op">&gt;</span></span>
+<span id="cb40-11"><a href="#cb40-11" aria-hidden="true" tabindex="-1"></a>    <span class="kw">explicit</span><span class="op">(!</span>is_convertible_v<span class="op">&lt;</span>OtherNestedAccessor, NestedAccessor<span class="op">&gt;&gt;)</span></span>
+<span id="cb40-12"><a href="#cb40-12" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> conjugated_accessor<span class="op">(</span><span class="kw">const</span> conjugated_accessor<span class="op">&lt;</span>OtherNestedAccessor<span class="op">&gt;&amp;</span> other<span class="op">)</span>;</span>
+<span id="cb40-13"><a href="#cb40-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb40-14"><a href="#cb40-14" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> reference access<span class="op">(</span>data_handle_type p, <span class="dt">size_t</span> i<span class="op">)</span> <span class="kw">const</span> <span class="kw">noexcept</span><span class="op">(</span><em>see below</em><span class="op">)</span>;</span>
+<span id="cb40-15"><a href="#cb40-15" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb40-16"><a href="#cb40-16" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> <span class="kw">typename</span> offset_policy<span class="op">::</span>data_handle_type</span>
+<span id="cb40-17"><a href="#cb40-17" aria-hidden="true" tabindex="-1"></a>    offset<span class="op">(</span>data_handle_type p, <span class="dt">size_t</span> i<span class="op">)</span> <span class="kw">const</span></span>
+<span id="cb40-18"><a href="#cb40-18" aria-hidden="true" tabindex="-1"></a>      <span class="kw">noexcept</span><span class="op">(</span><span class="kw">noexcept</span><span class="op">(</span><em>nested-accessor</em><span class="op">.</span>offset<span class="op">(</span>p, i<span class="op">)))</span>;</span>
+<span id="cb40-19"><a href="#cb40-19" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb40-20"><a href="#cb40-20" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> <span class="kw">const</span> Accessor<span class="op">&amp;</span> nested_accessor<span class="op">()</span> <span class="kw">const</span> <span class="kw">noexcept</span> <span class="op">{</span> <span class="cf">return</span> <em>nested-accessor</em>; <span class="op">}</span></span>
+<span id="cb40-21"><a href="#cb40-21" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb40-22"><a href="#cb40-22" aria-hidden="true" tabindex="-1"></a><span class="kw">private</span><span class="op">:</span></span>
+<span id="cb40-23"><a href="#cb40-23" aria-hidden="true" tabindex="-1"></a>  NestedAccessor <em>nested-accessor</em><span class="op">{}</span>; <span class="co">// exposition only</span></span>
+<span id="cb40-24"><a href="#cb40-24" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">2</a></span>
 <em>Mandates:</em></p>
 <ul>
@@ -6923,13 +6974,13 @@ reference. It is part of the implementation of <code>conjugated</code>
 <code>NestedAccessor</code> meets the accessor policy requirements
 [mdspan.accessor.reqmts].</p></li>
 </ul>
-<div class="sourceCode" id="cb38"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb38-1"><a href="#cb38-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> conjugated_accessor<span class="op">(</span><span class="kw">const</span> NestedAccessor<span class="op">&amp;</span> acc<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb41"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb41-1"><a href="#cb41-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> conjugated_accessor<span class="op">(</span><span class="kw">const</span> NestedAccessor<span class="op">&amp;</span> acc<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">3</a></span>
 <em>Effects:</em> Direct non-list-initializes
 <em><code>nested-accessor</code></em> with <code>acc</code>.</p>
-<div class="sourceCode" id="cb39"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb39-1"><a href="#cb39-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherScalingFactor, <span class="kw">class</span> OtherNestedAccessor<span class="op">&gt;</span></span>
-<span id="cb39-2"><a href="#cb39-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">explicit</span><span class="op">(!</span>is_convertible_v<span class="op">&lt;</span>OtherNestedAccessor, NestedAccessor<span class="op">&gt;&gt;)</span></span>
-<span id="cb39-3"><a href="#cb39-3" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> conjugated_accessor<span class="op">(</span><span class="kw">const</span> conjugated_accessor<span class="op">&lt;</span>OtherScalingFactor, OtherNestedAccessor<span class="op">&gt;&amp;</span> other<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb42"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb42-1"><a href="#cb42-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherScalingFactor, <span class="kw">class</span> OtherNestedAccessor<span class="op">&gt;</span></span>
+<span id="cb42-2"><a href="#cb42-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">explicit</span><span class="op">(!</span>is_convertible_v<span class="op">&lt;</span>OtherNestedAccessor, NestedAccessor<span class="op">&gt;&gt;)</span></span>
+<span id="cb42-3"><a href="#cb42-3" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> conjugated_accessor<span class="op">(</span><span class="kw">const</span> conjugated_accessor<span class="op">&lt;</span>OtherScalingFactor, OtherNestedAccessor<span class="op">&gt;&amp;</span> other<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">4</a></span>
 <em>Constraints:</em>
 <code>is_constructible_v&lt;NestedAccessor, const OtherNestedAccessor&amp;&gt;</code>
@@ -6938,28 +6989,28 @@ is <code>true</code>.</p>
 <em>Effects:</em> direct non-list-initializes
 <em><code>nested-accessor</code></em> with
 <code>other.nested_accessor()</code>.</p>
-<div class="sourceCode" id="cb40"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb40-1"><a href="#cb40-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> reference access<span class="op">(</span>data_handle_type p, <span class="dt">size_t</span> i<span class="op">)</span> <span class="kw">const</span></span>
-<span id="cb40-2"><a href="#cb40-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">noexcept</span><span class="op">(</span><span class="kw">noexcept</span><span class="op">(</span>reference<span class="op">(</span><em>nested-accessor</em><span class="op">.</span>access<span class="op">(</span>p, i<span class="op">))))</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb43"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb43-1"><a href="#cb43-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> reference access<span class="op">(</span>data_handle_type p, <span class="dt">size_t</span> i<span class="op">)</span> <span class="kw">const</span></span>
+<span id="cb43-2"><a href="#cb43-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">noexcept</span><span class="op">(</span><span class="kw">noexcept</span><span class="op">(</span>reference<span class="op">(</span><em>nested-accessor</em><span class="op">.</span>access<span class="op">(</span>p, i<span class="op">))))</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">6</a></span>
 <em>Returns:</em>
 <em><code>conj-if-needed</code></em><code>(NestedAccessor::element_type(</code><em><code>nested-accessor</code></em><code>.access(p, i)))</code></p>
 <p><span class="marginalizedparent"><a class="marginalized">7</a></span>
 <em>Remarks:</em> The exception specification is equivalent to:</p>
-<div class="sourceCode" id="cb41"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb41-1"><a href="#cb41-1" aria-hidden="true" tabindex="-1"></a><span class="kw">noexcept</span><span class="op">(</span><em>conj-if-needed</em><span class="op">(</span>NestedAccessor<span class="op">::</span>element_type<span class="op">(</span><em>nested-accessor</em><span class="op">.</span>access<span class="op">(</span>p, i<span class="op">)))</span></span></code></pre></div>
-<div class="sourceCode" id="cb42"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb42-1"><a href="#cb42-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">typename</span> offset_policy<span class="op">::</span>data_handle_type</span>
-<span id="cb42-2"><a href="#cb42-2" aria-hidden="true" tabindex="-1"></a>  offset<span class="op">(</span>data_handle_type p, <span class="dt">size_t</span> i<span class="op">)</span> <span class="kw">const</span></span>
-<span id="cb42-3"><a href="#cb42-3" aria-hidden="true" tabindex="-1"></a>    <span class="kw">noexcept</span><span class="op">(</span><span class="kw">noexcept</span><span class="op">(</span><em>nested-accessor</em><span class="op">.</span>offset<span class="op">(</span>p, i<span class="op">)))</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb44"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb44-1"><a href="#cb44-1" aria-hidden="true" tabindex="-1"></a><span class="kw">noexcept</span><span class="op">(</span><em>conj-if-needed</em><span class="op">(</span>NestedAccessor<span class="op">::</span>element_type<span class="op">(</span><em>nested-accessor</em><span class="op">.</span>access<span class="op">(</span>p, i<span class="op">)))</span></span></code></pre></div>
+<div class="sourceCode" id="cb45"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb45-1"><a href="#cb45-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">typename</span> offset_policy<span class="op">::</span>data_handle_type</span>
+<span id="cb45-2"><a href="#cb45-2" aria-hidden="true" tabindex="-1"></a>  offset<span class="op">(</span>data_handle_type p, <span class="dt">size_t</span> i<span class="op">)</span> <span class="kw">const</span></span>
+<span id="cb45-3"><a href="#cb45-3" aria-hidden="true" tabindex="-1"></a>    <span class="kw">noexcept</span><span class="op">(</span><span class="kw">noexcept</span><span class="op">(</span><em>nested-accessor</em><span class="op">.</span>offset<span class="op">(</span>p, i<span class="op">)))</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">8</a></span>
 <em>Returns:</em>
 <em><code>nested-accessor</code></em><code>.offset(p, i)</code></p>
 <h4 data-number="28.9.9.3" id="conjugated-linalg.conj.conjugated"><span class="header-section-number">28.9.9.3</span> <code>conjugated</code>
 [linalg.conj.conjugated]<a href="#conjugated-linalg.conj.conjugated" class="self-link"></a></h4>
-<div class="sourceCode" id="cb43"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb43-1"><a href="#cb43-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ElementType,</span>
-<span id="cb43-2"><a href="#cb43-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Extents,</span>
-<span id="cb43-3"><a href="#cb43-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Layout,</span>
-<span id="cb43-4"><a href="#cb43-4" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Accessor<span class="op">&gt;</span></span>
-<span id="cb43-5"><a href="#cb43-5" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> conjugated<span class="op">(</span></span>
-<span id="cb43-6"><a href="#cb43-6" aria-hidden="true" tabindex="-1"></a>  mdspan<span class="op">&lt;</span>ElementType, Extents, Layout, Accessor<span class="op">&gt;</span> a<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb46"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb46-1"><a href="#cb46-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ElementType,</span>
+<span id="cb46-2"><a href="#cb46-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Extents,</span>
+<span id="cb46-3"><a href="#cb46-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Layout,</span>
+<span id="cb46-4"><a href="#cb46-4" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Accessor<span class="op">&gt;</span></span>
+<span id="cb46-5"><a href="#cb46-5" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> conjugated<span class="op">(</span></span>
+<span id="cb46-6"><a href="#cb46-6" aria-hidden="true" tabindex="-1"></a>  mdspan<span class="op">&lt;</span>ElementType, Extents, Layout, Accessor<span class="op">&gt;</span> a<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 Let <code>A</code> be
 <code>decltype(a.accessor().nested_accessor())</code> if
@@ -6976,7 +7027,33 @@ if <code>Accessor</code> is a specialization of
 <li><p><span class="marginalizedparent"><a class="marginalized">(2.2)</a></span>
 <code>mdspan&lt;typename A::element_type, Extents, Layout, A&gt;(a.data_handle(), a.mapping(), conjugated_accessor(a.accessor()))</code>.</p></li>
 </ul>
-<p>[<em>Example:</em>]</p>
+<p>[<em>Example:</em></p>
+<div class="sourceCode" id="cb47"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb47-1"><a href="#cb47-1" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> test_conjugated_complex<span class="op">(</span></span>
+<span id="cb47-2"><a href="#cb47-2" aria-hidden="true" tabindex="-1"></a>  mdspan<span class="op">&lt;</span>complex<span class="op">&lt;</span><span class="dt">double</span><span class="op">&gt;</span>, extents<span class="op">&lt;</span><span class="dt">int</span>, <span class="dv">10</span><span class="op">&gt;&gt;</span> a<span class="op">)</span></span>
+<span id="cb47-3"><a href="#cb47-3" aria-hidden="true" tabindex="-1"></a><span class="op">{</span></span>
+<span id="cb47-4"><a href="#cb47-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">auto</span> a_conj <span class="op">=</span> conjugated<span class="op">(</span>a<span class="op">)</span>;</span>
+<span id="cb47-5"><a href="#cb47-5" aria-hidden="true" tabindex="-1"></a>  <span class="cf">for</span><span class="op">(</span><span class="dt">int</span> i <span class="op">=</span> <span class="dv">0</span>; i <span class="op">&lt;</span> a<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span>; <span class="op">++</span>i<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb47-6"><a href="#cb47-6" aria-hidden="true" tabindex="-1"></a>    <span class="ot">assert</span><span class="op">(</span>a_conj<span class="op">[</span>i<span class="op">]</span> <span class="op">==</span> conj<span class="op">(</span>a<span class="op">[</span>i<span class="op">])</span>;</span>
+<span id="cb47-7"><a href="#cb47-7" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb47-8"><a href="#cb47-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">auto</span> a_conj_conj <span class="op">=</span> conjugated<span class="op">(</span>a_conj<span class="op">)</span>;</span>
+<span id="cb47-9"><a href="#cb47-9" aria-hidden="true" tabindex="-1"></a>  <span class="cf">for</span><span class="op">(</span><span class="dt">int</span> i <span class="op">=</span> <span class="dv">0</span>; i <span class="op">&lt;</span> a<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span>; <span class="op">++</span>i<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb47-10"><a href="#cb47-10" aria-hidden="true" tabindex="-1"></a>    <span class="ot">assert</span><span class="op">(</span>a_conj_conj<span class="op">[</span>i<span class="op">]</span> <span class="op">==</span> a<span class="op">[</span>i<span class="op">])</span>;</span>
+<span id="cb47-11"><a href="#cb47-11" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb47-12"><a href="#cb47-12" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
+<span id="cb47-13"><a href="#cb47-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb47-14"><a href="#cb47-14" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> test_conjugated_real<span class="op">(</span></span>
+<span id="cb47-15"><a href="#cb47-15" aria-hidden="true" tabindex="-1"></a>  mdspan<span class="op">&lt;</span><span class="dt">double</span>, extents<span class="op">&lt;</span><span class="dt">int</span>, <span class="dv">10</span><span class="op">&gt;&gt;</span> a<span class="op">)</span></span>
+<span id="cb47-16"><a href="#cb47-16" aria-hidden="true" tabindex="-1"></a><span class="op">{</span></span>
+<span id="cb47-17"><a href="#cb47-17" aria-hidden="true" tabindex="-1"></a>  <span class="kw">auto</span> a_conj <span class="op">=</span> conjugated<span class="op">(</span>a<span class="op">)</span>;</span>
+<span id="cb47-18"><a href="#cb47-18" aria-hidden="true" tabindex="-1"></a>  <span class="cf">for</span><span class="op">(</span><span class="dt">int</span> i <span class="op">=</span> <span class="dv">0</span>; i <span class="op">&lt;</span> a<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span>; <span class="op">++</span>i<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb47-19"><a href="#cb47-19" aria-hidden="true" tabindex="-1"></a>    <span class="ot">assert</span><span class="op">(</span>a_conj<span class="op">[</span>i<span class="op">]</span> <span class="op">==</span> a<span class="op">[</span>i<span class="op">])</span>;</span>
+<span id="cb47-20"><a href="#cb47-20" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb47-21"><a href="#cb47-21" aria-hidden="true" tabindex="-1"></a>  <span class="kw">auto</span> a_conj_conj <span class="op">=</span> conjugated<span class="op">(</span>a_conj<span class="op">)</span>;</span>
+<span id="cb47-22"><a href="#cb47-22" aria-hidden="true" tabindex="-1"></a>  <span class="cf">for</span><span class="op">(</span><span class="dt">int</span> i <span class="op">=</span> <span class="dv">0</span>; i <span class="op">&lt;</span> a<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span>; <span class="op">++</span>i<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb47-23"><a href="#cb47-23" aria-hidden="true" tabindex="-1"></a>    <span class="ot">assert</span><span class="op">(</span>a_conj_conj<span class="op">[</span>i<span class="op">]</span> <span class="op">==</span> a<span class="op">[</span>i<span class="op">])</span>;</span>
+<span id="cb47-24"><a href="#cb47-24" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb47-25"><a href="#cb47-25" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<p>–<em>end example</em>]</p>
 <h3 data-number="28.9.10" id="transpose-in-place-transformation-linalg.transp"><span class="header-section-number">28.9.10</span> Transpose in-place
 transformation [linalg.transp]<a href="#transpose-in-place-transformation-linalg.transp" class="self-link"></a></h3>
 <h4 data-number="28.9.10.1" id="introduction-linalg.transp.intro"><span class="header-section-number">28.9.10.1</span> Introduction
@@ -6995,8 +7072,8 @@ representing the transpose of the input matrix.</p>
 <code>layout_transpose</code> is an <code>mdspan</code> layout mapping
 policy that swaps the rightmost two indices, extents, and strides of any
 unique <code>mdspan</code> layout mapping policy.</p>
-<div class="sourceCode" id="cb44"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb44-1"><a href="#cb44-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> InputExtents<span class="op">&gt;</span></span>
-<span id="cb44-2"><a href="#cb44-2" aria-hidden="true" tabindex="-1"></a><span class="kw">using</span> <em>transpose-extents-t</em> <span class="op">=</span> <span class="co">/* see below */</span>; <span class="co">// exposition only</span></span></code></pre></div>
+<div class="sourceCode" id="cb48"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb48-1"><a href="#cb48-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> InputExtents<span class="op">&gt;</span></span>
+<span id="cb48-2"><a href="#cb48-2" aria-hidden="true" tabindex="-1"></a><span class="kw">using</span> <em>transpose-extents-t</em> <span class="op">=</span> <span class="co">/* see below */</span>; <span class="co">// exposition only</span></span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">2</a></span>
 For <code>InputExtents</code> a specialization of <code>extents</code>,
 <em><code>transpose-extents-t</code></em><code>&lt;InputExtents&gt;</code>
@@ -7020,9 +7097,9 @@ and</p></li>
 <p><span class="marginalizedparent"><a class="marginalized">4</a></span>
 <em>Mandates:</em> <code>InputExtents</code> is a specialization of
 <code>extents</code>.</p>
-<div class="sourceCode" id="cb45"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb45-1"><a href="#cb45-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> InputExtents<span class="op">&gt;</span></span>
-<span id="cb45-2"><a href="#cb45-2" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <em>transpose-extents-t</em><span class="op">&lt;</span>InputExtents<span class="op">&gt;</span></span>
-<span id="cb45-3"><a href="#cb45-3" aria-hidden="true" tabindex="-1"></a><em>transpose-extents</em><span class="op">(</span><span class="kw">const</span> InputExtents<span class="op">&amp;</span> in<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
+<div class="sourceCode" id="cb49"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb49-1"><a href="#cb49-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> InputExtents<span class="op">&gt;</span></span>
+<span id="cb49-2"><a href="#cb49-2" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <em>transpose-extents-t</em><span class="op">&lt;</span>InputExtents<span class="op">&gt;</span></span>
+<span id="cb49-3"><a href="#cb49-3" aria-hidden="true" tabindex="-1"></a><em>transpose-extents</em><span class="op">(</span><span class="kw">const</span> InputExtents<span class="op">&amp;</span> in<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">5</a></span>
 <em>Constraints:</em> <code>InputExtents::rank()</code> equals 2.</p>
 <p><span class="marginalizedparent"><a class="marginalized">6</a></span>
@@ -7039,114 +7116,114 @@ that</p>
 <code>out.extent(r)</code> equals <code>in.extent(r)</code> for 0 ≤
 <code>r</code> &lt; <code>in.rank()-2</code>.</p></li>
 </ul>
-<div class="sourceCode" id="cb46"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb46-1"><a href="#cb46-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Layout<span class="op">&gt;</span></span>
-<span id="cb46-2"><a href="#cb46-2" aria-hidden="true" tabindex="-1"></a><span class="kw">class</span> layout_transpose <span class="op">{</span></span>
-<span id="cb46-3"><a href="#cb46-3" aria-hidden="true" tabindex="-1"></a><span class="kw">public</span><span class="op">:</span></span>
-<span id="cb46-4"><a href="#cb46-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Extents<span class="op">&gt;</span></span>
-<span id="cb46-5"><a href="#cb46-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">struct</span> mapping <span class="op">{</span></span>
-<span id="cb46-6"><a href="#cb46-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">private</span><span class="op">:</span></span>
-<span id="cb46-7"><a href="#cb46-7" aria-hidden="true" tabindex="-1"></a>    <span class="kw">using</span> <em>nested-mapping-type</em> <span class="op">=</span></span>
-<span id="cb46-8"><a href="#cb46-8" aria-hidden="true" tabindex="-1"></a>      <span class="kw">typename</span> Layout<span class="op">::</span><span class="kw">template</span> mapping<span class="op">&lt;</span></span>
-<span id="cb46-9"><a href="#cb46-9" aria-hidden="true" tabindex="-1"></a>        <em>transpose-extents-t</em><span class="op">&lt;</span>Extents<span class="op">&gt;&gt;</span>; <span class="co">// exposition only</span></span>
-<span id="cb46-10"><a href="#cb46-10" aria-hidden="true" tabindex="-1"></a>    <em>nested-mapping-type</em> <em>nested-mapping</em>; <span class="co">// exposition only</span></span>
-<span id="cb46-11"><a href="#cb46-11" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb46-12"><a href="#cb46-12" aria-hidden="true" tabindex="-1"></a>  <span class="kw">public</span><span class="op">:</span></span>
-<span id="cb46-13"><a href="#cb46-13" aria-hidden="true" tabindex="-1"></a>    <span class="kw">using</span> extents_type <span class="op">=</span> Extents;</span>
-<span id="cb46-14"><a href="#cb46-14" aria-hidden="true" tabindex="-1"></a>    <span class="kw">using</span> size_type <span class="op">=</span> <span class="kw">typename</span> extents_type<span class="op">::</span>size_type;</span>
-<span id="cb46-15"><a href="#cb46-15" aria-hidden="true" tabindex="-1"></a>    <span class="kw">using</span> layout_type <span class="op">=</span> layout_transpose;</span>
-<span id="cb46-16"><a href="#cb46-16" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb46-17"><a href="#cb46-17" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> <span class="kw">explicit</span> mapping<span class="op">(</span><span class="kw">const</span> <em>nested-mapping-type</em><span class="op">&amp;</span> map<span class="op">)</span>;</span>
-<span id="cb46-18"><a href="#cb46-18" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb46-19"><a href="#cb46-19" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> extents_type extents<span class="op">()</span> <span class="kw">const</span></span>
-<span id="cb46-20"><a href="#cb46-20" aria-hidden="true" tabindex="-1"></a>      <span class="kw">noexcept</span><span class="op">(</span><span class="kw">noexcept</span><span class="op">(</span><em>nested-mapping</em><span class="op">.</span>extents<span class="op">()))</span>;</span>
-<span id="cb46-21"><a href="#cb46-21" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb46-22"><a href="#cb46-22" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> size_type required_span_size<span class="op">()</span> <span class="kw">const</span></span>
-<span id="cb46-23"><a href="#cb46-23" aria-hidden="true" tabindex="-1"></a>      <span class="kw">noexcept</span><span class="op">(</span><span class="kw">noexcept</span><span class="op">(</span><em>nested-mapping</em><span class="op">.</span>required_span_size<span class="op">()))</span>;</span>
-<span id="cb46-24"><a href="#cb46-24" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb46-25"><a href="#cb46-25" aria-hidden="true" tabindex="-1"></a>    <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span><span class="op">...</span> Indices<span class="op">&gt;</span></span>
-<span id="cb46-26"><a href="#cb46-26" aria-hidden="true" tabindex="-1"></a>      <span class="kw">constexpr</span> size_type <span class="kw">operator</span><span class="op">()(</span>Indices<span class="op">...</span> indices<span class="op">)</span> <span class="kw">const</span></span>
-<span id="cb46-27"><a href="#cb46-27" aria-hidden="true" tabindex="-1"></a>        <span class="kw">noexcept</span><span class="op">(</span><span class="kw">noexcept</span><span class="op">(</span><em>nested-mapping</em><span class="op">(</span>indices<span class="op">...)))</span>;</span>
-<span id="cb46-28"><a href="#cb46-28" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb46-29"><a href="#cb46-29" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> <em>nested-mapping-type</em> nested_mapping<span class="op">()</span> <span class="kw">const</span>;</span>
-<span id="cb46-30"><a href="#cb46-30" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb46-31"><a href="#cb46-31" aria-hidden="true" tabindex="-1"></a>    <span class="kw">static</span> <span class="kw">constexpr</span> <span class="dt">bool</span> is_always_unique<span class="op">()</span>;</span>
-<span id="cb46-32"><a href="#cb46-32" aria-hidden="true" tabindex="-1"></a>    <span class="kw">static</span> <span class="kw">constexpr</span> <span class="dt">bool</span> is_always_contiguous<span class="op">()</span>;</span>
-<span id="cb46-33"><a href="#cb46-33" aria-hidden="true" tabindex="-1"></a>    <span class="kw">static</span> <span class="kw">constexpr</span> <span class="dt">bool</span> is_always_strided<span class="op">()</span>;</span>
-<span id="cb46-34"><a href="#cb46-34" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb46-35"><a href="#cb46-35" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> <span class="dt">bool</span> is_unique<span class="op">()</span> <span class="kw">const</span></span>
-<span id="cb46-36"><a href="#cb46-36" aria-hidden="true" tabindex="-1"></a>      <span class="kw">noexcept</span><span class="op">(</span><span class="kw">noexcept</span><span class="op">(</span><em>nested-mapping</em><span class="op">.</span>is_unique<span class="op">()))</span>;</span>
-<span id="cb46-37"><a href="#cb46-37" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> <span class="dt">bool</span> is_contiguous<span class="op">()</span> <span class="kw">const</span></span>
-<span id="cb46-38"><a href="#cb46-38" aria-hidden="true" tabindex="-1"></a>      <span class="kw">noexcept</span><span class="op">(</span><span class="kw">noexcept</span><span class="op">(</span><em>nested-mapping</em><span class="op">.</span>is_contiguous<span class="op">()))</span>;</span>
-<span id="cb46-39"><a href="#cb46-39" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> <span class="dt">bool</span> is_strided<span class="op">()</span> <span class="kw">const</span></span>
-<span id="cb46-40"><a href="#cb46-40" aria-hidden="true" tabindex="-1"></a>      <span class="kw">noexcept</span><span class="op">(</span><span class="kw">noexcept</span><span class="op">(</span><em>nested-mapping</em><span class="op">.</span>is_strided<span class="op">()))</span>;</span>
-<span id="cb46-41"><a href="#cb46-41" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb46-42"><a href="#cb46-42" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> size_type stride<span class="op">(</span><span class="dt">size_t</span> r<span class="op">)</span> <span class="kw">const</span></span>
-<span id="cb46-43"><a href="#cb46-43" aria-hidden="true" tabindex="-1"></a>      <span class="kw">noexcept</span><span class="op">(</span><span class="kw">noexcept</span><span class="op">(</span><em>nested-mapping</em><span class="op">.</span>stride<span class="op">(</span>r<span class="op">)))</span>;</span>
-<span id="cb46-44"><a href="#cb46-44" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb46-45"><a href="#cb46-45" aria-hidden="true" tabindex="-1"></a>    <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherExtents<span class="op">&gt;</span></span>
-<span id="cb46-46"><a href="#cb46-46" aria-hidden="true" tabindex="-1"></a>      <span class="kw">friend</span> <span class="kw">constexpr</span> <span class="dt">bool</span></span>
-<span id="cb46-47"><a href="#cb46-47" aria-hidden="true" tabindex="-1"></a>        <span class="kw">operator</span><span class="op">==(</span><span class="kw">const</span> mapping<span class="op">&amp;</span>, <span class="kw">const</span> mapping<span class="op">&lt;</span>OtherExtents<span class="op">&gt;&amp;)</span> <span class="kw">noexcept</span>;</span>
-<span id="cb46-48"><a href="#cb46-48" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span>;</span>
-<span id="cb46-49"><a href="#cb46-49" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb50"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb50-1"><a href="#cb50-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Layout<span class="op">&gt;</span></span>
+<span id="cb50-2"><a href="#cb50-2" aria-hidden="true" tabindex="-1"></a><span class="kw">class</span> layout_transpose <span class="op">{</span></span>
+<span id="cb50-3"><a href="#cb50-3" aria-hidden="true" tabindex="-1"></a><span class="kw">public</span><span class="op">:</span></span>
+<span id="cb50-4"><a href="#cb50-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Extents<span class="op">&gt;</span></span>
+<span id="cb50-5"><a href="#cb50-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">struct</span> mapping <span class="op">{</span></span>
+<span id="cb50-6"><a href="#cb50-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">private</span><span class="op">:</span></span>
+<span id="cb50-7"><a href="#cb50-7" aria-hidden="true" tabindex="-1"></a>    <span class="kw">using</span> <em>nested-mapping-type</em> <span class="op">=</span></span>
+<span id="cb50-8"><a href="#cb50-8" aria-hidden="true" tabindex="-1"></a>      <span class="kw">typename</span> Layout<span class="op">::</span><span class="kw">template</span> mapping<span class="op">&lt;</span></span>
+<span id="cb50-9"><a href="#cb50-9" aria-hidden="true" tabindex="-1"></a>        <em>transpose-extents-t</em><span class="op">&lt;</span>Extents<span class="op">&gt;&gt;</span>; <span class="co">// exposition only</span></span>
+<span id="cb50-10"><a href="#cb50-10" aria-hidden="true" tabindex="-1"></a>    <em>nested-mapping-type</em> <em>nested-mapping</em>; <span class="co">// exposition only</span></span>
+<span id="cb50-11"><a href="#cb50-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb50-12"><a href="#cb50-12" aria-hidden="true" tabindex="-1"></a>  <span class="kw">public</span><span class="op">:</span></span>
+<span id="cb50-13"><a href="#cb50-13" aria-hidden="true" tabindex="-1"></a>    <span class="kw">using</span> extents_type <span class="op">=</span> Extents;</span>
+<span id="cb50-14"><a href="#cb50-14" aria-hidden="true" tabindex="-1"></a>    <span class="kw">using</span> size_type <span class="op">=</span> <span class="kw">typename</span> extents_type<span class="op">::</span>size_type;</span>
+<span id="cb50-15"><a href="#cb50-15" aria-hidden="true" tabindex="-1"></a>    <span class="kw">using</span> layout_type <span class="op">=</span> layout_transpose;</span>
+<span id="cb50-16"><a href="#cb50-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb50-17"><a href="#cb50-17" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> <span class="kw">explicit</span> mapping<span class="op">(</span><span class="kw">const</span> <em>nested-mapping-type</em><span class="op">&amp;</span> map<span class="op">)</span>;</span>
+<span id="cb50-18"><a href="#cb50-18" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb50-19"><a href="#cb50-19" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> extents_type extents<span class="op">()</span> <span class="kw">const</span></span>
+<span id="cb50-20"><a href="#cb50-20" aria-hidden="true" tabindex="-1"></a>      <span class="kw">noexcept</span><span class="op">(</span><span class="kw">noexcept</span><span class="op">(</span><em>nested-mapping</em><span class="op">.</span>extents<span class="op">()))</span>;</span>
+<span id="cb50-21"><a href="#cb50-21" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb50-22"><a href="#cb50-22" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> size_type required_span_size<span class="op">()</span> <span class="kw">const</span></span>
+<span id="cb50-23"><a href="#cb50-23" aria-hidden="true" tabindex="-1"></a>      <span class="kw">noexcept</span><span class="op">(</span><span class="kw">noexcept</span><span class="op">(</span><em>nested-mapping</em><span class="op">.</span>required_span_size<span class="op">()))</span>;</span>
+<span id="cb50-24"><a href="#cb50-24" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb50-25"><a href="#cb50-25" aria-hidden="true" tabindex="-1"></a>    <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span><span class="op">...</span> Indices<span class="op">&gt;</span></span>
+<span id="cb50-26"><a href="#cb50-26" aria-hidden="true" tabindex="-1"></a>      <span class="kw">constexpr</span> size_type <span class="kw">operator</span><span class="op">()(</span>Indices<span class="op">...</span> indices<span class="op">)</span> <span class="kw">const</span></span>
+<span id="cb50-27"><a href="#cb50-27" aria-hidden="true" tabindex="-1"></a>        <span class="kw">noexcept</span><span class="op">(</span><span class="kw">noexcept</span><span class="op">(</span><em>nested-mapping</em><span class="op">(</span>indices<span class="op">...)))</span>;</span>
+<span id="cb50-28"><a href="#cb50-28" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb50-29"><a href="#cb50-29" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> <em>nested-mapping-type</em> nested_mapping<span class="op">()</span> <span class="kw">const</span>;</span>
+<span id="cb50-30"><a href="#cb50-30" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb50-31"><a href="#cb50-31" aria-hidden="true" tabindex="-1"></a>    <span class="kw">static</span> <span class="kw">constexpr</span> <span class="dt">bool</span> is_always_unique<span class="op">()</span>;</span>
+<span id="cb50-32"><a href="#cb50-32" aria-hidden="true" tabindex="-1"></a>    <span class="kw">static</span> <span class="kw">constexpr</span> <span class="dt">bool</span> is_always_contiguous<span class="op">()</span>;</span>
+<span id="cb50-33"><a href="#cb50-33" aria-hidden="true" tabindex="-1"></a>    <span class="kw">static</span> <span class="kw">constexpr</span> <span class="dt">bool</span> is_always_strided<span class="op">()</span>;</span>
+<span id="cb50-34"><a href="#cb50-34" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb50-35"><a href="#cb50-35" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> <span class="dt">bool</span> is_unique<span class="op">()</span> <span class="kw">const</span></span>
+<span id="cb50-36"><a href="#cb50-36" aria-hidden="true" tabindex="-1"></a>      <span class="kw">noexcept</span><span class="op">(</span><span class="kw">noexcept</span><span class="op">(</span><em>nested-mapping</em><span class="op">.</span>is_unique<span class="op">()))</span>;</span>
+<span id="cb50-37"><a href="#cb50-37" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> <span class="dt">bool</span> is_contiguous<span class="op">()</span> <span class="kw">const</span></span>
+<span id="cb50-38"><a href="#cb50-38" aria-hidden="true" tabindex="-1"></a>      <span class="kw">noexcept</span><span class="op">(</span><span class="kw">noexcept</span><span class="op">(</span><em>nested-mapping</em><span class="op">.</span>is_contiguous<span class="op">()))</span>;</span>
+<span id="cb50-39"><a href="#cb50-39" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> <span class="dt">bool</span> is_strided<span class="op">()</span> <span class="kw">const</span></span>
+<span id="cb50-40"><a href="#cb50-40" aria-hidden="true" tabindex="-1"></a>      <span class="kw">noexcept</span><span class="op">(</span><span class="kw">noexcept</span><span class="op">(</span><em>nested-mapping</em><span class="op">.</span>is_strided<span class="op">()))</span>;</span>
+<span id="cb50-41"><a href="#cb50-41" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb50-42"><a href="#cb50-42" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> size_type stride<span class="op">(</span><span class="dt">size_t</span> r<span class="op">)</span> <span class="kw">const</span></span>
+<span id="cb50-43"><a href="#cb50-43" aria-hidden="true" tabindex="-1"></a>      <span class="kw">noexcept</span><span class="op">(</span><span class="kw">noexcept</span><span class="op">(</span><em>nested-mapping</em><span class="op">.</span>stride<span class="op">(</span>r<span class="op">)))</span>;</span>
+<span id="cb50-44"><a href="#cb50-44" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb50-45"><a href="#cb50-45" aria-hidden="true" tabindex="-1"></a>    <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherExtents<span class="op">&gt;</span></span>
+<span id="cb50-46"><a href="#cb50-46" aria-hidden="true" tabindex="-1"></a>      <span class="kw">friend</span> <span class="kw">constexpr</span> <span class="dt">bool</span></span>
+<span id="cb50-47"><a href="#cb50-47" aria-hidden="true" tabindex="-1"></a>        <span class="kw">operator</span><span class="op">==(</span><span class="kw">const</span> mapping<span class="op">&amp;</span>, <span class="kw">const</span> mapping<span class="op">&lt;</span>OtherExtents<span class="op">&gt;&amp;)</span> <span class="kw">noexcept</span>;</span>
+<span id="cb50-48"><a href="#cb50-48" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span>;</span>
+<span id="cb50-49"><a href="#cb50-49" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">7</a></span>
 <code>Layout</code> shall meet the <code>mdspan</code> layout mapping
 policy requirements.</p>
 <p><span class="marginalizedparent"><a class="marginalized">8</a></span>
 <em>Constraints:</em> <code>Extents::rank()</code> equals 2.</p>
-<div class="sourceCode" id="cb47"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb47-1"><a href="#cb47-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">explicit</span> mapping<span class="op">(</span><span class="kw">const</span> <em>nested-mapping-type</em><span class="op">&amp;</span> map<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb51"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb51-1"><a href="#cb51-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">explicit</span> mapping<span class="op">(</span><span class="kw">const</span> <em>nested-mapping-type</em><span class="op">&amp;</span> map<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">9</a></span>
 <em>Effects:</em> Initializes <em><code>nested-mapping</code></em> with
 <code>map</code>.</p>
-<div class="sourceCode" id="cb48"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb48-1"><a href="#cb48-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> extents_type extents<span class="op">()</span> <span class="kw">const</span></span>
-<span id="cb48-2"><a href="#cb48-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">noexcept</span><span class="op">(</span><span class="kw">noexcept</span><span class="op">(</span><em>nested-mapping</em><span class="op">.</span>extents<span class="op">()))</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb52"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb52-1"><a href="#cb52-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> extents_type extents<span class="op">()</span> <span class="kw">const</span></span>
+<span id="cb52-2"><a href="#cb52-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">noexcept</span><span class="op">(</span><span class="kw">noexcept</span><span class="op">(</span><em>nested-mapping</em><span class="op">.</span>extents<span class="op">()))</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">10</a></span>
 <em>Returns:</em> <em><code>transpose-extents</code></em> <code>(</code>
 <em><code>nested_mapping</code></em> <code>.extents())</code></p>
-<div class="sourceCode" id="cb49"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb49-1"><a href="#cb49-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> size_type required_span_size<span class="op">()</span> <span class="kw">const</span></span>
-<span id="cb49-2"><a href="#cb49-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">noexcept</span><span class="op">(</span><span class="kw">noexcept</span><span class="op">(</span><em>nested-mapping</em><span class="op">.</span>required_span_size<span class="op">()))</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb53"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb53-1"><a href="#cb53-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> size_type required_span_size<span class="op">()</span> <span class="kw">const</span></span>
+<span id="cb53-2"><a href="#cb53-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">noexcept</span><span class="op">(</span><span class="kw">noexcept</span><span class="op">(</span><em>nested-mapping</em><span class="op">.</span>required_span_size<span class="op">()))</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">11</a></span>
 <em>Returns:</em> <em><code>nested-mapping</code></em>
 <code>.required_span_size()</code></p>
-<div class="sourceCode" id="cb50"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb50-1"><a href="#cb50-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span><span class="op">...</span> Indices<span class="op">&gt;</span></span>
-<span id="cb50-2"><a href="#cb50-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> size_type <span class="kw">operator</span><span class="op">()(</span>Indices<span class="op">...</span> indices<span class="op">)</span> <span class="kw">const</span></span>
-<span id="cb50-3"><a href="#cb50-3" aria-hidden="true" tabindex="-1"></a>    <span class="kw">noexcept</span><span class="op">(</span><span class="kw">noexcept</span><span class="op">(</span><em>nested-mapping</em><span class="op">(</span>indices<span class="op">...)))</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb54"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb54-1"><a href="#cb54-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span><span class="op">...</span> Indices<span class="op">&gt;</span></span>
+<span id="cb54-2"><a href="#cb54-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> size_type <span class="kw">operator</span><span class="op">()(</span>Indices<span class="op">...</span> indices<span class="op">)</span> <span class="kw">const</span></span>
+<span id="cb54-3"><a href="#cb54-3" aria-hidden="true" tabindex="-1"></a>    <span class="kw">noexcept</span><span class="op">(</span><span class="kw">noexcept</span><span class="op">(</span><em>nested-mapping</em><span class="op">(</span>indices<span class="op">...)))</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">12</a></span>
 <em>Returns:</em> <em><code>nested-mapping</code></em>
 <code>(last_2_indices_reversed)</code>, where
 <code>last_2_indices_reversed</code> is the result of reversing the last
 two elements of <code>indices</code>.</p>
-<div class="sourceCode" id="cb51"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb51-1"><a href="#cb51-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <em>nested-mapping-type</em> nested_mapping<span class="op">()</span> <span class="kw">const</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb55"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb55-1"><a href="#cb55-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <em>nested-mapping-type</em> nested_mapping<span class="op">()</span> <span class="kw">const</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">13</a></span>
 <em>Returns:</em> <em><code>nested-mapping</code></em></p>
-<div class="sourceCode" id="cb52"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb52-1"><a href="#cb52-1" aria-hidden="true" tabindex="-1"></a><span class="kw">static</span> <span class="kw">constexpr</span> <span class="dt">bool</span> is_always_unique<span class="op">()</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb56"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb56-1"><a href="#cb56-1" aria-hidden="true" tabindex="-1"></a><span class="kw">static</span> <span class="kw">constexpr</span> <span class="dt">bool</span> is_always_unique<span class="op">()</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">14</a></span>
 <em>Returns:</em> <em><code>nested-mapping-type</code></em>
 <code>::is_always_unique()</code></p>
-<div class="sourceCode" id="cb53"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb53-1"><a href="#cb53-1" aria-hidden="true" tabindex="-1"></a><span class="kw">static</span> <span class="kw">constexpr</span> <span class="dt">bool</span> is_always_contiguous<span class="op">()</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb57"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb57-1"><a href="#cb57-1" aria-hidden="true" tabindex="-1"></a><span class="kw">static</span> <span class="kw">constexpr</span> <span class="dt">bool</span> is_always_contiguous<span class="op">()</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">15</a></span>
 <em>Returns:</em> <em><code>nested-mapping-type</code></em>
 <code>::is_always_contiguous()</code></p>
-<div class="sourceCode" id="cb54"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb54-1"><a href="#cb54-1" aria-hidden="true" tabindex="-1"></a><span class="kw">static</span> <span class="kw">constexpr</span> <span class="dt">bool</span> is_always_strided<span class="op">()</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb58"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb58-1"><a href="#cb58-1" aria-hidden="true" tabindex="-1"></a><span class="kw">static</span> <span class="kw">constexpr</span> <span class="dt">bool</span> is_always_strided<span class="op">()</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">16</a></span>
 <em>Returns:</em> <em><code>nested-mapping-type</code></em>
 <code>::is_always_strided()</code></p>
-<div class="sourceCode" id="cb55"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb55-1"><a href="#cb55-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> is_unique<span class="op">()</span> <span class="kw">const</span></span>
-<span id="cb55-2"><a href="#cb55-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">noexcept</span><span class="op">(</span><span class="kw">noexcept</span><span class="op">(</span><em>nested-mapping</em><span class="op">.</span>is_unique<span class="op">()))</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb59"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb59-1"><a href="#cb59-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> is_unique<span class="op">()</span> <span class="kw">const</span></span>
+<span id="cb59-2"><a href="#cb59-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">noexcept</span><span class="op">(</span><span class="kw">noexcept</span><span class="op">(</span><em>nested-mapping</em><span class="op">.</span>is_unique<span class="op">()))</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">17</a></span>
 <em>Returns:</em> <em><code>nested-mapping</code></em>
 <code>.is_unique()</code></p>
-<div class="sourceCode" id="cb56"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb56-1"><a href="#cb56-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> is_contiguous<span class="op">()</span> <span class="kw">const</span></span>
-<span id="cb56-2"><a href="#cb56-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">noexcept</span><span class="op">(</span><span class="kw">noexcept</span><span class="op">(</span><em>nested-mapping</em><span class="op">.</span>is_contiguous<span class="op">()))</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb60"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb60-1"><a href="#cb60-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> is_contiguous<span class="op">()</span> <span class="kw">const</span></span>
+<span id="cb60-2"><a href="#cb60-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">noexcept</span><span class="op">(</span><span class="kw">noexcept</span><span class="op">(</span><em>nested-mapping</em><span class="op">.</span>is_contiguous<span class="op">()))</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">18</a></span>
 <em>Returns:</em> <em><code>nested-mapping</code></em>
 <code>.is_contiguous()</code></p>
-<div class="sourceCode" id="cb57"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb57-1"><a href="#cb57-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> is_strided<span class="op">()</span> <span class="kw">const</span></span>
-<span id="cb57-2"><a href="#cb57-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">noexcept</span><span class="op">(</span><span class="kw">noexcept</span><span class="op">(</span><em>nested-mapping</em><span class="op">.</span>is_strided<span class="op">()))</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb61"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb61-1"><a href="#cb61-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> is_strided<span class="op">()</span> <span class="kw">const</span></span>
+<span id="cb61-2"><a href="#cb61-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">noexcept</span><span class="op">(</span><span class="kw">noexcept</span><span class="op">(</span><em>nested-mapping</em><span class="op">.</span>is_strided<span class="op">()))</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">19</a></span>
 <em>Returns:</em> <em><code>nested-mapping</code></em>
 <code>.is_strided()</code></p>
-<div class="sourceCode" id="cb58"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb58-1"><a href="#cb58-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> size_type stride<span class="op">(</span><span class="dt">size_t</span> r<span class="op">)</span> <span class="kw">const</span></span>
-<span id="cb58-2"><a href="#cb58-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">noexcept</span><span class="op">(</span><span class="kw">noexcept</span><span class="op">(</span><em>nested-mapping</em><span class="op">.</span>stride<span class="op">(</span>r<span class="op">)))</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb62"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb62-1"><a href="#cb62-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> size_type stride<span class="op">(</span><span class="dt">size_t</span> r<span class="op">)</span> <span class="kw">const</span></span>
+<span id="cb62-2"><a href="#cb62-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">noexcept</span><span class="op">(</span><span class="kw">noexcept</span><span class="op">(</span><em>nested-mapping</em><span class="op">.</span>stride<span class="op">(</span>r<span class="op">)))</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">20</a></span>
 <em>Constraints:</em> <code>is_always_strided()</code> is
 <code>true</code>.</p>
@@ -7164,9 +7241,9 @@ Otherwise, <em><code>nested-mapping</code></em>
 Otherwise, <em><code>nested-mapping</code></em>
 <code>.stride(r)</code>.</p></li>
 </ul>
-<div class="sourceCode" id="cb59"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb59-1"><a href="#cb59-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherExtents<span class="op">&gt;</span></span>
-<span id="cb59-2"><a href="#cb59-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">friend</span> <span class="kw">constexpr</span> <span class="dt">bool</span></span>
-<span id="cb59-3"><a href="#cb59-3" aria-hidden="true" tabindex="-1"></a>    <span class="kw">operator</span><span class="op">==(</span><span class="kw">const</span> mapping<span class="op">&amp;</span>, <span class="kw">const</span> mapping<span class="op">&lt;</span>OtherExtents<span class="op">&gt;&amp;)</span> <span class="kw">noexcept</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb63"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb63-1"><a href="#cb63-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherExtents<span class="op">&gt;</span></span>
+<span id="cb63-2"><a href="#cb63-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">friend</span> <span class="kw">constexpr</span> <span class="dt">bool</span></span>
+<span id="cb63-3"><a href="#cb63-3" aria-hidden="true" tabindex="-1"></a>    <span class="kw">operator</span><span class="op">==(</span><span class="kw">const</span> mapping<span class="op">&amp;</span>, <span class="kw">const</span> mapping<span class="op">&lt;</span>OtherExtents<span class="op">&gt;&amp;)</span> <span class="kw">noexcept</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">22</a></span>
 <em>Constraints:</em></p>
 <ul>
@@ -7188,12 +7265,12 @@ representing a matrix, and returns a new <code>mdspan</code>
 representing the input matrix’s transpose. The input matrix’s data are
 not modified, and the returned <code>mdspan</code> accesses the input
 matrix’s data in place.</p>
-<div class="sourceCode" id="cb60"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb60-1"><a href="#cb60-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ElementType,</span>
-<span id="cb60-2"><a href="#cb60-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Extents,</span>
-<span id="cb60-3"><a href="#cb60-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Layout,</span>
-<span id="cb60-4"><a href="#cb60-4" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Accessor<span class="op">&gt;</span></span>
-<span id="cb60-5"><a href="#cb60-5" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> transposed<span class="op">(</span></span>
-<span id="cb60-6"><a href="#cb60-6" aria-hidden="true" tabindex="-1"></a>  mdspan<span class="op">&lt;</span>ElementType, Extents, Layout, Accessor<span class="op">&gt;</span> a<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb64"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb64-1"><a href="#cb64-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ElementType,</span>
+<span id="cb64-2"><a href="#cb64-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Extents,</span>
+<span id="cb64-3"><a href="#cb64-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Layout,</span>
+<span id="cb64-4"><a href="#cb64-4" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Accessor<span class="op">&gt;</span></span>
+<span id="cb64-5"><a href="#cb64-5" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> transposed<span class="op">(</span></span>
+<span id="cb64-6"><a href="#cb64-6" aria-hidden="true" tabindex="-1"></a>  mdspan<span class="op">&lt;</span>ElementType, Extents, Layout, Accessor<span class="op">&gt;</span> a<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">2</a></span>
 Let <code>ReturnExtents</code> be
 <em><code>transpose-extents-t</code></em><code>&lt;Extents&gt;</code>.
@@ -7285,22 +7362,84 @@ Otherwise,
 where <code>ReturnMapping</code> is
 <code>typename layout_transpose&lt;Layout&gt;::template mapping&lt;ReturnExtents&gt;</code>.</p></li>
 </ul>
-<p>[<em>Example:</em>]</p>
+<p>[<em>Example:</em></p>
+<div class="sourceCode" id="cb65"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb65-1"><a href="#cb65-1" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> test_transposed<span class="op">(</span>mdspan<span class="op">&lt;</span><span class="dt">double</span>, extents<span class="op">&lt;</span><span class="dt">size_t</span>, <span class="dv">3</span>, <span class="dv">4</span><span class="op">&gt;&gt;</span> a<span class="op">)</span></span>
+<span id="cb65-2"><a href="#cb65-2" aria-hidden="true" tabindex="-1"></a><span class="op">{</span></span>
+<span id="cb65-3"><a href="#cb65-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> <span class="kw">auto</span> num_rows <span class="op">=</span> a<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span>;</span>
+<span id="cb65-4"><a href="#cb65-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> <span class="kw">auto</span> num_cols <span class="op">=</span> a<span class="op">.</span>extent<span class="op">(</span><span class="dv">1</span><span class="op">)</span>;</span>
+<span id="cb65-5"><a href="#cb65-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb65-6"><a href="#cb65-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">auto</span> a_t <span class="op">=</span> transposed<span class="op">(</span>a<span class="op">)</span>;</span>
+<span id="cb65-7"><a href="#cb65-7" aria-hidden="true" tabindex="-1"></a>  <span class="ot">assert</span><span class="op">(</span>num_rows <span class="op">==</span> a_t<span class="op">.</span>extent<span class="op">(</span><span class="dv">1</span><span class="op">))</span>;</span>
+<span id="cb65-8"><a href="#cb65-8" aria-hidden="true" tabindex="-1"></a>  <span class="ot">assert</span><span class="op">(</span>num_cols <span class="op">==</span> a_t<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">))</span>;</span>
+<span id="cb65-9"><a href="#cb65-9" aria-hidden="true" tabindex="-1"></a>  <span class="ot">assert</span><span class="op">(</span>a<span class="op">.</span>stride<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">==</span> a_t<span class="op">.</span>stride<span class="op">(</span><span class="dv">1</span><span class="op">))</span>;</span>
+<span id="cb65-10"><a href="#cb65-10" aria-hidden="true" tabindex="-1"></a>  <span class="ot">assert</span><span class="op">(</span>a<span class="op">.</span>stride<span class="op">(</span><span class="dv">1</span><span class="op">)</span> <span class="op">==</span> a_t<span class="op">.</span>stride<span class="op">(</span><span class="dv">0</span><span class="op">))</span>;</span>
+<span id="cb65-11"><a href="#cb65-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb65-12"><a href="#cb65-12" aria-hidden="true" tabindex="-1"></a>  <span class="cf">for</span><span class="op">(</span><span class="dt">size_t</span> row <span class="op">=</span> <span class="dv">0</span>; row <span class="op">&lt;</span> num_rows; <span class="op">++</span>row<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb65-13"><a href="#cb65-13" aria-hidden="true" tabindex="-1"></a>    <span class="cf">for</span><span class="op">(</span><span class="dt">size_t</span> col <span class="op">=</span> <span class="dv">0</span>; col <span class="op">&lt;</span> num_rows; <span class="op">++</span>col<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb65-14"><a href="#cb65-14" aria-hidden="true" tabindex="-1"></a>      <span class="ot">assert</span><span class="op">(</span>a<span class="op">[</span>row, col<span class="op">]</span> <span class="op">==</span> a_t<span class="op">[</span>col, row<span class="op">])</span>;</span>
+<span id="cb65-15"><a href="#cb65-15" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb65-16"><a href="#cb65-16" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb65-17"><a href="#cb65-17" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb65-18"><a href="#cb65-18" aria-hidden="true" tabindex="-1"></a>  <span class="kw">auto</span> a_t_t <span class="op">=</span> transposed<span class="op">(</span>a_t<span class="op">)</span>;</span>
+<span id="cb65-19"><a href="#cb65-19" aria-hidden="true" tabindex="-1"></a>  <span class="ot">assert</span><span class="op">(</span>num_rows <span class="op">==</span> a_t_t<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">))</span>;</span>
+<span id="cb65-20"><a href="#cb65-20" aria-hidden="true" tabindex="-1"></a>  <span class="ot">assert</span><span class="op">(</span>num_cols <span class="op">==</span> a_t_t<span class="op">.</span>extent<span class="op">(</span><span class="dv">1</span><span class="op">))</span>;</span>
+<span id="cb65-21"><a href="#cb65-21" aria-hidden="true" tabindex="-1"></a>  <span class="ot">assert</span><span class="op">(</span>a<span class="op">.</span>stride<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">==</span> a_t_t<span class="op">.</span>stride<span class="op">(</span><span class="dv">0</span><span class="op">))</span>;</span>
+<span id="cb65-22"><a href="#cb65-22" aria-hidden="true" tabindex="-1"></a>  <span class="ot">assert</span><span class="op">(</span>a<span class="op">.</span>stride<span class="op">(</span><span class="dv">1</span><span class="op">)</span> <span class="op">==</span> a_t_t<span class="op">.</span>stride<span class="op">(</span><span class="dv">1</span><span class="op">))</span>;</span>
+<span id="cb65-23"><a href="#cb65-23" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb65-24"><a href="#cb65-24" aria-hidden="true" tabindex="-1"></a>  <span class="cf">for</span><span class="op">(</span><span class="dt">size_t</span> row <span class="op">=</span> <span class="dv">0</span>; row <span class="op">&lt;</span> num_rows; <span class="op">++</span>row<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb65-25"><a href="#cb65-25" aria-hidden="true" tabindex="-1"></a>    <span class="cf">for</span><span class="op">(</span><span class="dt">size_t</span> col <span class="op">=</span> <span class="dv">0</span>; col <span class="op">&lt;</span> num_rows; <span class="op">++</span>col<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb65-26"><a href="#cb65-26" aria-hidden="true" tabindex="-1"></a>      <span class="ot">assert</span><span class="op">(</span>a<span class="op">[</span>row, col<span class="op">]</span> <span class="op">==</span> a_t_t<span class="op">[</span>row, col<span class="op">])</span>;</span>
+<span id="cb65-27"><a href="#cb65-27" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb65-28"><a href="#cb65-28" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb65-29"><a href="#cb65-29" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<p>–<em>end example</em>]</p>
 <h3 data-number="28.9.11" id="conjugate-transpose-transform-linalg.conjtransposed"><span class="header-section-number">28.9.11</span> Conjugate transpose
 transform [linalg.conjtransposed]<a href="#conjugate-transpose-transform-linalg.conjtransposed" class="self-link"></a></h3>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 The <code>conjugate_transposed</code> function returns a conjugate
 transpose view of an object. This combines the effects of
 <code>transposed</code> and <code>conjugated</code>.</p>
-<div class="sourceCode" id="cb61"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb61-1"><a href="#cb61-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ElementType,</span>
-<span id="cb61-2"><a href="#cb61-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Extents,</span>
-<span id="cb61-3"><a href="#cb61-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Layout,</span>
-<span id="cb61-4"><a href="#cb61-4" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Accessor<span class="op">&gt;</span></span>
-<span id="cb61-5"><a href="#cb61-5" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> conjugate_transposed<span class="op">(</span></span>
-<span id="cb61-6"><a href="#cb61-6" aria-hidden="true" tabindex="-1"></a>  mdspan<span class="op">&lt;</span>ElementType, Extents, Layout, Accessor<span class="op">&gt;</span> a<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb66"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb66-1"><a href="#cb66-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ElementType,</span>
+<span id="cb66-2"><a href="#cb66-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Extents,</span>
+<span id="cb66-3"><a href="#cb66-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Layout,</span>
+<span id="cb66-4"><a href="#cb66-4" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Accessor<span class="op">&gt;</span></span>
+<span id="cb66-5"><a href="#cb66-5" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> conjugate_transposed<span class="op">(</span></span>
+<span id="cb66-6"><a href="#cb66-6" aria-hidden="true" tabindex="-1"></a>  mdspan<span class="op">&lt;</span>ElementType, Extents, Layout, Accessor<span class="op">&gt;</span> a<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">2</a></span>
 <em>Returns:</em> <code>conjugated(transposed(a))</code></p>
-<p>[<em>Example:</em>]</p>
+<p>[<em>Example:</em></p>
+<div class="sourceCode" id="cb67"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb67-1"><a href="#cb67-1" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> test_conjugate_transposed<span class="op">(</span></span>
+<span id="cb67-2"><a href="#cb67-2" aria-hidden="true" tabindex="-1"></a>  mdspan<span class="op">&lt;</span>complex<span class="op">&lt;</span><span class="dt">double</span><span class="op">&gt;</span>, extents<span class="op">&lt;</span><span class="dt">size_t</span>, <span class="dv">3</span>, <span class="dv">4</span><span class="op">&gt;&gt;</span> a<span class="op">)</span></span>
+<span id="cb67-3"><a href="#cb67-3" aria-hidden="true" tabindex="-1"></a><span class="op">{</span></span>
+<span id="cb67-4"><a href="#cb67-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> <span class="kw">auto</span> num_rows <span class="op">=</span> a<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span>;</span>
+<span id="cb67-5"><a href="#cb67-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> <span class="kw">auto</span> num_cols <span class="op">=</span> a<span class="op">.</span>extent<span class="op">(</span><span class="dv">1</span><span class="op">)</span>;</span>
+<span id="cb67-6"><a href="#cb67-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb67-7"><a href="#cb67-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">auto</span> a_ct <span class="op">=</span> conjugate_transposed<span class="op">(</span>a<span class="op">)</span>;</span>
+<span id="cb67-8"><a href="#cb67-8" aria-hidden="true" tabindex="-1"></a>  <span class="ot">assert</span><span class="op">(</span>num_rows <span class="op">==</span> a_ct<span class="op">.</span>extent<span class="op">(</span><span class="dv">1</span><span class="op">))</span>;</span>
+<span id="cb67-9"><a href="#cb67-9" aria-hidden="true" tabindex="-1"></a>  <span class="ot">assert</span><span class="op">(</span>num_cols <span class="op">==</span> a_ct<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">))</span>;</span>
+<span id="cb67-10"><a href="#cb67-10" aria-hidden="true" tabindex="-1"></a>  <span class="ot">assert</span><span class="op">(</span>a<span class="op">.</span>stride<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">==</span> a_ct<span class="op">.</span>stride<span class="op">(</span><span class="dv">1</span><span class="op">))</span>;</span>
+<span id="cb67-11"><a href="#cb67-11" aria-hidden="true" tabindex="-1"></a>  <span class="ot">assert</span><span class="op">(</span>a<span class="op">.</span>stride<span class="op">(</span><span class="dv">1</span><span class="op">)</span> <span class="op">==</span> a_ct<span class="op">.</span>stride<span class="op">(</span><span class="dv">0</span><span class="op">))</span>;</span>
+<span id="cb67-12"><a href="#cb67-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb67-13"><a href="#cb67-13" aria-hidden="true" tabindex="-1"></a>  <span class="cf">for</span><span class="op">(</span><span class="dt">size_t</span> row <span class="op">=</span> <span class="dv">0</span>; row <span class="op">&lt;</span> num_rows; <span class="op">++</span>row<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb67-14"><a href="#cb67-14" aria-hidden="true" tabindex="-1"></a>    <span class="cf">for</span><span class="op">(</span><span class="dt">size_t</span> col <span class="op">=</span> <span class="dv">0</span>; col <span class="op">&lt;</span> num_rows; <span class="op">++</span>col<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb67-15"><a href="#cb67-15" aria-hidden="true" tabindex="-1"></a>      <span class="ot">assert</span><span class="op">(</span>a<span class="op">[</span>row, col<span class="op">]</span> <span class="op">==</span> conj<span class="op">(</span>a_ct<span class="op">[</span>col, row<span class="op">]))</span>;</span>
+<span id="cb67-16"><a href="#cb67-16" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb67-17"><a href="#cb67-17" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb67-18"><a href="#cb67-18" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb67-19"><a href="#cb67-19" aria-hidden="true" tabindex="-1"></a>  <span class="kw">auto</span> a_ct_ct <span class="op">=</span> conjugate_transposed<span class="op">(</span>a_ct<span class="op">)</span>;</span>
+<span id="cb67-20"><a href="#cb67-20" aria-hidden="true" tabindex="-1"></a>  <span class="ot">assert</span><span class="op">(</span>num_rows <span class="op">==</span> a_ct_ct<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">))</span>;</span>
+<span id="cb67-21"><a href="#cb67-21" aria-hidden="true" tabindex="-1"></a>  <span class="ot">assert</span><span class="op">(</span>num_cols <span class="op">==</span> a_ct_ct<span class="op">.</span>extent<span class="op">(</span><span class="dv">1</span><span class="op">))</span>;</span>
+<span id="cb67-22"><a href="#cb67-22" aria-hidden="true" tabindex="-1"></a>  <span class="ot">assert</span><span class="op">(</span>a<span class="op">.</span>stride<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">==</span> a_ct_ct<span class="op">.</span>stride<span class="op">(</span><span class="dv">0</span><span class="op">))</span>;</span>
+<span id="cb67-23"><a href="#cb67-23" aria-hidden="true" tabindex="-1"></a>  <span class="ot">assert</span><span class="op">(</span>a<span class="op">.</span>stride<span class="op">(</span><span class="dv">1</span><span class="op">)</span> <span class="op">==</span> a_ct_ct<span class="op">.</span>stride<span class="op">(</span><span class="dv">1</span><span class="op">))</span>;</span>
+<span id="cb67-24"><a href="#cb67-24" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb67-25"><a href="#cb67-25" aria-hidden="true" tabindex="-1"></a>  <span class="cf">for</span><span class="op">(</span><span class="dt">size_t</span> row <span class="op">=</span> <span class="dv">0</span>; row <span class="op">&lt;</span> num_rows; <span class="op">++</span>row<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb67-26"><a href="#cb67-26" aria-hidden="true" tabindex="-1"></a>    <span class="cf">for</span><span class="op">(</span><span class="dt">size_t</span> col <span class="op">=</span> <span class="dv">0</span>; col <span class="op">&lt;</span> num_rows; <span class="op">++</span>col<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb67-27"><a href="#cb67-27" aria-hidden="true" tabindex="-1"></a>      <span class="ot">assert</span><span class="op">(</span>a<span class="op">[</span>row, col<span class="op">]</span> <span class="op">==</span> a_ct_ct<span class="op">[</span>row, col<span class="op">])</span>;</span>
+<span id="cb67-28"><a href="#cb67-28" aria-hidden="true" tabindex="-1"></a>      <span class="ot">assert</span><span class="op">(</span>conj<span class="op">(</span>a_ct<span class="op">[</span>col, row<span class="op">])</span> <span class="op">==</span> a_ct_ct<span class="op">[</span>row, col<span class="op">])</span>;</span>
+<span id="cb67-29"><a href="#cb67-29" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb67-30"><a href="#cb67-30" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb67-31"><a href="#cb67-31" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<p>–<em>end example</em>]</p>
 <h3 data-number="28.9.12" id="algorithm-requirements-based-on-template-parameter-name-linalg.algs.reqs"><span class="header-section-number">28.9.12</span> Algorithm Requirements
 based on template parameter name [linalg.algs.reqs]<a href="#algorithm-requirements-based-on-template-parameter-name-linalg.algs.reqs" class="self-link"></a></h3>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
@@ -7342,20 +7481,20 @@ product of extents of any <code>mdspan</code> parameter.</p>
 [linalg.algs.blas1.givens]<a href="#givens-rotations-linalg.algs.blas1.givens" class="self-link"></a></h4>
 <h5 data-number="28.9.13.2.1" id="compute-givens-rotation-linalg.algs.blas1.givens.lartg"><span class="header-section-number">28.9.13.2.1</span> Compute Givens rotation
 [linalg.algs.blas1.givens.lartg]<a href="#compute-givens-rotation-linalg.algs.blas1.givens.lartg" class="self-link"></a></h5>
-<div class="sourceCode" id="cb62"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb62-1"><a href="#cb62-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Real<span class="op">&gt;</span></span>
-<span id="cb62-2"><a href="#cb62-2" aria-hidden="true" tabindex="-1"></a>givens_rotation_setup_result<span class="op">&lt;</span>Real<span class="op">&gt;</span></span>
-<span id="cb62-3"><a href="#cb62-3" aria-hidden="true" tabindex="-1"></a>givens_rotation_setup<span class="op">(</span>Real a, Real b<span class="op">)</span> <span class="kw">noexcept</span>;</span>
-<span id="cb62-4"><a href="#cb62-4" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Real<span class="op">&gt;</span></span>
-<span id="cb62-5"><a href="#cb62-5" aria-hidden="true" tabindex="-1"></a>givens_rotation_setup_result<span class="op">&lt;</span>complex<span class="op">&lt;</span>Real<span class="op">&gt;&gt;</span></span>
-<span id="cb62-6"><a href="#cb62-6" aria-hidden="true" tabindex="-1"></a>givens_rotation_setup<span class="op">(</span>complex<span class="op">&lt;</span>Real<span class="op">&gt;</span> a, complex<span class="op">&lt;</span>Real<span class="op">&gt;</span> b<span class="op">)</span> <span class="kw">noexcept</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb68"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb68-1"><a href="#cb68-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Real<span class="op">&gt;</span></span>
+<span id="cb68-2"><a href="#cb68-2" aria-hidden="true" tabindex="-1"></a>givens_rotation_setup_result<span class="op">&lt;</span>Real<span class="op">&gt;</span></span>
+<span id="cb68-3"><a href="#cb68-3" aria-hidden="true" tabindex="-1"></a>givens_rotation_setup<span class="op">(</span>Real a, Real b<span class="op">)</span> <span class="kw">noexcept</span>;</span>
+<span id="cb68-4"><a href="#cb68-4" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Real<span class="op">&gt;</span></span>
+<span id="cb68-5"><a href="#cb68-5" aria-hidden="true" tabindex="-1"></a>givens_rotation_setup_result<span class="op">&lt;</span>complex<span class="op">&lt;</span>Real<span class="op">&gt;&gt;</span></span>
+<span id="cb68-6"><a href="#cb68-6" aria-hidden="true" tabindex="-1"></a>givens_rotation_setup<span class="op">(</span>complex<span class="op">&lt;</span>Real<span class="op">&gt;</span> a, complex<span class="op">&lt;</span>Real<span class="op">&gt;</span> b<span class="op">)</span> <span class="kw">noexcept</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 This function computes the plane (Givens) rotation represented by the
 two values <code>c</code> and <code>s</code> such that the 2x2 system of
 equations <i>[Note:</i> use of monospaced text in this equation does not
 indicate C++ code <i>– end note]</i></p>
-<div class="sourceCode" id="cb63"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb63-1"><a href="#cb63-1" aria-hidden="true" tabindex="-1"></a>[c        s]   [a]   [r]</span>
-<span id="cb63-2"><a href="#cb63-2" aria-hidden="true" tabindex="-1"></a>[          ] * [ ] = [ ]</span>
-<span id="cb63-3"><a href="#cb63-3" aria-hidden="true" tabindex="-1"></a>[-conj(s) c]   [b]   [0]</span></code></pre></div>
+<div class="sourceCode" id="cb69"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb69-1"><a href="#cb69-1" aria-hidden="true" tabindex="-1"></a>[c        s]   [a]   [r]</span>
+<span id="cb69-2"><a href="#cb69-2" aria-hidden="true" tabindex="-1"></a>[          ] * [ ] = [ ]</span>
+<span id="cb69-3"><a href="#cb69-3" aria-hidden="true" tabindex="-1"></a>[-conj(s) c]   [b]   [0]</span></code></pre></div>
 <p>holds, where <code>c</code> is always a real scalar, and
 <code>c*c +</code> <em><code>abs-if-needed</code></em>
 <code>(s) *</code> <em><code>abs-if-needed</code></em> <code>(s)</code>
@@ -7383,45 +7522,45 @@ Euclidean norm of the two-component vector formed by <code>a</code> and
 <code>b</code>.</p>
 <h5 data-number="28.9.13.2.2" id="apply-a-computed-givens-rotation-to-vectors-linalg.algs.blas1.givens.rot"><span class="header-section-number">28.9.13.2.2</span> Apply a computed Givens
 rotation to vectors [linalg.algs.blas1.givens.rot]<a href="#apply-a-computed-givens-rotation-to-vectors-linalg.algs.blas1.givens.rot" class="self-link"></a></h5>
-<div class="sourceCode" id="cb64"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb64-1"><a href="#cb64-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>inout-vector</em> InOutVec1,</span>
-<span id="cb64-2"><a href="#cb64-2" aria-hidden="true" tabindex="-1"></a>         <em>inout-vector</em> InOutVec2,</span>
-<span id="cb64-3"><a href="#cb64-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Real<span class="op">&gt;</span></span>
-<span id="cb64-4"><a href="#cb64-4" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> givens_rotation_apply<span class="op">(</span></span>
-<span id="cb64-5"><a href="#cb64-5" aria-hidden="true" tabindex="-1"></a>  InOutVec1 x,</span>
-<span id="cb64-6"><a href="#cb64-6" aria-hidden="true" tabindex="-1"></a>  InOutVec2 y,</span>
-<span id="cb64-7"><a href="#cb64-7" aria-hidden="true" tabindex="-1"></a>  Real c,</span>
-<span id="cb64-8"><a href="#cb64-8" aria-hidden="true" tabindex="-1"></a>  Real s<span class="op">)</span>;</span>
-<span id="cb64-9"><a href="#cb64-9" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb64-10"><a href="#cb64-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb64-11"><a href="#cb64-11" aria-hidden="true" tabindex="-1"></a>         <em>inout-vector</em> InOutVec1,</span>
-<span id="cb64-12"><a href="#cb64-12" aria-hidden="true" tabindex="-1"></a>         <em>inout-vector</em> InOutVec2,</span>
-<span id="cb64-13"><a href="#cb64-13" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Real<span class="op">&gt;</span></span>
-<span id="cb64-14"><a href="#cb64-14" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> givens_rotation_apply<span class="op">(</span></span>
-<span id="cb64-15"><a href="#cb64-15" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb64-16"><a href="#cb64-16" aria-hidden="true" tabindex="-1"></a>  InOutVec1 x,</span>
-<span id="cb64-17"><a href="#cb64-17" aria-hidden="true" tabindex="-1"></a>  InOutVec2 y,</span>
-<span id="cb64-18"><a href="#cb64-18" aria-hidden="true" tabindex="-1"></a>  Real c,</span>
-<span id="cb64-19"><a href="#cb64-19" aria-hidden="true" tabindex="-1"></a>  Real s<span class="op">)</span>;</span>
-<span id="cb64-20"><a href="#cb64-20" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb64-21"><a href="#cb64-21" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>inout-vector</em> InOutVec1,</span>
-<span id="cb64-22"><a href="#cb64-22" aria-hidden="true" tabindex="-1"></a>         <em>inout-vector</em> InOutVec2,</span>
-<span id="cb64-23"><a href="#cb64-23" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Real<span class="op">&gt;</span></span>
-<span id="cb64-24"><a href="#cb64-24" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> givens_rotation_apply<span class="op">(</span></span>
-<span id="cb64-25"><a href="#cb64-25" aria-hidden="true" tabindex="-1"></a>  InOutVec1 x,</span>
-<span id="cb64-26"><a href="#cb64-26" aria-hidden="true" tabindex="-1"></a>  InOutVec2 y,</span>
-<span id="cb64-27"><a href="#cb64-27" aria-hidden="true" tabindex="-1"></a>  Real c,</span>
-<span id="cb64-28"><a href="#cb64-28" aria-hidden="true" tabindex="-1"></a>  complex<span class="op">&lt;</span>Real<span class="op">&gt;</span> s<span class="op">)</span>;</span>
-<span id="cb64-29"><a href="#cb64-29" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb64-30"><a href="#cb64-30" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb64-31"><a href="#cb64-31" aria-hidden="true" tabindex="-1"></a>         <em>inout-vector</em> InOutVec1,</span>
-<span id="cb64-32"><a href="#cb64-32" aria-hidden="true" tabindex="-1"></a>         <em>inout-vector</em> InOutVec2,</span>
-<span id="cb64-33"><a href="#cb64-33" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Real<span class="op">&gt;</span></span>
-<span id="cb64-34"><a href="#cb64-34" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> givens_rotation_apply<span class="op">(</span></span>
-<span id="cb64-35"><a href="#cb64-35" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb64-36"><a href="#cb64-36" aria-hidden="true" tabindex="-1"></a>  InOutVec1 x,</span>
-<span id="cb64-37"><a href="#cb64-37" aria-hidden="true" tabindex="-1"></a>  InOutVec2 y,</span>
-<span id="cb64-38"><a href="#cb64-38" aria-hidden="true" tabindex="-1"></a>  Real c,</span>
-<span id="cb64-39"><a href="#cb64-39" aria-hidden="true" tabindex="-1"></a>  complex<span class="op">&lt;</span>Real<span class="op">&gt;</span> s<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb70"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb70-1"><a href="#cb70-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>inout-vector</em> InOutVec1,</span>
+<span id="cb70-2"><a href="#cb70-2" aria-hidden="true" tabindex="-1"></a>         <em>inout-vector</em> InOutVec2,</span>
+<span id="cb70-3"><a href="#cb70-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Real<span class="op">&gt;</span></span>
+<span id="cb70-4"><a href="#cb70-4" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> givens_rotation_apply<span class="op">(</span></span>
+<span id="cb70-5"><a href="#cb70-5" aria-hidden="true" tabindex="-1"></a>  InOutVec1 x,</span>
+<span id="cb70-6"><a href="#cb70-6" aria-hidden="true" tabindex="-1"></a>  InOutVec2 y,</span>
+<span id="cb70-7"><a href="#cb70-7" aria-hidden="true" tabindex="-1"></a>  Real c,</span>
+<span id="cb70-8"><a href="#cb70-8" aria-hidden="true" tabindex="-1"></a>  Real s<span class="op">)</span>;</span>
+<span id="cb70-9"><a href="#cb70-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb70-10"><a href="#cb70-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb70-11"><a href="#cb70-11" aria-hidden="true" tabindex="-1"></a>         <em>inout-vector</em> InOutVec1,</span>
+<span id="cb70-12"><a href="#cb70-12" aria-hidden="true" tabindex="-1"></a>         <em>inout-vector</em> InOutVec2,</span>
+<span id="cb70-13"><a href="#cb70-13" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Real<span class="op">&gt;</span></span>
+<span id="cb70-14"><a href="#cb70-14" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> givens_rotation_apply<span class="op">(</span></span>
+<span id="cb70-15"><a href="#cb70-15" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb70-16"><a href="#cb70-16" aria-hidden="true" tabindex="-1"></a>  InOutVec1 x,</span>
+<span id="cb70-17"><a href="#cb70-17" aria-hidden="true" tabindex="-1"></a>  InOutVec2 y,</span>
+<span id="cb70-18"><a href="#cb70-18" aria-hidden="true" tabindex="-1"></a>  Real c,</span>
+<span id="cb70-19"><a href="#cb70-19" aria-hidden="true" tabindex="-1"></a>  Real s<span class="op">)</span>;</span>
+<span id="cb70-20"><a href="#cb70-20" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb70-21"><a href="#cb70-21" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>inout-vector</em> InOutVec1,</span>
+<span id="cb70-22"><a href="#cb70-22" aria-hidden="true" tabindex="-1"></a>         <em>inout-vector</em> InOutVec2,</span>
+<span id="cb70-23"><a href="#cb70-23" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Real<span class="op">&gt;</span></span>
+<span id="cb70-24"><a href="#cb70-24" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> givens_rotation_apply<span class="op">(</span></span>
+<span id="cb70-25"><a href="#cb70-25" aria-hidden="true" tabindex="-1"></a>  InOutVec1 x,</span>
+<span id="cb70-26"><a href="#cb70-26" aria-hidden="true" tabindex="-1"></a>  InOutVec2 y,</span>
+<span id="cb70-27"><a href="#cb70-27" aria-hidden="true" tabindex="-1"></a>  Real c,</span>
+<span id="cb70-28"><a href="#cb70-28" aria-hidden="true" tabindex="-1"></a>  complex<span class="op">&lt;</span>Real<span class="op">&gt;</span> s<span class="op">)</span>;</span>
+<span id="cb70-29"><a href="#cb70-29" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb70-30"><a href="#cb70-30" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb70-31"><a href="#cb70-31" aria-hidden="true" tabindex="-1"></a>         <em>inout-vector</em> InOutVec1,</span>
+<span id="cb70-32"><a href="#cb70-32" aria-hidden="true" tabindex="-1"></a>         <em>inout-vector</em> InOutVec2,</span>
+<span id="cb70-33"><a href="#cb70-33" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Real<span class="op">&gt;</span></span>
+<span id="cb70-34"><a href="#cb70-34" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> givens_rotation_apply<span class="op">(</span></span>
+<span id="cb70-35"><a href="#cb70-35" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb70-36"><a href="#cb70-36" aria-hidden="true" tabindex="-1"></a>  InOutVec1 x,</span>
+<span id="cb70-37"><a href="#cb70-37" aria-hidden="true" tabindex="-1"></a>  InOutVec2 y,</span>
+<span id="cb70-38"><a href="#cb70-38" aria-hidden="true" tabindex="-1"></a>  Real c,</span>
+<span id="cb70-39"><a href="#cb70-39" aria-hidden="true" tabindex="-1"></a>  complex<span class="op">&lt;</span>Real<span class="op">&gt;</span> s<span class="op">)</span>;</span></code></pre></div>
 <p><i>[Note:</i> These functions correspond to the BLAS function
 <code>xROT</code>. <i>– end note]</i></p>
 <!--
@@ -7453,17 +7592,17 @@ and <code>y</code>, as if the rotation were a 2 x 2 matrix and the input
 vectors were successive rows of a matrix with two rows.</p>
 <h4 data-number="28.9.13.3" id="swap-matrix-or-vector-elements-linalg.algs.blas1.swap"><span class="header-section-number">28.9.13.3</span> Swap matrix or vector
 elements [linalg.algs.blas1.swap]<a href="#swap-matrix-or-vector-elements-linalg.algs.blas1.swap" class="self-link"></a></h4>
-<div class="sourceCode" id="cb65"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb65-1"><a href="#cb65-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>inout-object</em> InOutObj1,</span>
-<span id="cb65-2"><a href="#cb65-2" aria-hidden="true" tabindex="-1"></a>         <em>inout-object</em> InOutObj2<span class="op">&gt;</span></span>
-<span id="cb65-3"><a href="#cb65-3" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> swap_elements<span class="op">(</span>InOutObj1 x,</span>
-<span id="cb65-4"><a href="#cb65-4" aria-hidden="true" tabindex="-1"></a>                   InOutObj2 y<span class="op">)</span>;</span>
-<span id="cb65-5"><a href="#cb65-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb65-6"><a href="#cb65-6" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb65-7"><a href="#cb65-7" aria-hidden="true" tabindex="-1"></a>         <em>inout-object</em> InOutObj1,</span>
-<span id="cb65-8"><a href="#cb65-8" aria-hidden="true" tabindex="-1"></a>         <em>inout-object</em> InOutObj2<span class="op">&gt;</span></span>
-<span id="cb65-9"><a href="#cb65-9" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> swap_elements<span class="op">(</span>ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb65-10"><a href="#cb65-10" aria-hidden="true" tabindex="-1"></a>                   InOutObj1 x,</span>
-<span id="cb65-11"><a href="#cb65-11" aria-hidden="true" tabindex="-1"></a>                   InOutObj2 y<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb71"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb71-1"><a href="#cb71-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>inout-object</em> InOutObj1,</span>
+<span id="cb71-2"><a href="#cb71-2" aria-hidden="true" tabindex="-1"></a>         <em>inout-object</em> InOutObj2<span class="op">&gt;</span></span>
+<span id="cb71-3"><a href="#cb71-3" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> swap_elements<span class="op">(</span>InOutObj1 x,</span>
+<span id="cb71-4"><a href="#cb71-4" aria-hidden="true" tabindex="-1"></a>                   InOutObj2 y<span class="op">)</span>;</span>
+<span id="cb71-5"><a href="#cb71-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb71-6"><a href="#cb71-6" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb71-7"><a href="#cb71-7" aria-hidden="true" tabindex="-1"></a>         <em>inout-object</em> InOutObj1,</span>
+<span id="cb71-8"><a href="#cb71-8" aria-hidden="true" tabindex="-1"></a>         <em>inout-object</em> InOutObj2<span class="op">&gt;</span></span>
+<span id="cb71-9"><a href="#cb71-9" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> swap_elements<span class="op">(</span>ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb71-10"><a href="#cb71-10" aria-hidden="true" tabindex="-1"></a>                   InOutObj1 x,</span>
+<span id="cb71-11"><a href="#cb71-11" aria-hidden="true" tabindex="-1"></a>                   InOutObj2 y<span class="op">)</span>;</span></code></pre></div>
 <p><i>[Note:</i> These functions correspond to the BLAS function
 <code>xSWAP</code>. <i>– end note]</i></p>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
@@ -7482,17 +7621,17 @@ is <code>true</code>.</p>
 <code>y</code>.</p>
 <h4 data-number="28.9.13.4" id="multiply-the-elements-of-an-object-in-place-by-a-scalar-linalg.algs.blas1.scal"><span class="header-section-number">28.9.13.4</span> Multiply the elements of
 an object in place by a scalar [linalg.algs.blas1.scal]<a href="#multiply-the-elements-of-an-object-in-place-by-a-scalar-linalg.algs.blas1.scal" class="self-link"></a></h4>
-<div class="sourceCode" id="cb66"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb66-1"><a href="#cb66-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Scalar,</span>
-<span id="cb66-2"><a href="#cb66-2" aria-hidden="true" tabindex="-1"></a>         <em>inout-object</em> InOutObj<span class="op">&gt;</span></span>
-<span id="cb66-3"><a href="#cb66-3" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> scale<span class="op">(</span>Scalar alpha,</span>
-<span id="cb66-4"><a href="#cb66-4" aria-hidden="true" tabindex="-1"></a>           InOutObj x<span class="op">)</span>;</span>
-<span id="cb66-5"><a href="#cb66-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb66-6"><a href="#cb66-6" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb66-7"><a href="#cb66-7" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar,</span>
-<span id="cb66-8"><a href="#cb66-8" aria-hidden="true" tabindex="-1"></a>         <em>inout-object</em> InOutObj<span class="op">&gt;</span></span>
-<span id="cb66-9"><a href="#cb66-9" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> scale<span class="op">(</span>ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb66-10"><a href="#cb66-10" aria-hidden="true" tabindex="-1"></a>           Scalar alpha,</span>
-<span id="cb66-11"><a href="#cb66-11" aria-hidden="true" tabindex="-1"></a>           InOutObj x<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb72"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb72-1"><a href="#cb72-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Scalar,</span>
+<span id="cb72-2"><a href="#cb72-2" aria-hidden="true" tabindex="-1"></a>         <em>inout-object</em> InOutObj<span class="op">&gt;</span></span>
+<span id="cb72-3"><a href="#cb72-3" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> scale<span class="op">(</span>Scalar alpha,</span>
+<span id="cb72-4"><a href="#cb72-4" aria-hidden="true" tabindex="-1"></a>           InOutObj x<span class="op">)</span>;</span>
+<span id="cb72-5"><a href="#cb72-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb72-6"><a href="#cb72-6" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb72-7"><a href="#cb72-7" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar,</span>
+<span id="cb72-8"><a href="#cb72-8" aria-hidden="true" tabindex="-1"></a>         <em>inout-object</em> InOutObj<span class="op">&gt;</span></span>
+<span id="cb72-9"><a href="#cb72-9" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> scale<span class="op">(</span>ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb72-10"><a href="#cb72-10" aria-hidden="true" tabindex="-1"></a>           Scalar alpha,</span>
+<span id="cb72-11"><a href="#cb72-11" aria-hidden="true" tabindex="-1"></a>           InOutObj x<span class="op">)</span>;</span></code></pre></div>
 <p><i>[Note:</i> These functions correspond to the BLAS function
 <code>xSCAL</code>. <i>– end note]</i></p>
 <p><span class="marginalizedparent"><a class="marginalized">5</a></span>
@@ -7500,17 +7639,17 @@ an object in place by a scalar [linalg.algs.blas1.scal]<a href="#multiply-the-el
 with the result of computing the elementwise multiplication <span class="math inline"><em>α</em><em>x</em></span>, where the scalar <span class="math inline"><em>α</em></span> is <code>alpha</code>.</p>
 <h4 data-number="28.9.13.5" id="copy-elements-of-one-matrix-or-vector-into-another-linalg.algs.blas1.copy"><span class="header-section-number">28.9.13.5</span> Copy elements of one
 matrix or vector into another [linalg.algs.blas1.copy]<a href="#copy-elements-of-one-matrix-or-vector-into-another-linalg.algs.blas1.copy" class="self-link"></a></h4>
-<div class="sourceCode" id="cb67"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb67-1"><a href="#cb67-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-object</em> InObj,</span>
-<span id="cb67-2"><a href="#cb67-2" aria-hidden="true" tabindex="-1"></a>         <em>out-object</em> OutObj<span class="op">&gt;</span></span>
-<span id="cb67-3"><a href="#cb67-3" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> copy<span class="op">(</span>InObj x,</span>
-<span id="cb67-4"><a href="#cb67-4" aria-hidden="true" tabindex="-1"></a>          OutObj y<span class="op">)</span>;</span>
-<span id="cb67-5"><a href="#cb67-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb67-6"><a href="#cb67-6" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb67-7"><a href="#cb67-7" aria-hidden="true" tabindex="-1"></a>         <em>in-object</em> InObj,</span>
-<span id="cb67-8"><a href="#cb67-8" aria-hidden="true" tabindex="-1"></a>         <em>out-object</em> OutObj<span class="op">&gt;</span></span>
-<span id="cb67-9"><a href="#cb67-9" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> copy<span class="op">(</span>ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb67-10"><a href="#cb67-10" aria-hidden="true" tabindex="-1"></a>          InObj x,</span>
-<span id="cb67-11"><a href="#cb67-11" aria-hidden="true" tabindex="-1"></a>          OutObj y<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb73"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb73-1"><a href="#cb73-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-object</em> InObj,</span>
+<span id="cb73-2"><a href="#cb73-2" aria-hidden="true" tabindex="-1"></a>         <em>out-object</em> OutObj<span class="op">&gt;</span></span>
+<span id="cb73-3"><a href="#cb73-3" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> copy<span class="op">(</span>InObj x,</span>
+<span id="cb73-4"><a href="#cb73-4" aria-hidden="true" tabindex="-1"></a>          OutObj y<span class="op">)</span>;</span>
+<span id="cb73-5"><a href="#cb73-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb73-6"><a href="#cb73-6" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb73-7"><a href="#cb73-7" aria-hidden="true" tabindex="-1"></a>         <em>in-object</em> InObj,</span>
+<span id="cb73-8"><a href="#cb73-8" aria-hidden="true" tabindex="-1"></a>         <em>out-object</em> OutObj<span class="op">&gt;</span></span>
+<span id="cb73-9"><a href="#cb73-9" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> copy<span class="op">(</span>ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb73-10"><a href="#cb73-10" aria-hidden="true" tabindex="-1"></a>          InObj x,</span>
+<span id="cb73-11"><a href="#cb73-11" aria-hidden="true" tabindex="-1"></a>          OutObj y<span class="op">)</span>;</span></code></pre></div>
 <p><i>[Note:</i> These functions correspond to the BLAS function
 <code>xCOPY</code>. <i>– end note]</i></p>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
@@ -7529,21 +7668,21 @@ is <code>true</code>.</p>
 <span class="math inline"><em>y</em></span>.</p>
 <h4 data-number="28.9.13.6" id="add-vectors-or-matrices-elementwise-linalg.algs.blas1.add"><span class="header-section-number">28.9.13.6</span> Add vectors or matrices
 elementwise [linalg.algs.blas1.add]<a href="#add-vectors-or-matrices-elementwise-linalg.algs.blas1.add" class="self-link"></a></h4>
-<div class="sourceCode" id="cb68"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb68-1"><a href="#cb68-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-object</em> InObj1,</span>
-<span id="cb68-2"><a href="#cb68-2" aria-hidden="true" tabindex="-1"></a>         <em>in-object</em> InObj2,</span>
-<span id="cb68-3"><a href="#cb68-3" aria-hidden="true" tabindex="-1"></a>         <em>out-object</em> OutObj<span class="op">&gt;</span></span>
-<span id="cb68-4"><a href="#cb68-4" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> add<span class="op">(</span>InObj1 x,</span>
-<span id="cb68-5"><a href="#cb68-5" aria-hidden="true" tabindex="-1"></a>         InObj2 y,</span>
-<span id="cb68-6"><a href="#cb68-6" aria-hidden="true" tabindex="-1"></a>         OutObj z<span class="op">)</span>;</span>
-<span id="cb68-7"><a href="#cb68-7" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb68-8"><a href="#cb68-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb68-9"><a href="#cb68-9" aria-hidden="true" tabindex="-1"></a>         <em>in-object</em> InObj1,</span>
-<span id="cb68-10"><a href="#cb68-10" aria-hidden="true" tabindex="-1"></a>         <em>in-object</em> InObj2,</span>
-<span id="cb68-11"><a href="#cb68-11" aria-hidden="true" tabindex="-1"></a>         <em>out-object</em> OutObj<span class="op">&gt;</span></span>
-<span id="cb68-12"><a href="#cb68-12" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> add<span class="op">(</span>ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb68-13"><a href="#cb68-13" aria-hidden="true" tabindex="-1"></a>         InObj1 x,</span>
-<span id="cb68-14"><a href="#cb68-14" aria-hidden="true" tabindex="-1"></a>         InObj2 y,</span>
-<span id="cb68-15"><a href="#cb68-15" aria-hidden="true" tabindex="-1"></a>         OutObj z<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb74"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb74-1"><a href="#cb74-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-object</em> InObj1,</span>
+<span id="cb74-2"><a href="#cb74-2" aria-hidden="true" tabindex="-1"></a>         <em>in-object</em> InObj2,</span>
+<span id="cb74-3"><a href="#cb74-3" aria-hidden="true" tabindex="-1"></a>         <em>out-object</em> OutObj<span class="op">&gt;</span></span>
+<span id="cb74-4"><a href="#cb74-4" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> add<span class="op">(</span>InObj1 x,</span>
+<span id="cb74-5"><a href="#cb74-5" aria-hidden="true" tabindex="-1"></a>         InObj2 y,</span>
+<span id="cb74-6"><a href="#cb74-6" aria-hidden="true" tabindex="-1"></a>         OutObj z<span class="op">)</span>;</span>
+<span id="cb74-7"><a href="#cb74-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb74-8"><a href="#cb74-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb74-9"><a href="#cb74-9" aria-hidden="true" tabindex="-1"></a>         <em>in-object</em> InObj1,</span>
+<span id="cb74-10"><a href="#cb74-10" aria-hidden="true" tabindex="-1"></a>         <em>in-object</em> InObj2,</span>
+<span id="cb74-11"><a href="#cb74-11" aria-hidden="true" tabindex="-1"></a>         <em>out-object</em> OutObj<span class="op">&gt;</span></span>
+<span id="cb74-12"><a href="#cb74-12" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> add<span class="op">(</span>ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb74-13"><a href="#cb74-13" aria-hidden="true" tabindex="-1"></a>         InObj1 x,</span>
+<span id="cb74-14"><a href="#cb74-14" aria-hidden="true" tabindex="-1"></a>         InObj2 y,</span>
+<span id="cb74-15"><a href="#cb74-15" aria-hidden="true" tabindex="-1"></a>         OutObj z<span class="op">)</span>;</span></code></pre></div>
 <p><i>[Note:</i> These functions correspond to the BLAS function
 <code>xAXPY</code>. <i>– end note]</i></p>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
@@ -7587,20 +7726,20 @@ functions <code>xDOT</code> (for real element types) and
 <code>xDOTU</code> (for complex element types). <i>– end note]</i></p>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 Nonconjugated dot product with specified result type</p>
-<div class="sourceCode" id="cb69"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb69-1"><a href="#cb69-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-vector</em> InVec1,</span>
-<span id="cb69-2"><a href="#cb69-2" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2,</span>
-<span id="cb69-3"><a href="#cb69-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar<span class="op">&gt;</span></span>
-<span id="cb69-4"><a href="#cb69-4" aria-hidden="true" tabindex="-1"></a>Scalar dot<span class="op">(</span>InVec1 v1,</span>
-<span id="cb69-5"><a href="#cb69-5" aria-hidden="true" tabindex="-1"></a>           InVec2 v2,</span>
-<span id="cb69-6"><a href="#cb69-6" aria-hidden="true" tabindex="-1"></a>           Scalar init<span class="op">)</span>;</span>
-<span id="cb69-7"><a href="#cb69-7" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb69-8"><a href="#cb69-8" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec1,</span>
-<span id="cb69-9"><a href="#cb69-9" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2,</span>
-<span id="cb69-10"><a href="#cb69-10" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar<span class="op">&gt;</span></span>
-<span id="cb69-11"><a href="#cb69-11" aria-hidden="true" tabindex="-1"></a>Scalar dot<span class="op">(</span>ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb69-12"><a href="#cb69-12" aria-hidden="true" tabindex="-1"></a>           InVec1 v1,</span>
-<span id="cb69-13"><a href="#cb69-13" aria-hidden="true" tabindex="-1"></a>           InVec2 v2,</span>
-<span id="cb69-14"><a href="#cb69-14" aria-hidden="true" tabindex="-1"></a>           Scalar init<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb75"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb75-1"><a href="#cb75-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-vector</em> InVec1,</span>
+<span id="cb75-2"><a href="#cb75-2" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2,</span>
+<span id="cb75-3"><a href="#cb75-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar<span class="op">&gt;</span></span>
+<span id="cb75-4"><a href="#cb75-4" aria-hidden="true" tabindex="-1"></a>Scalar dot<span class="op">(</span>InVec1 v1,</span>
+<span id="cb75-5"><a href="#cb75-5" aria-hidden="true" tabindex="-1"></a>           InVec2 v2,</span>
+<span id="cb75-6"><a href="#cb75-6" aria-hidden="true" tabindex="-1"></a>           Scalar init<span class="op">)</span>;</span>
+<span id="cb75-7"><a href="#cb75-7" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb75-8"><a href="#cb75-8" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec1,</span>
+<span id="cb75-9"><a href="#cb75-9" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2,</span>
+<span id="cb75-10"><a href="#cb75-10" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar<span class="op">&gt;</span></span>
+<span id="cb75-11"><a href="#cb75-11" aria-hidden="true" tabindex="-1"></a>Scalar dot<span class="op">(</span>ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb75-12"><a href="#cb75-12" aria-hidden="true" tabindex="-1"></a>           InVec1 v1,</span>
+<span id="cb75-13"><a href="#cb75-13" aria-hidden="true" tabindex="-1"></a>           InVec2 v2,</span>
+<span id="cb75-14"><a href="#cb75-14" aria-hidden="true" tabindex="-1"></a>           Scalar init<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">2</a></span>
 <em>Returns:</em> Let <code>N</code> be <code>v1.extent(0)</code>.</p>
 <ul>
@@ -7632,16 +7771,16 @@ Alternately, they can use the shortcut `dotc` below.
 -->
 <p><span class="marginalizedparent"><a class="marginalized">5</a></span>
 Nonconjugated dot product with default result type</p>
-<div class="sourceCode" id="cb70"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb70-1"><a href="#cb70-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-vector</em> InVec1,</span>
-<span id="cb70-2"><a href="#cb70-2" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2<span class="op">&gt;</span></span>
-<span id="cb70-3"><a href="#cb70-3" aria-hidden="true" tabindex="-1"></a><span class="kw">auto</span> dot<span class="op">(</span>InVec1 v1,</span>
-<span id="cb70-4"><a href="#cb70-4" aria-hidden="true" tabindex="-1"></a>         InVec2 v2<span class="op">)</span> <span class="op">-&gt;</span> <span class="co">/* see-below */</span>;</span>
-<span id="cb70-5"><a href="#cb70-5" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb70-6"><a href="#cb70-6" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec1,</span>
-<span id="cb70-7"><a href="#cb70-7" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2<span class="op">&gt;</span></span>
-<span id="cb70-8"><a href="#cb70-8" aria-hidden="true" tabindex="-1"></a><span class="kw">auto</span> dot<span class="op">(</span>ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb70-9"><a href="#cb70-9" aria-hidden="true" tabindex="-1"></a>         InVec1 v1,</span>
-<span id="cb70-10"><a href="#cb70-10" aria-hidden="true" tabindex="-1"></a>         InVec2 v2<span class="op">)</span> <span class="op">-&gt;</span> <span class="co">/* see-below */</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb76"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb76-1"><a href="#cb76-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-vector</em> InVec1,</span>
+<span id="cb76-2"><a href="#cb76-2" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2<span class="op">&gt;</span></span>
+<span id="cb76-3"><a href="#cb76-3" aria-hidden="true" tabindex="-1"></a><span class="kw">auto</span> dot<span class="op">(</span>InVec1 v1,</span>
+<span id="cb76-4"><a href="#cb76-4" aria-hidden="true" tabindex="-1"></a>         InVec2 v2<span class="op">)</span> <span class="op">-&gt;</span> <span class="co">/* see-below */</span>;</span>
+<span id="cb76-5"><a href="#cb76-5" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb76-6"><a href="#cb76-6" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec1,</span>
+<span id="cb76-7"><a href="#cb76-7" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2<span class="op">&gt;</span></span>
+<span id="cb76-8"><a href="#cb76-8" aria-hidden="true" tabindex="-1"></a><span class="kw">auto</span> dot<span class="op">(</span>ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb76-9"><a href="#cb76-9" aria-hidden="true" tabindex="-1"></a>         InVec1 v1,</span>
+<span id="cb76-10"><a href="#cb76-10" aria-hidden="true" tabindex="-1"></a>         InVec2 v2<span class="op">)</span> <span class="op">-&gt;</span> <span class="co">/* see-below */</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">6</a></span>
 <em>Effects:</em> Let <code>T</code> be
 <code>decltype(declval&lt;InVec1::value_type&gt;() * declval&lt;InVec2::value_type&gt;())</code>.
@@ -7658,20 +7797,20 @@ for both real and complex element types.
 --></p>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 Conjugated dot product with specified result type</p>
-<div class="sourceCode" id="cb71"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb71-1"><a href="#cb71-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-vector</em> InVec1,</span>
-<span id="cb71-2"><a href="#cb71-2" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2,</span>
-<span id="cb71-3"><a href="#cb71-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar<span class="op">&gt;</span></span>
-<span id="cb71-4"><a href="#cb71-4" aria-hidden="true" tabindex="-1"></a>Scalar dotc<span class="op">(</span>InVec1 v1,</span>
-<span id="cb71-5"><a href="#cb71-5" aria-hidden="true" tabindex="-1"></a>            InVec2 v2,</span>
-<span id="cb71-6"><a href="#cb71-6" aria-hidden="true" tabindex="-1"></a>            Scalar init<span class="op">)</span>;</span>
-<span id="cb71-7"><a href="#cb71-7" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb71-8"><a href="#cb71-8" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec1,</span>
-<span id="cb71-9"><a href="#cb71-9" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2,</span>
-<span id="cb71-10"><a href="#cb71-10" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar<span class="op">&gt;</span></span>
-<span id="cb71-11"><a href="#cb71-11" aria-hidden="true" tabindex="-1"></a>Scalar dotc<span class="op">(</span>ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb71-12"><a href="#cb71-12" aria-hidden="true" tabindex="-1"></a>            InVec1 v1,</span>
-<span id="cb71-13"><a href="#cb71-13" aria-hidden="true" tabindex="-1"></a>            InVec2 v2,</span>
-<span id="cb71-14"><a href="#cb71-14" aria-hidden="true" tabindex="-1"></a>            Scalar init<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb77"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb77-1"><a href="#cb77-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-vector</em> InVec1,</span>
+<span id="cb77-2"><a href="#cb77-2" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2,</span>
+<span id="cb77-3"><a href="#cb77-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar<span class="op">&gt;</span></span>
+<span id="cb77-4"><a href="#cb77-4" aria-hidden="true" tabindex="-1"></a>Scalar dotc<span class="op">(</span>InVec1 v1,</span>
+<span id="cb77-5"><a href="#cb77-5" aria-hidden="true" tabindex="-1"></a>            InVec2 v2,</span>
+<span id="cb77-6"><a href="#cb77-6" aria-hidden="true" tabindex="-1"></a>            Scalar init<span class="op">)</span>;</span>
+<span id="cb77-7"><a href="#cb77-7" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb77-8"><a href="#cb77-8" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec1,</span>
+<span id="cb77-9"><a href="#cb77-9" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2,</span>
+<span id="cb77-10"><a href="#cb77-10" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar<span class="op">&gt;</span></span>
+<span id="cb77-11"><a href="#cb77-11" aria-hidden="true" tabindex="-1"></a>Scalar dotc<span class="op">(</span>ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb77-12"><a href="#cb77-12" aria-hidden="true" tabindex="-1"></a>            InVec1 v1,</span>
+<span id="cb77-13"><a href="#cb77-13" aria-hidden="true" tabindex="-1"></a>            InVec2 v2,</span>
+<span id="cb77-14"><a href="#cb77-14" aria-hidden="true" tabindex="-1"></a>            Scalar init<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">2</a></span>
 <em>Effects:</em> The three-argument overload is equivalent to
 <code>return dot(conjugated(v1), v2, init);</code>. The four-argument
@@ -7679,16 +7818,16 @@ overload is equivalent to
 <code>return dot(exec, conjugated(v1), v2, init);</code>.</p>
 <p><span class="marginalizedparent"><a class="marginalized">3</a></span>
 Conjugated dot product with default result type</p>
-<div class="sourceCode" id="cb72"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb72-1"><a href="#cb72-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-vector</em> InVec1,</span>
-<span id="cb72-2"><a href="#cb72-2" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2<span class="op">&gt;</span></span>
-<span id="cb72-3"><a href="#cb72-3" aria-hidden="true" tabindex="-1"></a><span class="kw">auto</span> dotc<span class="op">(</span>InVec1 v1,</span>
-<span id="cb72-4"><a href="#cb72-4" aria-hidden="true" tabindex="-1"></a>          InVec2 v2<span class="op">)</span> <span class="op">-&gt;</span> <span class="co">/* see-below */</span>;</span>
-<span id="cb72-5"><a href="#cb72-5" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb72-6"><a href="#cb72-6" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec1,</span>
-<span id="cb72-7"><a href="#cb72-7" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2<span class="op">&gt;</span></span>
-<span id="cb72-8"><a href="#cb72-8" aria-hidden="true" tabindex="-1"></a><span class="kw">auto</span> dotc<span class="op">(</span>ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb72-9"><a href="#cb72-9" aria-hidden="true" tabindex="-1"></a>          InVec1 v1,</span>
-<span id="cb72-10"><a href="#cb72-10" aria-hidden="true" tabindex="-1"></a>          InVec2 v2<span class="op">)</span> <span class="op">-&gt;</span> <span class="co">/* see-below */</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb78"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb78-1"><a href="#cb78-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-vector</em> InVec1,</span>
+<span id="cb78-2"><a href="#cb78-2" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2<span class="op">&gt;</span></span>
+<span id="cb78-3"><a href="#cb78-3" aria-hidden="true" tabindex="-1"></a><span class="kw">auto</span> dotc<span class="op">(</span>InVec1 v1,</span>
+<span id="cb78-4"><a href="#cb78-4" aria-hidden="true" tabindex="-1"></a>          InVec2 v2<span class="op">)</span> <span class="op">-&gt;</span> <span class="co">/* see-below */</span>;</span>
+<span id="cb78-5"><a href="#cb78-5" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb78-6"><a href="#cb78-6" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec1,</span>
+<span id="cb78-7"><a href="#cb78-7" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2<span class="op">&gt;</span></span>
+<span id="cb78-8"><a href="#cb78-8" aria-hidden="true" tabindex="-1"></a><span class="kw">auto</span> dotc<span class="op">(</span>ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb78-9"><a href="#cb78-9" aria-hidden="true" tabindex="-1"></a>          InVec1 v1,</span>
+<span id="cb78-10"><a href="#cb78-10" aria-hidden="true" tabindex="-1"></a>          InVec2 v2<span class="op">)</span> <span class="op">-&gt;</span> <span class="co">/* see-below */</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">4</a></span>
 <em>Effects:</em> Let <code>T</code> be
 <code>decltype(</code><em><code>conj-if-needed</code></em><code>(declval&lt;typename InVec1::value_type&gt;()]) * declval&lt;typename InVec2::value_type&gt;())</code>.
@@ -7697,23 +7836,23 @@ Then, the two-parameter overload is equivalent to
 is equivalent to <code>return dotc(exec, v1, v2, T{});</code>.</p>
 <h4 data-number="28.9.13.8" id="scaled-sum-of-squares-of-a-vectors-elements-linalg.algs.blas1.ssq"><span class="header-section-number">28.9.13.8</span> Scaled sum of squares of
 a vector’s elements [linalg.algs.blas1.ssq]<a href="#scaled-sum-of-squares-of-a-vectors-elements-linalg.algs.blas1.ssq" class="self-link"></a></h4>
-<div class="sourceCode" id="cb73"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb73-1"><a href="#cb73-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Scalar<span class="op">&gt;</span></span>
-<span id="cb73-2"><a href="#cb73-2" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> sum_of_squares_result <span class="op">{</span></span>
-<span id="cb73-3"><a href="#cb73-3" aria-hidden="true" tabindex="-1"></a>  Scalar scaling_factor;</span>
-<span id="cb73-4"><a href="#cb73-4" aria-hidden="true" tabindex="-1"></a>  Scalar scaled_sum_of_squares;</span>
-<span id="cb73-5"><a href="#cb73-5" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
-<span id="cb73-6"><a href="#cb73-6" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-vector</em> InVec,</span>
-<span id="cb73-7"><a href="#cb73-7" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar<span class="op">&gt;</span></span>
-<span id="cb73-8"><a href="#cb73-8" aria-hidden="true" tabindex="-1"></a>sum_of_squares_result<span class="op">&lt;</span>Scalar<span class="op">&gt;</span> vector_sum_of_squares<span class="op">(</span></span>
-<span id="cb73-9"><a href="#cb73-9" aria-hidden="true" tabindex="-1"></a>  InVec v,</span>
-<span id="cb73-10"><a href="#cb73-10" aria-hidden="true" tabindex="-1"></a>  sum_of_squares_result<span class="op">&lt;</span>Scalar<span class="op">&gt;</span> init<span class="op">)</span>;</span>
-<span id="cb73-11"><a href="#cb73-11" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb73-12"><a href="#cb73-12" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
-<span id="cb73-13"><a href="#cb73-13" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar<span class="op">&gt;</span></span>
-<span id="cb73-14"><a href="#cb73-14" aria-hidden="true" tabindex="-1"></a>sum_of_squares_result<span class="op">&lt;</span>Scalar<span class="op">&gt;</span> vector_sum_of_squares<span class="op">(</span></span>
-<span id="cb73-15"><a href="#cb73-15" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb73-16"><a href="#cb73-16" aria-hidden="true" tabindex="-1"></a>  InVec v,</span>
-<span id="cb73-17"><a href="#cb73-17" aria-hidden="true" tabindex="-1"></a>  sum_of_squares_result<span class="op">&lt;</span>Scalar<span class="op">&gt;</span> init<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb79"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb79-1"><a href="#cb79-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Scalar<span class="op">&gt;</span></span>
+<span id="cb79-2"><a href="#cb79-2" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> sum_of_squares_result <span class="op">{</span></span>
+<span id="cb79-3"><a href="#cb79-3" aria-hidden="true" tabindex="-1"></a>  Scalar scaling_factor;</span>
+<span id="cb79-4"><a href="#cb79-4" aria-hidden="true" tabindex="-1"></a>  Scalar scaled_sum_of_squares;</span>
+<span id="cb79-5"><a href="#cb79-5" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
+<span id="cb79-6"><a href="#cb79-6" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-vector</em> InVec,</span>
+<span id="cb79-7"><a href="#cb79-7" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar<span class="op">&gt;</span></span>
+<span id="cb79-8"><a href="#cb79-8" aria-hidden="true" tabindex="-1"></a>sum_of_squares_result<span class="op">&lt;</span>Scalar<span class="op">&gt;</span> vector_sum_of_squares<span class="op">(</span></span>
+<span id="cb79-9"><a href="#cb79-9" aria-hidden="true" tabindex="-1"></a>  InVec v,</span>
+<span id="cb79-10"><a href="#cb79-10" aria-hidden="true" tabindex="-1"></a>  sum_of_squares_result<span class="op">&lt;</span>Scalar<span class="op">&gt;</span> init<span class="op">)</span>;</span>
+<span id="cb79-11"><a href="#cb79-11" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb79-12"><a href="#cb79-12" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
+<span id="cb79-13"><a href="#cb79-13" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar<span class="op">&gt;</span></span>
+<span id="cb79-14"><a href="#cb79-14" aria-hidden="true" tabindex="-1"></a>sum_of_squares_result<span class="op">&lt;</span>Scalar<span class="op">&gt;</span> vector_sum_of_squares<span class="op">(</span></span>
+<span id="cb79-15"><a href="#cb79-15" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb79-16"><a href="#cb79-16" aria-hidden="true" tabindex="-1"></a>  InVec v,</span>
+<span id="cb79-17"><a href="#cb79-17" aria-hidden="true" tabindex="-1"></a>  sum_of_squares_result<span class="op">&lt;</span>Scalar<span class="op">&gt;</span> init<span class="op">)</span>;</span></code></pre></div>
 <p><i>[Note:</i> These functions correspond to the LAPACK function
 <code>xLASSQ</code>. <i>– end note]</i></p>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
@@ -7761,16 +7900,16 @@ guarantees regarding overflow and underflow of
 vector [linalg.algs.blas1.nrm2]<a href="#euclidean-norm-of-a-vector-linalg.algs.blas1.nrm2" class="self-link"></a></h4>
 <h5 data-number="28.9.13.9.1" id="euclidean-norm-with-specified-result-type"><span class="header-section-number">28.9.13.9.1</span> Euclidean norm with
 specified result type<a href="#euclidean-norm-with-specified-result-type" class="self-link"></a></h5>
-<div class="sourceCode" id="cb74"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb74-1"><a href="#cb74-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-vector</em> InVec,</span>
-<span id="cb74-2"><a href="#cb74-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar<span class="op">&gt;</span></span>
-<span id="cb74-3"><a href="#cb74-3" aria-hidden="true" tabindex="-1"></a>Scalar vector_two_norm<span class="op">(</span>InVec v,</span>
-<span id="cb74-4"><a href="#cb74-4" aria-hidden="true" tabindex="-1"></a>                       Scalar init<span class="op">)</span>;</span>
-<span id="cb74-5"><a href="#cb74-5" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb74-6"><a href="#cb74-6" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
-<span id="cb74-7"><a href="#cb74-7" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar<span class="op">&gt;</span></span>
-<span id="cb74-8"><a href="#cb74-8" aria-hidden="true" tabindex="-1"></a>Scalar vector_two_norm<span class="op">(</span>ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb74-9"><a href="#cb74-9" aria-hidden="true" tabindex="-1"></a>                       InVec v,</span>
-<span id="cb74-10"><a href="#cb74-10" aria-hidden="true" tabindex="-1"></a>                       Scalar init<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb80"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb80-1"><a href="#cb80-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-vector</em> InVec,</span>
+<span id="cb80-2"><a href="#cb80-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar<span class="op">&gt;</span></span>
+<span id="cb80-3"><a href="#cb80-3" aria-hidden="true" tabindex="-1"></a>Scalar vector_two_norm<span class="op">(</span>InVec v,</span>
+<span id="cb80-4"><a href="#cb80-4" aria-hidden="true" tabindex="-1"></a>                       Scalar init<span class="op">)</span>;</span>
+<span id="cb80-5"><a href="#cb80-5" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb80-6"><a href="#cb80-6" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
+<span id="cb80-7"><a href="#cb80-7" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar<span class="op">&gt;</span></span>
+<span id="cb80-8"><a href="#cb80-8" aria-hidden="true" tabindex="-1"></a>Scalar vector_two_norm<span class="op">(</span>ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb80-9"><a href="#cb80-9" aria-hidden="true" tabindex="-1"></a>                       InVec v,</span>
+<span id="cb80-10"><a href="#cb80-10" aria-hidden="true" tabindex="-1"></a>                       Scalar init<span class="op">)</span>;</span></code></pre></div>
 <p><i>[Note:</i> These functions correspond to the BLAS function
 <code>xNRM2</code>. <i>– end note]</i></p>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
@@ -7785,7 +7924,9 @@ specified result type<a href="#euclidean-norm-with-specified-result-type" class=
 (<code>init</code> and the absolute values of the elements of
 <code>v</code>). <i>[Note:</i> For <code>init</code> equal to zero, this
 is the Euclidean norm (also called 2-norm) of the vector
-<code>v</code>.]</i></p>
+<code>v</code>.</p>
+<p>This description does not imply a recommended implementation for
+floating-point types. See <em>Remarks</em> below. <i>– end note]</i></p>
 <p><span class="marginalizedparent"><a class="marginalized">3</a></span>
 <em>Remarks:</em> If <code>InVec::value_type</code> is a floating-point
 type or a specialization of <code>complex</code>, and if <code>T</code>
@@ -7806,12 +7947,12 @@ floating-point types <code>T</code> would use the
 <i>– end note]</i></p>
 <h5 data-number="28.9.13.9.2" id="euclidean-norm-with-default-result-type"><span class="header-section-number">28.9.13.9.2</span> Euclidean norm with
 default result type<a href="#euclidean-norm-with-default-result-type" class="self-link"></a></h5>
-<div class="sourceCode" id="cb75"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb75-1"><a href="#cb75-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-vector</em> InVec<span class="op">&gt;</span></span>
-<span id="cb75-2"><a href="#cb75-2" aria-hidden="true" tabindex="-1"></a><span class="kw">auto</span> vector_two_norm<span class="op">(</span>InVec v<span class="op">)</span> <span class="op">-&gt;</span> <span class="co">/* see-below */</span>;</span>
-<span id="cb75-3"><a href="#cb75-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb75-4"><a href="#cb75-4" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec<span class="op">&gt;</span></span>
-<span id="cb75-5"><a href="#cb75-5" aria-hidden="true" tabindex="-1"></a><span class="kw">auto</span> vector_two_norm<span class="op">(</span>ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb75-6"><a href="#cb75-6" aria-hidden="true" tabindex="-1"></a>                     InVec v<span class="op">)</span> <span class="op">-&gt;</span> <span class="co">/* see-below */</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb81"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb81-1"><a href="#cb81-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-vector</em> InVec<span class="op">&gt;</span></span>
+<span id="cb81-2"><a href="#cb81-2" aria-hidden="true" tabindex="-1"></a><span class="kw">auto</span> vector_two_norm<span class="op">(</span>InVec v<span class="op">)</span> <span class="op">-&gt;</span> <span class="co">/* see-below */</span>;</span>
+<span id="cb81-3"><a href="#cb81-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb81-4"><a href="#cb81-4" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec<span class="op">&gt;</span></span>
+<span id="cb81-5"><a href="#cb81-5" aria-hidden="true" tabindex="-1"></a><span class="kw">auto</span> vector_two_norm<span class="op">(</span>ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb81-6"><a href="#cb81-6" aria-hidden="true" tabindex="-1"></a>                     InVec v<span class="op">)</span> <span class="op">-&gt;</span> <span class="co">/* see-below */</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 <em>Effects:</em> Let <code>T</code> be <code>decltype(</code>
 <em><code>abs-if-needed</code></em>
@@ -7826,16 +7967,16 @@ overload is equivalent to
 of vector elements [linalg.algs.blas1.asum]<a href="#sum-of-absolute-values-of-vector-elements-linalg.algs.blas1.asum" class="self-link"></a></h4>
 <h5 data-number="28.9.13.10.1" id="sum-of-absolute-values-with-specified-result-type"><span class="header-section-number">28.9.13.10.1</span> Sum of absolute values
 with specified result type<a href="#sum-of-absolute-values-with-specified-result-type" class="self-link"></a></h5>
-<div class="sourceCode" id="cb76"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb76-1"><a href="#cb76-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-vector</em> InVec,</span>
-<span id="cb76-2"><a href="#cb76-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar<span class="op">&gt;</span></span>
-<span id="cb76-3"><a href="#cb76-3" aria-hidden="true" tabindex="-1"></a>Scalar vector_abs_sum<span class="op">(</span>InVec v,</span>
-<span id="cb76-4"><a href="#cb76-4" aria-hidden="true" tabindex="-1"></a>                      Scalar init<span class="op">)</span>;</span>
-<span id="cb76-5"><a href="#cb76-5" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb76-6"><a href="#cb76-6" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
-<span id="cb76-7"><a href="#cb76-7" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar<span class="op">&gt;</span></span>
-<span id="cb76-8"><a href="#cb76-8" aria-hidden="true" tabindex="-1"></a>Scalar vector_abs_sum<span class="op">(</span>ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb76-9"><a href="#cb76-9" aria-hidden="true" tabindex="-1"></a>                      InVec v,</span>
-<span id="cb76-10"><a href="#cb76-10" aria-hidden="true" tabindex="-1"></a>                      Scalar init<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb82"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb82-1"><a href="#cb82-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-vector</em> InVec,</span>
+<span id="cb82-2"><a href="#cb82-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar<span class="op">&gt;</span></span>
+<span id="cb82-3"><a href="#cb82-3" aria-hidden="true" tabindex="-1"></a>Scalar vector_abs_sum<span class="op">(</span>InVec v,</span>
+<span id="cb82-4"><a href="#cb82-4" aria-hidden="true" tabindex="-1"></a>                      Scalar init<span class="op">)</span>;</span>
+<span id="cb82-5"><a href="#cb82-5" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb82-6"><a href="#cb82-6" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
+<span id="cb82-7"><a href="#cb82-7" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar<span class="op">&gt;</span></span>
+<span id="cb82-8"><a href="#cb82-8" aria-hidden="true" tabindex="-1"></a>Scalar vector_abs_sum<span class="op">(</span>ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb82-9"><a href="#cb82-9" aria-hidden="true" tabindex="-1"></a>                      InVec v,</span>
+<span id="cb82-10"><a href="#cb82-10" aria-hidden="true" tabindex="-1"></a>                      Scalar init<span class="op">)</span>;</span></code></pre></div>
 <p><i>[Note:</i> This function corresponds to the BLAS functions
 <code>SASUM</code>, <code>DASUM</code>, <code>SCASUM</code>, and
 <code>DZASUM</code>.<i>– end note]</i></p>
@@ -7893,12 +8034,12 @@ floating-point type, and if <code>T</code> has higher precision than
 <code>T</code>’s precision or greater.</p>
 <h5 data-number="28.9.13.10.2" id="sum-of-absolute-values-with-default-result-type"><span class="header-section-number">28.9.13.10.2</span> Sum of absolute values
 with default result type<a href="#sum-of-absolute-values-with-default-result-type" class="self-link"></a></h5>
-<div class="sourceCode" id="cb77"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb77-1"><a href="#cb77-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-vector</em> InVec<span class="op">&gt;</span></span>
-<span id="cb77-2"><a href="#cb77-2" aria-hidden="true" tabindex="-1"></a><span class="kw">auto</span> vector_abs_sum<span class="op">(</span>InVec v<span class="op">)</span> <span class="op">-&gt;</span> <span class="co">/* see-below */</span>;</span>
-<span id="cb77-3"><a href="#cb77-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb77-4"><a href="#cb77-4" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec<span class="op">&gt;</span></span>
-<span id="cb77-5"><a href="#cb77-5" aria-hidden="true" tabindex="-1"></a><span class="kw">auto</span> vector_abs_sum<span class="op">(</span>ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb77-6"><a href="#cb77-6" aria-hidden="true" tabindex="-1"></a>                    InVec v<span class="op">)</span> <span class="op">-&gt;</span> <span class="co">/* see-below */</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb83"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb83-1"><a href="#cb83-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-vector</em> InVec<span class="op">&gt;</span></span>
+<span id="cb83-2"><a href="#cb83-2" aria-hidden="true" tabindex="-1"></a><span class="kw">auto</span> vector_abs_sum<span class="op">(</span>InVec v<span class="op">)</span> <span class="op">-&gt;</span> <span class="co">/* see-below */</span>;</span>
+<span id="cb83-3"><a href="#cb83-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb83-4"><a href="#cb83-4" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec<span class="op">&gt;</span></span>
+<span id="cb83-5"><a href="#cb83-5" aria-hidden="true" tabindex="-1"></a><span class="kw">auto</span> vector_abs_sum<span class="op">(</span>ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb83-6"><a href="#cb83-6" aria-hidden="true" tabindex="-1"></a>                    InVec v<span class="op">)</span> <span class="op">-&gt;</span> <span class="co">/* see-below */</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 <em>Effects:</em> Let <code>T</code> be
 <code>typename InVec::value_type</code>. Then, the one-parameter
@@ -7907,14 +8048,14 @@ and the two-parameter overload is equivalent to
 <code>return vector_abs_sum(exec, v, T{});</code>.</p>
 <h4 data-number="28.9.13.11" id="index-of-maximum-absolute-value-of-vector-elements-linalg.algs.blas1.iamax"><span class="header-section-number">28.9.13.11</span> Index of maximum
 absolute value of vector elements [linalg.algs.blas1.iamax]<a href="#index-of-maximum-absolute-value-of-vector-elements-linalg.algs.blas1.iamax" class="self-link"></a></h4>
-<div class="sourceCode" id="cb78"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb78-1"><a href="#cb78-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-vector</em> InVec<span class="op">&gt;</span></span>
-<span id="cb78-2"><a href="#cb78-2" aria-hidden="true" tabindex="-1"></a><span class="kw">typename</span> InVec<span class="op">::</span>size_type idx_abs_max<span class="op">(</span>InVec v<span class="op">)</span>;</span>
-<span id="cb78-3"><a href="#cb78-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb78-4"><a href="#cb78-4" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb78-5"><a href="#cb78-5" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec<span class="op">&gt;</span></span>
-<span id="cb78-6"><a href="#cb78-6" aria-hidden="true" tabindex="-1"></a><span class="kw">typename</span> InVec<span class="op">::</span>size_type idx_abs_max<span class="op">(</span></span>
-<span id="cb78-7"><a href="#cb78-7" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb78-8"><a href="#cb78-8" aria-hidden="true" tabindex="-1"></a>  InVec v<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb84"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb84-1"><a href="#cb84-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-vector</em> InVec<span class="op">&gt;</span></span>
+<span id="cb84-2"><a href="#cb84-2" aria-hidden="true" tabindex="-1"></a><span class="kw">typename</span> InVec<span class="op">::</span>size_type idx_abs_max<span class="op">(</span>InVec v<span class="op">)</span>;</span>
+<span id="cb84-3"><a href="#cb84-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb84-4"><a href="#cb84-4" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb84-5"><a href="#cb84-5" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec<span class="op">&gt;</span></span>
+<span id="cb84-6"><a href="#cb84-6" aria-hidden="true" tabindex="-1"></a><span class="kw">typename</span> InVec<span class="op">::</span>size_type idx_abs_max<span class="op">(</span></span>
+<span id="cb84-7"><a href="#cb84-7" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb84-8"><a href="#cb84-8" aria-hidden="true" tabindex="-1"></a>  InVec v<span class="op">)</span>;</span></code></pre></div>
 <p><i>[Note:</i> These functions correspond to the BLAS function
 <code>IxAMAX</code>. <i>– end note]</i></p>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
@@ -7955,18 +8096,18 @@ value.</p></li>
 matrix [linalg.algs.blas1.matfrobnorm]<a href="#frobenius-norm-of-a-matrix-linalg.algs.blas1.matfrobnorm" class="self-link"></a></h4>
 <h5 data-number="28.9.13.12.1" id="frobenius-norm-with-specified-result-type"><span class="header-section-number">28.9.13.12.1</span> Frobenius norm with
 specified result type<a href="#frobenius-norm-with-specified-result-type" class="self-link"></a></h5>
-<div class="sourceCode" id="cb79"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb79-1"><a href="#cb79-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat,</span>
-<span id="cb79-2"><a href="#cb79-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar<span class="op">&gt;</span></span>
-<span id="cb79-3"><a href="#cb79-3" aria-hidden="true" tabindex="-1"></a>Scalar matrix_frob_norm<span class="op">(</span></span>
-<span id="cb79-4"><a href="#cb79-4" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
-<span id="cb79-5"><a href="#cb79-5" aria-hidden="true" tabindex="-1"></a>  Scalar init<span class="op">)</span>;</span>
-<span id="cb79-6"><a href="#cb79-6" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb79-7"><a href="#cb79-7" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat,</span>
-<span id="cb79-8"><a href="#cb79-8" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar<span class="op">&gt;</span></span>
-<span id="cb79-9"><a href="#cb79-9" aria-hidden="true" tabindex="-1"></a>Scalar matrix_frob_norm<span class="op">(</span></span>
-<span id="cb79-10"><a href="#cb79-10" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb79-11"><a href="#cb79-11" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
-<span id="cb79-12"><a href="#cb79-12" aria-hidden="true" tabindex="-1"></a>  Scalar init<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb85"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb85-1"><a href="#cb85-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat,</span>
+<span id="cb85-2"><a href="#cb85-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar<span class="op">&gt;</span></span>
+<span id="cb85-3"><a href="#cb85-3" aria-hidden="true" tabindex="-1"></a>Scalar matrix_frob_norm<span class="op">(</span></span>
+<span id="cb85-4"><a href="#cb85-4" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
+<span id="cb85-5"><a href="#cb85-5" aria-hidden="true" tabindex="-1"></a>  Scalar init<span class="op">)</span>;</span>
+<span id="cb85-6"><a href="#cb85-6" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb85-7"><a href="#cb85-7" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat,</span>
+<span id="cb85-8"><a href="#cb85-8" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar<span class="op">&gt;</span></span>
+<span id="cb85-9"><a href="#cb85-9" aria-hidden="true" tabindex="-1"></a>Scalar matrix_frob_norm<span class="op">(</span></span>
+<span id="cb85-10"><a href="#cb85-10" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb85-11"><a href="#cb85-11" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
+<span id="cb85-12"><a href="#cb85-12" aria-hidden="true" tabindex="-1"></a>  Scalar init<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 <em>Mandates:</em> <code>init +</code>
 <em><code>abs-if-needed</code></em>
@@ -7978,7 +8119,9 @@ specified result type<a href="#frobenius-norm-with-specified-result-type" class=
 <em>Returns:</em> The square root of the sum of squares of
 <code>init</code> and the absolute values of the elements of
 <code>A</code>. <i>[Note:</i> For <code>init</code> equal to zero, this
-is the Frobenius norm of the matrix <code>A</code>.]</i></p>
+is the Frobenius norm of the matrix <code>A</code>.</p>
+<p>This description does not imply a recommended implementation for
+floating-point types. See <em>Remarks</em> below. <i>– end note]</i></p>
 <p><span class="marginalizedparent"><a class="marginalized">3</a></span>
 <em>Remarks:</em> If <code>InMat::value_type</code> is a floating-point
 type or <code>complex&lt;R&gt;</code> for some floating-point type
@@ -7994,14 +8137,14 @@ guarantees regarding overflow and underflow of
 </ul>
 <h5 data-number="28.9.13.12.2" id="frobenius-norm-with-default-result-type"><span class="header-section-number">28.9.13.12.2</span> Frobenius norm with
 default result type<a href="#frobenius-norm-with-default-result-type" class="self-link"></a></h5>
-<div class="sourceCode" id="cb80"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb80-1"><a href="#cb80-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat<span class="op">&gt;</span></span>
-<span id="cb80-2"><a href="#cb80-2" aria-hidden="true" tabindex="-1"></a><span class="kw">auto</span> matrix_frob_norm<span class="op">(</span></span>
-<span id="cb80-3"><a href="#cb80-3" aria-hidden="true" tabindex="-1"></a>  InMat A<span class="op">)</span> <span class="op">-&gt;</span> <span class="co">/* see-below */</span>;</span>
-<span id="cb80-4"><a href="#cb80-4" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb80-5"><a href="#cb80-5" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat<span class="op">&gt;</span></span>
-<span id="cb80-6"><a href="#cb80-6" aria-hidden="true" tabindex="-1"></a><span class="kw">auto</span> matrix_frob_norm<span class="op">(</span></span>
-<span id="cb80-7"><a href="#cb80-7" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb80-8"><a href="#cb80-8" aria-hidden="true" tabindex="-1"></a>  InMat A<span class="op">)</span> <span class="op">-&gt;</span> <span class="co">/* see-below */</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb86"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb86-1"><a href="#cb86-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat<span class="op">&gt;</span></span>
+<span id="cb86-2"><a href="#cb86-2" aria-hidden="true" tabindex="-1"></a><span class="kw">auto</span> matrix_frob_norm<span class="op">(</span></span>
+<span id="cb86-3"><a href="#cb86-3" aria-hidden="true" tabindex="-1"></a>  InMat A<span class="op">)</span> <span class="op">-&gt;</span> <span class="co">/* see-below */</span>;</span>
+<span id="cb86-4"><a href="#cb86-4" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb86-5"><a href="#cb86-5" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat<span class="op">&gt;</span></span>
+<span id="cb86-6"><a href="#cb86-6" aria-hidden="true" tabindex="-1"></a><span class="kw">auto</span> matrix_frob_norm<span class="op">(</span></span>
+<span id="cb86-7"><a href="#cb86-7" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb86-8"><a href="#cb86-8" aria-hidden="true" tabindex="-1"></a>  InMat A<span class="op">)</span> <span class="op">-&gt;</span> <span class="co">/* see-below */</span>;</span></code></pre></div>
 <!-- TODO (mfh 2023/02/16)
 What if that product of absolute values is an expression template?
 Is it even our job to worry about that?
@@ -8020,18 +8163,18 @@ overload is equivalent to
 [linalg.algs.blas1.matonenorm]<a href="#one-norm-of-a-matrix-linalg.algs.blas1.matonenorm" class="self-link"></a></h4>
 <h5 data-number="28.9.13.13.1" id="one-norm-with-specified-result-type"><span class="header-section-number">28.9.13.13.1</span> One norm with
 specified result type<a href="#one-norm-with-specified-result-type" class="self-link"></a></h5>
-<div class="sourceCode" id="cb81"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb81-1"><a href="#cb81-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat,</span>
-<span id="cb81-2"><a href="#cb81-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar<span class="op">&gt;</span></span>
-<span id="cb81-3"><a href="#cb81-3" aria-hidden="true" tabindex="-1"></a>Scalar matrix_one_norm<span class="op">(</span></span>
-<span id="cb81-4"><a href="#cb81-4" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
-<span id="cb81-5"><a href="#cb81-5" aria-hidden="true" tabindex="-1"></a>  Scalar init<span class="op">)</span>;</span>
-<span id="cb81-6"><a href="#cb81-6" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb81-7"><a href="#cb81-7" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat,</span>
-<span id="cb81-8"><a href="#cb81-8" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar<span class="op">&gt;</span></span>
-<span id="cb81-9"><a href="#cb81-9" aria-hidden="true" tabindex="-1"></a>Scalar matrix_one_norm<span class="op">(</span></span>
-<span id="cb81-10"><a href="#cb81-10" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb81-11"><a href="#cb81-11" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
-<span id="cb81-12"><a href="#cb81-12" aria-hidden="true" tabindex="-1"></a>  Scalar init<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb87"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb87-1"><a href="#cb87-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat,</span>
+<span id="cb87-2"><a href="#cb87-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar<span class="op">&gt;</span></span>
+<span id="cb87-3"><a href="#cb87-3" aria-hidden="true" tabindex="-1"></a>Scalar matrix_one_norm<span class="op">(</span></span>
+<span id="cb87-4"><a href="#cb87-4" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
+<span id="cb87-5"><a href="#cb87-5" aria-hidden="true" tabindex="-1"></a>  Scalar init<span class="op">)</span>;</span>
+<span id="cb87-6"><a href="#cb87-6" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb87-7"><a href="#cb87-7" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat,</span>
+<span id="cb87-8"><a href="#cb87-8" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar<span class="op">&gt;</span></span>
+<span id="cb87-9"><a href="#cb87-9" aria-hidden="true" tabindex="-1"></a>Scalar matrix_one_norm<span class="op">(</span></span>
+<span id="cb87-10"><a href="#cb87-10" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb87-11"><a href="#cb87-11" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
+<span id="cb87-12"><a href="#cb87-12" aria-hidden="true" tabindex="-1"></a>  Scalar init<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 <em>Mandates:</em> <em><code>abs-if-needed</code></em>
 <code>(declval&lt;InMat::value_type&gt;())</code> is convertible to
@@ -8057,14 +8200,14 @@ then intermediate terms in each sum use <code>T</code>’s precision or
 greater.</p>
 <h5 data-number="28.9.13.13.2" id="one-norm-with-default-result-type"><span class="header-section-number">28.9.13.13.2</span> One norm with default
 result type<a href="#one-norm-with-default-result-type" class="self-link"></a></h5>
-<div class="sourceCode" id="cb82"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb82-1"><a href="#cb82-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat<span class="op">&gt;</span></span>
-<span id="cb82-2"><a href="#cb82-2" aria-hidden="true" tabindex="-1"></a><span class="kw">auto</span> matrix_one_norm<span class="op">(</span></span>
-<span id="cb82-3"><a href="#cb82-3" aria-hidden="true" tabindex="-1"></a>  InMat A<span class="op">)</span> <span class="op">-&gt;</span> <span class="co">/* see-below */</span>;</span>
-<span id="cb82-4"><a href="#cb82-4" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb82-5"><a href="#cb82-5" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat<span class="op">&gt;</span></span>
-<span id="cb82-6"><a href="#cb82-6" aria-hidden="true" tabindex="-1"></a><span class="kw">auto</span> matrix_one_norm<span class="op">(</span></span>
-<span id="cb82-7"><a href="#cb82-7" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb82-8"><a href="#cb82-8" aria-hidden="true" tabindex="-1"></a>  InMat A<span class="op">)</span> <span class="op">-&gt;</span> <span class="co">/* see-below */</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb88"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb88-1"><a href="#cb88-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat<span class="op">&gt;</span></span>
+<span id="cb88-2"><a href="#cb88-2" aria-hidden="true" tabindex="-1"></a><span class="kw">auto</span> matrix_one_norm<span class="op">(</span></span>
+<span id="cb88-3"><a href="#cb88-3" aria-hidden="true" tabindex="-1"></a>  InMat A<span class="op">)</span> <span class="op">-&gt;</span> <span class="co">/* see-below */</span>;</span>
+<span id="cb88-4"><a href="#cb88-4" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb88-5"><a href="#cb88-5" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat<span class="op">&gt;</span></span>
+<span id="cb88-6"><a href="#cb88-6" aria-hidden="true" tabindex="-1"></a><span class="kw">auto</span> matrix_one_norm<span class="op">(</span></span>
+<span id="cb88-7"><a href="#cb88-7" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb88-8"><a href="#cb88-8" aria-hidden="true" tabindex="-1"></a>  InMat A<span class="op">)</span> <span class="op">-&gt;</span> <span class="co">/* see-below */</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 <em>Effects:</em> Let <code>T</code> be <code>decltype(</code>
 <em><code>abs-if-needed</code></em>
@@ -8077,18 +8220,18 @@ overload is equivalent to
 matrix [linalg.algs.blas1.matinfnorm]<a href="#infinity-norm-of-a-matrix-linalg.algs.blas1.matinfnorm" class="self-link"></a></h4>
 <h5 data-number="28.9.13.14.1" id="infinity-norm-with-specified-result-type"><span class="header-section-number">28.9.13.14.1</span> Infinity norm with
 specified result type<a href="#infinity-norm-with-specified-result-type" class="self-link"></a></h5>
-<div class="sourceCode" id="cb83"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb83-1"><a href="#cb83-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat,</span>
-<span id="cb83-2"><a href="#cb83-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar<span class="op">&gt;</span></span>
-<span id="cb83-3"><a href="#cb83-3" aria-hidden="true" tabindex="-1"></a>Scalar matrix_inf_norm<span class="op">(</span></span>
-<span id="cb83-4"><a href="#cb83-4" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
-<span id="cb83-5"><a href="#cb83-5" aria-hidden="true" tabindex="-1"></a>  Scalar init<span class="op">)</span>;</span>
-<span id="cb83-6"><a href="#cb83-6" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb83-7"><a href="#cb83-7" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat,</span>
-<span id="cb83-8"><a href="#cb83-8" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar<span class="op">&gt;</span></span>
-<span id="cb83-9"><a href="#cb83-9" aria-hidden="true" tabindex="-1"></a>Scalar matrix_inf_norm<span class="op">(</span></span>
-<span id="cb83-10"><a href="#cb83-10" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb83-11"><a href="#cb83-11" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
-<span id="cb83-12"><a href="#cb83-12" aria-hidden="true" tabindex="-1"></a>  Scalar init<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb89"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb89-1"><a href="#cb89-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat,</span>
+<span id="cb89-2"><a href="#cb89-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar<span class="op">&gt;</span></span>
+<span id="cb89-3"><a href="#cb89-3" aria-hidden="true" tabindex="-1"></a>Scalar matrix_inf_norm<span class="op">(</span></span>
+<span id="cb89-4"><a href="#cb89-4" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
+<span id="cb89-5"><a href="#cb89-5" aria-hidden="true" tabindex="-1"></a>  Scalar init<span class="op">)</span>;</span>
+<span id="cb89-6"><a href="#cb89-6" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb89-7"><a href="#cb89-7" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat,</span>
+<span id="cb89-8"><a href="#cb89-8" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar<span class="op">&gt;</span></span>
+<span id="cb89-9"><a href="#cb89-9" aria-hidden="true" tabindex="-1"></a>Scalar matrix_inf_norm<span class="op">(</span></span>
+<span id="cb89-10"><a href="#cb89-10" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb89-11"><a href="#cb89-11" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
+<span id="cb89-12"><a href="#cb89-12" aria-hidden="true" tabindex="-1"></a>  Scalar init<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 <em>Mandates:</em> <em><code>abs-if-needed</code></em>
 <code>(declval&lt;InMat::value_type&gt;())</code> is convertible to
@@ -8114,14 +8257,14 @@ then intermediate terms in each sum use <code>T</code>’s precision or
 greater.</p>
 <h5 data-number="28.9.13.14.2" id="infinity-norm-with-default-result-type"><span class="header-section-number">28.9.13.14.2</span> Infinity norm with
 default result type<a href="#infinity-norm-with-default-result-type" class="self-link"></a></h5>
-<div class="sourceCode" id="cb84"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb84-1"><a href="#cb84-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat<span class="op">&gt;</span></span>
-<span id="cb84-2"><a href="#cb84-2" aria-hidden="true" tabindex="-1"></a><span class="kw">auto</span> matrix_inf_norm<span class="op">(</span></span>
-<span id="cb84-3"><a href="#cb84-3" aria-hidden="true" tabindex="-1"></a>  InMat A<span class="op">)</span> <span class="op">-&gt;</span> <span class="co">/* see-below */</span>;</span>
-<span id="cb84-4"><a href="#cb84-4" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb84-5"><a href="#cb84-5" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat<span class="op">&gt;</span></span>
-<span id="cb84-6"><a href="#cb84-6" aria-hidden="true" tabindex="-1"></a><span class="kw">auto</span> matrix_inf_norm<span class="op">(</span></span>
-<span id="cb84-7"><a href="#cb84-7" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb84-8"><a href="#cb84-8" aria-hidden="true" tabindex="-1"></a>  InMat A<span class="op">)</span> <span class="op">-&gt;</span> <span class="co">/* see-below */</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb90"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb90-1"><a href="#cb90-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat<span class="op">&gt;</span></span>
+<span id="cb90-2"><a href="#cb90-2" aria-hidden="true" tabindex="-1"></a><span class="kw">auto</span> matrix_inf_norm<span class="op">(</span></span>
+<span id="cb90-3"><a href="#cb90-3" aria-hidden="true" tabindex="-1"></a>  InMat A<span class="op">)</span> <span class="op">-&gt;</span> <span class="co">/* see-below */</span>;</span>
+<span id="cb90-4"><a href="#cb90-4" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb90-5"><a href="#cb90-5" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat<span class="op">&gt;</span></span>
+<span id="cb90-6"><a href="#cb90-6" aria-hidden="true" tabindex="-1"></a><span class="kw">auto</span> matrix_inf_norm<span class="op">(</span></span>
+<span id="cb90-7"><a href="#cb90-7" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb90-8"><a href="#cb90-8" aria-hidden="true" tabindex="-1"></a>  InMat A<span class="op">)</span> <span class="op">-&gt;</span> <span class="co">/* see-below */</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 <em>Effects:</em> Let <code>T</code> be <code>decltype(</code>
 <em><code>abs-if-needed</code></em>
@@ -8168,45 +8311,75 @@ array accesses and arithmetic operations that is linear in
 <code>x.extent(0)</code> times <code>A.extent(1)</code>.</p>
 <h5 data-number="28.9.14.1.2" id="overwriting-matrix-vector-product"><span class="header-section-number">28.9.14.1.2</span> Overwriting
 matrix-vector product<a href="#overwriting-matrix-vector-product" class="self-link"></a></h5>
-<div class="sourceCode" id="cb85"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb85-1"><a href="#cb85-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat,</span>
-<span id="cb85-2"><a href="#cb85-2" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
-<span id="cb85-3"><a href="#cb85-3" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec<span class="op">&gt;</span></span>
-<span id="cb85-4"><a href="#cb85-4" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> matrix_vector_product<span class="op">(</span>InMat A,</span>
-<span id="cb85-5"><a href="#cb85-5" aria-hidden="true" tabindex="-1"></a>                           InVec x,</span>
-<span id="cb85-6"><a href="#cb85-6" aria-hidden="true" tabindex="-1"></a>                           OutVec y<span class="op">)</span>;</span>
-<span id="cb85-7"><a href="#cb85-7" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb85-8"><a href="#cb85-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb85-9"><a href="#cb85-9" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat,</span>
-<span id="cb85-10"><a href="#cb85-10" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
-<span id="cb85-11"><a href="#cb85-11" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec<span class="op">&gt;</span></span>
-<span id="cb85-12"><a href="#cb85-12" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> matrix_vector_product<span class="op">(</span>ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb85-13"><a href="#cb85-13" aria-hidden="true" tabindex="-1"></a>                           InMat A,</span>
-<span id="cb85-14"><a href="#cb85-14" aria-hidden="true" tabindex="-1"></a>                           InVec x,</span>
-<span id="cb85-15"><a href="#cb85-15" aria-hidden="true" tabindex="-1"></a>                           OutVec y<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb91"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb91-1"><a href="#cb91-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat,</span>
+<span id="cb91-2"><a href="#cb91-2" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
+<span id="cb91-3"><a href="#cb91-3" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec<span class="op">&gt;</span></span>
+<span id="cb91-4"><a href="#cb91-4" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> matrix_vector_product<span class="op">(</span>InMat A,</span>
+<span id="cb91-5"><a href="#cb91-5" aria-hidden="true" tabindex="-1"></a>                           InVec x,</span>
+<span id="cb91-6"><a href="#cb91-6" aria-hidden="true" tabindex="-1"></a>                           OutVec y<span class="op">)</span>;</span>
+<span id="cb91-7"><a href="#cb91-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb91-8"><a href="#cb91-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb91-9"><a href="#cb91-9" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat,</span>
+<span id="cb91-10"><a href="#cb91-10" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
+<span id="cb91-11"><a href="#cb91-11" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec<span class="op">&gt;</span></span>
+<span id="cb91-12"><a href="#cb91-12" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> matrix_vector_product<span class="op">(</span>ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb91-13"><a href="#cb91-13" aria-hidden="true" tabindex="-1"></a>                           InMat A,</span>
+<span id="cb91-14"><a href="#cb91-14" aria-hidden="true" tabindex="-1"></a>                           InVec x,</span>
+<span id="cb91-15"><a href="#cb91-15" aria-hidden="true" tabindex="-1"></a>                           OutVec y<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 <em>Effects:</em> Computes <span class="math inline"><em>y</em> = <em>A</em><em>x</em></span>.</p>
-<p>[<em>Example:</em>]</p>
+<p>[<em>Example:</em></p>
+<div class="sourceCode" id="cb92"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb92-1"><a href="#cb92-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">size_t</span> num_rows <span class="op">=</span> <span class="dv">5</span>;</span>
+<span id="cb92-2"><a href="#cb92-2" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">size_t</span> num_cols <span class="op">=</span> <span class="dv">6</span>;</span>
+<span id="cb92-3"><a href="#cb92-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb92-4"><a href="#cb92-4" aria-hidden="true" tabindex="-1"></a><span class="co">// y = 3.0 * A * x</span></span>
+<span id="cb92-5"><a href="#cb92-5" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> scaled_matvec_1<span class="op">(</span></span>
+<span id="cb92-6"><a href="#cb92-6" aria-hidden="true" tabindex="-1"></a>  mdspan<span class="op">&lt;</span><span class="dt">double</span>, extents<span class="op">&lt;</span><span class="dt">size_t</span>, num_rows, num_cols<span class="op">&gt;&gt;</span> A,</span>
+<span id="cb92-7"><a href="#cb92-7" aria-hidden="true" tabindex="-1"></a>  mdspan<span class="op">&lt;</span><span class="dt">double</span>, extents<span class="op">&lt;</span><span class="dt">size_t</span>, num_cols<span class="op">&gt;&gt;</span> x,</span>
+<span id="cb92-8"><a href="#cb92-8" aria-hidden="true" tabindex="-1"></a>  mdspan<span class="op">&lt;</span><span class="dt">double</span>, extents<span class="op">&lt;</span><span class="dt">size_t</span>, num_rows<span class="op">&gt;&gt;</span> y<span class="op">)</span></span>
+<span id="cb92-9"><a href="#cb92-9" aria-hidden="true" tabindex="-1"></a><span class="op">{</span></span>
+<span id="cb92-10"><a href="#cb92-10" aria-hidden="true" tabindex="-1"></a>  matrix_vector_product<span class="op">(</span>scaled<span class="op">(</span><span class="fl">3.0</span>, A<span class="op">)</span>, x, y<span class="op">)</span>;</span>
+<span id="cb92-11"><a href="#cb92-11" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
+<span id="cb92-12"><a href="#cb92-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb92-13"><a href="#cb92-13" aria-hidden="true" tabindex="-1"></a><span class="co">// y = 3.0 * A * x + 2.0 * y</span></span>
+<span id="cb92-14"><a href="#cb92-14" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> scaled_matvec_2<span class="op">(</span></span>
+<span id="cb92-15"><a href="#cb92-15" aria-hidden="true" tabindex="-1"></a>  mdspan<span class="op">&lt;</span><span class="dt">double</span>, extents<span class="op">&lt;</span><span class="dt">size_t</span>, num_rows, num_cols<span class="op">&gt;&gt;</span> A,</span>
+<span id="cb92-16"><a href="#cb92-16" aria-hidden="true" tabindex="-1"></a>  mdspan<span class="op">&lt;</span><span class="dt">double</span>, extents<span class="op">&lt;</span><span class="dt">size_t</span>, num_cols<span class="op">&gt;&gt;</span> x,</span>
+<span id="cb92-17"><a href="#cb92-17" aria-hidden="true" tabindex="-1"></a>  mdspan<span class="op">&lt;</span><span class="dt">double</span>, extents<span class="op">&lt;</span><span class="dt">size_t</span>, num_rows<span class="op">&gt;&gt;</span> y<span class="op">)</span></span>
+<span id="cb92-18"><a href="#cb92-18" aria-hidden="true" tabindex="-1"></a><span class="op">{</span></span>
+<span id="cb92-19"><a href="#cb92-19" aria-hidden="true" tabindex="-1"></a>  matrix_vector_product<span class="op">(</span>scaled<span class="op">(</span><span class="fl">3.0</span>, A<span class="op">)</span>, x,</span>
+<span id="cb92-20"><a href="#cb92-20" aria-hidden="true" tabindex="-1"></a>                        scaled<span class="op">(</span><span class="fl">2.0</span>, y<span class="op">)</span>, y<span class="op">)</span>;</span>
+<span id="cb92-21"><a href="#cb92-21" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
+<span id="cb92-22"><a href="#cb92-22" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb92-23"><a href="#cb92-23" aria-hidden="true" tabindex="-1"></a><span class="co">// z = 7.0 times the transpose of A, times y</span></span>
+<span id="cb92-24"><a href="#cb92-24" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> scaled_matvec_2<span class="op">(</span>mdspan<span class="op">&lt;</span><span class="dt">double</span>, extents<span class="op">&lt;</span><span class="dt">size_t</span>, num_rows, num_cols<span class="op">&gt;&gt;</span> A,</span>
+<span id="cb92-25"><a href="#cb92-25" aria-hidden="true" tabindex="-1"></a>  mdspan<span class="op">&lt;</span><span class="dt">double</span>, extents<span class="op">&lt;</span><span class="dt">size_t</span>, num_rows<span class="op">&gt;&gt;</span> y,</span>
+<span id="cb92-26"><a href="#cb92-26" aria-hidden="true" tabindex="-1"></a>  mdspan<span class="op">&lt;</span><span class="dt">double</span>, extents<span class="op">&lt;</span><span class="dt">size_t</span>, num_cols<span class="op">&gt;&gt;</span> z<span class="op">)</span></span>
+<span id="cb92-27"><a href="#cb92-27" aria-hidden="true" tabindex="-1"></a><span class="op">{</span></span>
+<span id="cb92-28"><a href="#cb92-28" aria-hidden="true" tabindex="-1"></a>  matrix_vector_product<span class="op">(</span>scaled<span class="op">(</span><span class="fl">7.0</span>, transposed<span class="op">(</span>A<span class="op">))</span>, y, z<span class="op">)</span>;</span>
+<span id="cb92-29"><a href="#cb92-29" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<p>–<em>end example</em>]</p>
 <h5 data-number="28.9.14.1.3" id="updating-matrix-vector-product"><span class="header-section-number">28.9.14.1.3</span> Updating matrix-vector
 product<a href="#updating-matrix-vector-product" class="self-link"></a></h5>
-<div class="sourceCode" id="cb86"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb86-1"><a href="#cb86-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat,</span>
-<span id="cb86-2"><a href="#cb86-2" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec1,</span>
-<span id="cb86-3"><a href="#cb86-3" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2,</span>
-<span id="cb86-4"><a href="#cb86-4" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec<span class="op">&gt;</span></span>
-<span id="cb86-5"><a href="#cb86-5" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> matrix_vector_product<span class="op">(</span>InMat A,</span>
-<span id="cb86-6"><a href="#cb86-6" aria-hidden="true" tabindex="-1"></a>                           InVec1 x,</span>
-<span id="cb86-7"><a href="#cb86-7" aria-hidden="true" tabindex="-1"></a>                           InVec2 y,</span>
-<span id="cb86-8"><a href="#cb86-8" aria-hidden="true" tabindex="-1"></a>                           OutVec z<span class="op">)</span>;</span>
-<span id="cb86-9"><a href="#cb86-9" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb86-10"><a href="#cb86-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb86-11"><a href="#cb86-11" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat,</span>
-<span id="cb86-12"><a href="#cb86-12" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec1,</span>
-<span id="cb86-13"><a href="#cb86-13" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2,</span>
-<span id="cb86-14"><a href="#cb86-14" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec<span class="op">&gt;</span></span>
-<span id="cb86-15"><a href="#cb86-15" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> matrix_vector_product<span class="op">(</span>ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb86-16"><a href="#cb86-16" aria-hidden="true" tabindex="-1"></a>                           InMat A,</span>
-<span id="cb86-17"><a href="#cb86-17" aria-hidden="true" tabindex="-1"></a>                           InVec1 x,</span>
-<span id="cb86-18"><a href="#cb86-18" aria-hidden="true" tabindex="-1"></a>                           InVec2 y,</span>
-<span id="cb86-19"><a href="#cb86-19" aria-hidden="true" tabindex="-1"></a>                           OutVec z<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb93"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb93-1"><a href="#cb93-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat,</span>
+<span id="cb93-2"><a href="#cb93-2" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec1,</span>
+<span id="cb93-3"><a href="#cb93-3" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2,</span>
+<span id="cb93-4"><a href="#cb93-4" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec<span class="op">&gt;</span></span>
+<span id="cb93-5"><a href="#cb93-5" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> matrix_vector_product<span class="op">(</span>InMat A,</span>
+<span id="cb93-6"><a href="#cb93-6" aria-hidden="true" tabindex="-1"></a>                           InVec1 x,</span>
+<span id="cb93-7"><a href="#cb93-7" aria-hidden="true" tabindex="-1"></a>                           InVec2 y,</span>
+<span id="cb93-8"><a href="#cb93-8" aria-hidden="true" tabindex="-1"></a>                           OutVec z<span class="op">)</span>;</span>
+<span id="cb93-9"><a href="#cb93-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb93-10"><a href="#cb93-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb93-11"><a href="#cb93-11" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat,</span>
+<span id="cb93-12"><a href="#cb93-12" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec1,</span>
+<span id="cb93-13"><a href="#cb93-13" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2,</span>
+<span id="cb93-14"><a href="#cb93-14" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec<span class="op">&gt;</span></span>
+<span id="cb93-15"><a href="#cb93-15" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> matrix_vector_product<span class="op">(</span>ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb93-16"><a href="#cb93-16" aria-hidden="true" tabindex="-1"></a>                           InMat A,</span>
+<span id="cb93-17"><a href="#cb93-17" aria-hidden="true" tabindex="-1"></a>                           InVec1 x,</span>
+<span id="cb93-18"><a href="#cb93-18" aria-hidden="true" tabindex="-1"></a>                           InVec2 y,</span>
+<span id="cb93-19"><a href="#cb93-19" aria-hidden="true" tabindex="-1"></a>                           OutVec z<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 <em>Effects:</em> Computes <span class="math inline"><em>z</em> = <em>y</em> + <em>A</em><em>x</em></span>.</p>
 <p><span class="marginalizedparent"><a class="marginalized">2</a></span>
@@ -8271,54 +8444,54 @@ array accesses and arithmetic operations that is linear in
 <code>x.extent(0)</code> times <code>A.extent(1)</code>.</p>
 <h5 data-number="28.9.14.2.2" id="overwriting-symmetric-matrix-vector-product"><span class="header-section-number">28.9.14.2.2</span> Overwriting symmetric
 matrix-vector product<a href="#overwriting-symmetric-matrix-vector-product" class="self-link"></a></h5>
-<div class="sourceCode" id="cb87"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb87-1"><a href="#cb87-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat,</span>
-<span id="cb87-2"><a href="#cb87-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb87-3"><a href="#cb87-3" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
-<span id="cb87-4"><a href="#cb87-4" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec<span class="op">&gt;</span></span>
-<span id="cb87-5"><a href="#cb87-5" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_vector_product<span class="op">(</span>InMat A,</span>
-<span id="cb87-6"><a href="#cb87-6" aria-hidden="true" tabindex="-1"></a>                                     Triangle t,</span>
-<span id="cb87-7"><a href="#cb87-7" aria-hidden="true" tabindex="-1"></a>                                     InVec x,</span>
-<span id="cb87-8"><a href="#cb87-8" aria-hidden="true" tabindex="-1"></a>                                     OutVec y<span class="op">)</span>;</span>
-<span id="cb87-9"><a href="#cb87-9" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb87-10"><a href="#cb87-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb87-11"><a href="#cb87-11" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat,</span>
-<span id="cb87-12"><a href="#cb87-12" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb87-13"><a href="#cb87-13" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
-<span id="cb87-14"><a href="#cb87-14" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec<span class="op">&gt;</span></span>
-<span id="cb87-15"><a href="#cb87-15" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_vector_product<span class="op">(</span>ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb87-16"><a href="#cb87-16" aria-hidden="true" tabindex="-1"></a>                                     InMat A,</span>
-<span id="cb87-17"><a href="#cb87-17" aria-hidden="true" tabindex="-1"></a>                                     Triangle t,</span>
-<span id="cb87-18"><a href="#cb87-18" aria-hidden="true" tabindex="-1"></a>                                     InVec x,</span>
-<span id="cb87-19"><a href="#cb87-19" aria-hidden="true" tabindex="-1"></a>                                     OutVec y<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb94"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb94-1"><a href="#cb94-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat,</span>
+<span id="cb94-2"><a href="#cb94-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb94-3"><a href="#cb94-3" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
+<span id="cb94-4"><a href="#cb94-4" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec<span class="op">&gt;</span></span>
+<span id="cb94-5"><a href="#cb94-5" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_vector_product<span class="op">(</span>InMat A,</span>
+<span id="cb94-6"><a href="#cb94-6" aria-hidden="true" tabindex="-1"></a>                                     Triangle t,</span>
+<span id="cb94-7"><a href="#cb94-7" aria-hidden="true" tabindex="-1"></a>                                     InVec x,</span>
+<span id="cb94-8"><a href="#cb94-8" aria-hidden="true" tabindex="-1"></a>                                     OutVec y<span class="op">)</span>;</span>
+<span id="cb94-9"><a href="#cb94-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb94-10"><a href="#cb94-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb94-11"><a href="#cb94-11" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat,</span>
+<span id="cb94-12"><a href="#cb94-12" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb94-13"><a href="#cb94-13" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
+<span id="cb94-14"><a href="#cb94-14" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec<span class="op">&gt;</span></span>
+<span id="cb94-15"><a href="#cb94-15" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_vector_product<span class="op">(</span>ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb94-16"><a href="#cb94-16" aria-hidden="true" tabindex="-1"></a>                                     InMat A,</span>
+<span id="cb94-17"><a href="#cb94-17" aria-hidden="true" tabindex="-1"></a>                                     Triangle t,</span>
+<span id="cb94-18"><a href="#cb94-18" aria-hidden="true" tabindex="-1"></a>                                     InVec x,</span>
+<span id="cb94-19"><a href="#cb94-19" aria-hidden="true" tabindex="-1"></a>                                     OutVec y<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 <em>Effects:</em> Computes <span class="math inline"><em>y</em> = <em>A</em><em>x</em></span>.</p>
 <h5 data-number="28.9.14.2.3" id="updating-symmetric-matrix-vector-product"><span class="header-section-number">28.9.14.2.3</span> Updating symmetric
 matrix-vector product<a href="#updating-symmetric-matrix-vector-product" class="self-link"></a></h5>
-<div class="sourceCode" id="cb88"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb88-1"><a href="#cb88-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat,</span>
-<span id="cb88-2"><a href="#cb88-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb88-3"><a href="#cb88-3" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec1,</span>
-<span id="cb88-4"><a href="#cb88-4" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2,</span>
-<span id="cb88-5"><a href="#cb88-5" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec<span class="op">&gt;</span></span>
-<span id="cb88-6"><a href="#cb88-6" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_vector_product<span class="op">(</span></span>
-<span id="cb88-7"><a href="#cb88-7" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
-<span id="cb88-8"><a href="#cb88-8" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb88-9"><a href="#cb88-9" aria-hidden="true" tabindex="-1"></a>  InVec1 x,</span>
-<span id="cb88-10"><a href="#cb88-10" aria-hidden="true" tabindex="-1"></a>  InVec2 y,</span>
-<span id="cb88-11"><a href="#cb88-11" aria-hidden="true" tabindex="-1"></a>  OutVec z<span class="op">)</span>;</span>
-<span id="cb88-12"><a href="#cb88-12" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb88-13"><a href="#cb88-13" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb88-14"><a href="#cb88-14" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat,</span>
-<span id="cb88-15"><a href="#cb88-15" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb88-16"><a href="#cb88-16" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec1,</span>
-<span id="cb88-17"><a href="#cb88-17" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2,</span>
-<span id="cb88-18"><a href="#cb88-18" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec<span class="op">&gt;</span></span>
-<span id="cb88-19"><a href="#cb88-19" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_vector_product<span class="op">(</span></span>
-<span id="cb88-20"><a href="#cb88-20" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb88-21"><a href="#cb88-21" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
-<span id="cb88-22"><a href="#cb88-22" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb88-23"><a href="#cb88-23" aria-hidden="true" tabindex="-1"></a>  InVec1 x,</span>
-<span id="cb88-24"><a href="#cb88-24" aria-hidden="true" tabindex="-1"></a>  InVec2 y,</span>
-<span id="cb88-25"><a href="#cb88-25" aria-hidden="true" tabindex="-1"></a>  OutVec z<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb95"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb95-1"><a href="#cb95-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat,</span>
+<span id="cb95-2"><a href="#cb95-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb95-3"><a href="#cb95-3" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec1,</span>
+<span id="cb95-4"><a href="#cb95-4" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2,</span>
+<span id="cb95-5"><a href="#cb95-5" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec<span class="op">&gt;</span></span>
+<span id="cb95-6"><a href="#cb95-6" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_vector_product<span class="op">(</span></span>
+<span id="cb95-7"><a href="#cb95-7" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
+<span id="cb95-8"><a href="#cb95-8" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb95-9"><a href="#cb95-9" aria-hidden="true" tabindex="-1"></a>  InVec1 x,</span>
+<span id="cb95-10"><a href="#cb95-10" aria-hidden="true" tabindex="-1"></a>  InVec2 y,</span>
+<span id="cb95-11"><a href="#cb95-11" aria-hidden="true" tabindex="-1"></a>  OutVec z<span class="op">)</span>;</span>
+<span id="cb95-12"><a href="#cb95-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb95-13"><a href="#cb95-13" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb95-14"><a href="#cb95-14" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat,</span>
+<span id="cb95-15"><a href="#cb95-15" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb95-16"><a href="#cb95-16" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec1,</span>
+<span id="cb95-17"><a href="#cb95-17" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2,</span>
+<span id="cb95-18"><a href="#cb95-18" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec<span class="op">&gt;</span></span>
+<span id="cb95-19"><a href="#cb95-19" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_vector_product<span class="op">(</span></span>
+<span id="cb95-20"><a href="#cb95-20" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb95-21"><a href="#cb95-21" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
+<span id="cb95-22"><a href="#cb95-22" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb95-23"><a href="#cb95-23" aria-hidden="true" tabindex="-1"></a>  InVec1 x,</span>
+<span id="cb95-24"><a href="#cb95-24" aria-hidden="true" tabindex="-1"></a>  InVec2 y,</span>
+<span id="cb95-25"><a href="#cb95-25" aria-hidden="true" tabindex="-1"></a>  OutVec z<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 <em>Effects:</em> Computes <span class="math inline"><em>z</em> = <em>y</em> + <em>A</em><em>x</em></span>.</p>
 <p><span class="marginalizedparent"><a class="marginalized">2</a></span>
@@ -8383,52 +8556,52 @@ array accesses and arithmetic operations that is linear in
 <code>x.extent(0)</code> times <code>A.extent(1)</code>.</p>
 <h5 data-number="28.9.14.3.2" id="overwriting-hermitian-matrix-vector-product"><span class="header-section-number">28.9.14.3.2</span> Overwriting Hermitian
 matrix-vector product<a href="#overwriting-hermitian-matrix-vector-product" class="self-link"></a></h5>
-<div class="sourceCode" id="cb89"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb89-1"><a href="#cb89-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat,</span>
-<span id="cb89-2"><a href="#cb89-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb89-3"><a href="#cb89-3" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
-<span id="cb89-4"><a href="#cb89-4" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec<span class="op">&gt;</span></span>
-<span id="cb89-5"><a href="#cb89-5" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_vector_product<span class="op">(</span>InMat A,</span>
-<span id="cb89-6"><a href="#cb89-6" aria-hidden="true" tabindex="-1"></a>                                     Triangle t,</span>
-<span id="cb89-7"><a href="#cb89-7" aria-hidden="true" tabindex="-1"></a>                                     InVec x,</span>
-<span id="cb89-8"><a href="#cb89-8" aria-hidden="true" tabindex="-1"></a>                                     OutVec y<span class="op">)</span>;</span>
-<span id="cb89-9"><a href="#cb89-9" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb89-10"><a href="#cb89-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb89-11"><a href="#cb89-11" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat,</span>
-<span id="cb89-12"><a href="#cb89-12" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb89-13"><a href="#cb89-13" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
-<span id="cb89-14"><a href="#cb89-14" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec<span class="op">&gt;</span></span>
-<span id="cb89-15"><a href="#cb89-15" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_vector_product<span class="op">(</span>ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb89-16"><a href="#cb89-16" aria-hidden="true" tabindex="-1"></a>                                     InMat A,</span>
-<span id="cb89-17"><a href="#cb89-17" aria-hidden="true" tabindex="-1"></a>                                     Triangle t,</span>
-<span id="cb89-18"><a href="#cb89-18" aria-hidden="true" tabindex="-1"></a>                                     InVec x,</span>
-<span id="cb89-19"><a href="#cb89-19" aria-hidden="true" tabindex="-1"></a>                                     OutVec y<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb96"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb96-1"><a href="#cb96-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat,</span>
+<span id="cb96-2"><a href="#cb96-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb96-3"><a href="#cb96-3" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
+<span id="cb96-4"><a href="#cb96-4" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec<span class="op">&gt;</span></span>
+<span id="cb96-5"><a href="#cb96-5" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_vector_product<span class="op">(</span>InMat A,</span>
+<span id="cb96-6"><a href="#cb96-6" aria-hidden="true" tabindex="-1"></a>                                     Triangle t,</span>
+<span id="cb96-7"><a href="#cb96-7" aria-hidden="true" tabindex="-1"></a>                                     InVec x,</span>
+<span id="cb96-8"><a href="#cb96-8" aria-hidden="true" tabindex="-1"></a>                                     OutVec y<span class="op">)</span>;</span>
+<span id="cb96-9"><a href="#cb96-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb96-10"><a href="#cb96-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb96-11"><a href="#cb96-11" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat,</span>
+<span id="cb96-12"><a href="#cb96-12" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb96-13"><a href="#cb96-13" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
+<span id="cb96-14"><a href="#cb96-14" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec<span class="op">&gt;</span></span>
+<span id="cb96-15"><a href="#cb96-15" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_vector_product<span class="op">(</span>ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb96-16"><a href="#cb96-16" aria-hidden="true" tabindex="-1"></a>                                     InMat A,</span>
+<span id="cb96-17"><a href="#cb96-17" aria-hidden="true" tabindex="-1"></a>                                     Triangle t,</span>
+<span id="cb96-18"><a href="#cb96-18" aria-hidden="true" tabindex="-1"></a>                                     InVec x,</span>
+<span id="cb96-19"><a href="#cb96-19" aria-hidden="true" tabindex="-1"></a>                                     OutVec y<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 <em>Effects:</em> Computes <span class="math inline"><em>y</em> = <em>A</em><em>x</em></span>.</p>
 <h5 data-number="28.9.14.3.3" id="updating-hermitian-matrix-vector-product"><span class="header-section-number">28.9.14.3.3</span> Updating Hermitian
 matrix-vector product<a href="#updating-hermitian-matrix-vector-product" class="self-link"></a></h5>
-<div class="sourceCode" id="cb90"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb90-1"><a href="#cb90-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat,</span>
-<span id="cb90-2"><a href="#cb90-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb90-3"><a href="#cb90-3" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec1,</span>
-<span id="cb90-4"><a href="#cb90-4" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2,</span>
-<span id="cb90-5"><a href="#cb90-5" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec<span class="op">&gt;</span></span>
-<span id="cb90-6"><a href="#cb90-6" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_vector_product<span class="op">(</span>InMat A,</span>
-<span id="cb90-7"><a href="#cb90-7" aria-hidden="true" tabindex="-1"></a>                                     Triangle t,</span>
-<span id="cb90-8"><a href="#cb90-8" aria-hidden="true" tabindex="-1"></a>                                     InVec1 x,</span>
-<span id="cb90-9"><a href="#cb90-9" aria-hidden="true" tabindex="-1"></a>                                     InVec2 y,</span>
-<span id="cb90-10"><a href="#cb90-10" aria-hidden="true" tabindex="-1"></a>                                     OutVec z<span class="op">)</span>;</span>
-<span id="cb90-11"><a href="#cb90-11" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb90-12"><a href="#cb90-12" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb90-13"><a href="#cb90-13" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat,</span>
-<span id="cb90-14"><a href="#cb90-14" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb90-15"><a href="#cb90-15" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec1,</span>
-<span id="cb90-16"><a href="#cb90-16" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2,</span>
-<span id="cb90-17"><a href="#cb90-17" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec<span class="op">&gt;</span></span>
-<span id="cb90-18"><a href="#cb90-18" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_vector_product<span class="op">(</span>ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb90-19"><a href="#cb90-19" aria-hidden="true" tabindex="-1"></a>                                     InMat A,</span>
-<span id="cb90-20"><a href="#cb90-20" aria-hidden="true" tabindex="-1"></a>                                     Triangle t,</span>
-<span id="cb90-21"><a href="#cb90-21" aria-hidden="true" tabindex="-1"></a>                                     InVec1 x,</span>
-<span id="cb90-22"><a href="#cb90-22" aria-hidden="true" tabindex="-1"></a>                                     InVec2 y,</span>
-<span id="cb90-23"><a href="#cb90-23" aria-hidden="true" tabindex="-1"></a>                                     OutVec z<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb97"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb97-1"><a href="#cb97-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat,</span>
+<span id="cb97-2"><a href="#cb97-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb97-3"><a href="#cb97-3" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec1,</span>
+<span id="cb97-4"><a href="#cb97-4" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2,</span>
+<span id="cb97-5"><a href="#cb97-5" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec<span class="op">&gt;</span></span>
+<span id="cb97-6"><a href="#cb97-6" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_vector_product<span class="op">(</span>InMat A,</span>
+<span id="cb97-7"><a href="#cb97-7" aria-hidden="true" tabindex="-1"></a>                                     Triangle t,</span>
+<span id="cb97-8"><a href="#cb97-8" aria-hidden="true" tabindex="-1"></a>                                     InVec1 x,</span>
+<span id="cb97-9"><a href="#cb97-9" aria-hidden="true" tabindex="-1"></a>                                     InVec2 y,</span>
+<span id="cb97-10"><a href="#cb97-10" aria-hidden="true" tabindex="-1"></a>                                     OutVec z<span class="op">)</span>;</span>
+<span id="cb97-11"><a href="#cb97-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb97-12"><a href="#cb97-12" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb97-13"><a href="#cb97-13" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat,</span>
+<span id="cb97-14"><a href="#cb97-14" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb97-15"><a href="#cb97-15" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec1,</span>
+<span id="cb97-16"><a href="#cb97-16" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2,</span>
+<span id="cb97-17"><a href="#cb97-17" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec<span class="op">&gt;</span></span>
+<span id="cb97-18"><a href="#cb97-18" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_vector_product<span class="op">(</span>ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb97-19"><a href="#cb97-19" aria-hidden="true" tabindex="-1"></a>                                     InMat A,</span>
+<span id="cb97-20"><a href="#cb97-20" aria-hidden="true" tabindex="-1"></a>                                     Triangle t,</span>
+<span id="cb97-21"><a href="#cb97-21" aria-hidden="true" tabindex="-1"></a>                                     InVec1 x,</span>
+<span id="cb97-22"><a href="#cb97-22" aria-hidden="true" tabindex="-1"></a>                                     InVec2 y,</span>
+<span id="cb97-23"><a href="#cb97-23" aria-hidden="true" tabindex="-1"></a>                                     OutVec z<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 <em>Effects:</em> Computes <span class="math inline"><em>z</em> = <em>y</em> + <em>A</em><em>x</em></span>.</p>
 <p><span class="marginalizedparent"><a class="marginalized">2</a></span>
@@ -8502,54 +8675,54 @@ that is linear in <code>y.extent(0)</code> times
 </ul>
 <h5 data-number="28.9.14.4.2" id="overwriting-triangular-matrix-vector-product-linalg.algs.blas2.trmv.ov"><span class="header-section-number">28.9.14.4.2</span> Overwriting triangular
 matrix-vector product [linalg.algs.blas2.trmv.ov]<a href="#overwriting-triangular-matrix-vector-product-linalg.algs.blas2.trmv.ov" class="self-link"></a></h5>
-<div class="sourceCode" id="cb91"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb91-1"><a href="#cb91-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat,</span>
-<span id="cb91-2"><a href="#cb91-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb91-3"><a href="#cb91-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb91-4"><a href="#cb91-4" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
-<span id="cb91-5"><a href="#cb91-5" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec<span class="op">&gt;</span></span>
-<span id="cb91-6"><a href="#cb91-6" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_vector_product<span class="op">(</span></span>
-<span id="cb91-7"><a href="#cb91-7" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
-<span id="cb91-8"><a href="#cb91-8" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb91-9"><a href="#cb91-9" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
-<span id="cb91-10"><a href="#cb91-10" aria-hidden="true" tabindex="-1"></a>  InVec x,</span>
-<span id="cb91-11"><a href="#cb91-11" aria-hidden="true" tabindex="-1"></a>  OutVec y<span class="op">)</span>;</span>
-<span id="cb91-12"><a href="#cb91-12" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb91-13"><a href="#cb91-13" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat,</span>
-<span id="cb91-14"><a href="#cb91-14" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb91-15"><a href="#cb91-15" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb91-16"><a href="#cb91-16" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
-<span id="cb91-17"><a href="#cb91-17" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec<span class="op">&gt;</span></span>
-<span id="cb91-18"><a href="#cb91-18" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_vector_product<span class="op">(</span></span>
-<span id="cb91-19"><a href="#cb91-19" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb91-20"><a href="#cb91-20" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
-<span id="cb91-21"><a href="#cb91-21" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb91-22"><a href="#cb91-22" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
-<span id="cb91-23"><a href="#cb91-23" aria-hidden="true" tabindex="-1"></a>  InVec x,</span>
-<span id="cb91-24"><a href="#cb91-24" aria-hidden="true" tabindex="-1"></a>  OutVec y<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb98"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb98-1"><a href="#cb98-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat,</span>
+<span id="cb98-2"><a href="#cb98-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb98-3"><a href="#cb98-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb98-4"><a href="#cb98-4" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
+<span id="cb98-5"><a href="#cb98-5" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec<span class="op">&gt;</span></span>
+<span id="cb98-6"><a href="#cb98-6" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_vector_product<span class="op">(</span></span>
+<span id="cb98-7"><a href="#cb98-7" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
+<span id="cb98-8"><a href="#cb98-8" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb98-9"><a href="#cb98-9" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
+<span id="cb98-10"><a href="#cb98-10" aria-hidden="true" tabindex="-1"></a>  InVec x,</span>
+<span id="cb98-11"><a href="#cb98-11" aria-hidden="true" tabindex="-1"></a>  OutVec y<span class="op">)</span>;</span>
+<span id="cb98-12"><a href="#cb98-12" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb98-13"><a href="#cb98-13" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat,</span>
+<span id="cb98-14"><a href="#cb98-14" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb98-15"><a href="#cb98-15" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb98-16"><a href="#cb98-16" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
+<span id="cb98-17"><a href="#cb98-17" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec<span class="op">&gt;</span></span>
+<span id="cb98-18"><a href="#cb98-18" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_vector_product<span class="op">(</span></span>
+<span id="cb98-19"><a href="#cb98-19" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb98-20"><a href="#cb98-20" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
+<span id="cb98-21"><a href="#cb98-21" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb98-22"><a href="#cb98-22" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
+<span id="cb98-23"><a href="#cb98-23" aria-hidden="true" tabindex="-1"></a>  InVec x,</span>
+<span id="cb98-24"><a href="#cb98-24" aria-hidden="true" tabindex="-1"></a>  OutVec y<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 <em>Effects:</em> Computes <span class="math inline"><em>y</em> = <em>A</em><em>x</em></span>.</p>
 <h5 data-number="28.9.14.4.3" id="in-place-triangular-matrix-vector-product-linalg.algs.blas2.trmv.in-place"><span class="header-section-number">28.9.14.4.3</span> In-place triangular
 matrix-vector product [linalg.algs.blas2.trmv.in-place]<a href="#in-place-triangular-matrix-vector-product-linalg.algs.blas2.trmv.in-place" class="self-link"></a></h5>
-<div class="sourceCode" id="cb92"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb92-1"><a href="#cb92-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat,</span>
-<span id="cb92-2"><a href="#cb92-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb92-3"><a href="#cb92-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb92-4"><a href="#cb92-4" aria-hidden="true" tabindex="-1"></a>         <em>inout-vector</em> InOutVec<span class="op">&gt;</span></span>
-<span id="cb92-5"><a href="#cb92-5" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_vector_product<span class="op">(</span></span>
-<span id="cb92-6"><a href="#cb92-6" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
-<span id="cb92-7"><a href="#cb92-7" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb92-8"><a href="#cb92-8" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
-<span id="cb92-9"><a href="#cb92-9" aria-hidden="true" tabindex="-1"></a>  InOutVec y<span class="op">)</span>;</span>
-<span id="cb92-10"><a href="#cb92-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb92-11"><a href="#cb92-11" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat,</span>
-<span id="cb92-12"><a href="#cb92-12" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb92-13"><a href="#cb92-13" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb92-14"><a href="#cb92-14" aria-hidden="true" tabindex="-1"></a>         <em>inout-vector</em> InOutVec<span class="op">&gt;</span></span>
-<span id="cb92-15"><a href="#cb92-15" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_vector_product<span class="op">(</span></span>
-<span id="cb92-16"><a href="#cb92-16" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb92-17"><a href="#cb92-17" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
-<span id="cb92-18"><a href="#cb92-18" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb92-19"><a href="#cb92-19" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
-<span id="cb92-20"><a href="#cb92-20" aria-hidden="true" tabindex="-1"></a>  InOutVec y<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb99"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb99-1"><a href="#cb99-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat,</span>
+<span id="cb99-2"><a href="#cb99-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb99-3"><a href="#cb99-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb99-4"><a href="#cb99-4" aria-hidden="true" tabindex="-1"></a>         <em>inout-vector</em> InOutVec<span class="op">&gt;</span></span>
+<span id="cb99-5"><a href="#cb99-5" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_vector_product<span class="op">(</span></span>
+<span id="cb99-6"><a href="#cb99-6" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
+<span id="cb99-7"><a href="#cb99-7" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb99-8"><a href="#cb99-8" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
+<span id="cb99-9"><a href="#cb99-9" aria-hidden="true" tabindex="-1"></a>  InOutVec y<span class="op">)</span>;</span>
+<span id="cb99-10"><a href="#cb99-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb99-11"><a href="#cb99-11" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat,</span>
+<span id="cb99-12"><a href="#cb99-12" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb99-13"><a href="#cb99-13" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb99-14"><a href="#cb99-14" aria-hidden="true" tabindex="-1"></a>         <em>inout-vector</em> InOutVec<span class="op">&gt;</span></span>
+<span id="cb99-15"><a href="#cb99-15" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_vector_product<span class="op">(</span></span>
+<span id="cb99-16"><a href="#cb99-16" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb99-17"><a href="#cb99-17" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
+<span id="cb99-18"><a href="#cb99-18" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb99-19"><a href="#cb99-19" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
+<span id="cb99-20"><a href="#cb99-20" aria-hidden="true" tabindex="-1"></a>  InOutVec y<span class="op">)</span>;</span></code></pre></div>
 <p><i>[Note:</i> Performing this operation in place hinders
 parallelization. However, other <code>ExecutionPolicy</code>-specific
 optimizations, such as vectorization, are still possible. <i>– end
@@ -8566,33 +8739,33 @@ note]</i></p>
 <em>Effects:</em> Computes <span class="math inline"><em>y</em> = <em>A</em><em>y</em></span>.</p>
 <h5 data-number="28.9.14.4.4" id="updating-triangular-matrix-vector-product-linalg.algs.blas2.trmv.up"><span class="header-section-number">28.9.14.4.4</span> Updating triangular
 matrix-vector product [linalg.algs.blas2.trmv.up]<a href="#updating-triangular-matrix-vector-product-linalg.algs.blas2.trmv.up" class="self-link"></a></h5>
-<div class="sourceCode" id="cb93"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb93-1"><a href="#cb93-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat,</span>
-<span id="cb93-2"><a href="#cb93-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb93-3"><a href="#cb93-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb93-4"><a href="#cb93-4" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec1,</span>
-<span id="cb93-5"><a href="#cb93-5" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2,</span>
-<span id="cb93-6"><a href="#cb93-6" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec<span class="op">&gt;</span></span>
-<span id="cb93-7"><a href="#cb93-7" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_vector_product<span class="op">(</span>InMat A,</span>
-<span id="cb93-8"><a href="#cb93-8" aria-hidden="true" tabindex="-1"></a>                                      Triangle t,</span>
-<span id="cb93-9"><a href="#cb93-9" aria-hidden="true" tabindex="-1"></a>                                      DiagonalStorage d,</span>
-<span id="cb93-10"><a href="#cb93-10" aria-hidden="true" tabindex="-1"></a>                                      InVec1 x,</span>
-<span id="cb93-11"><a href="#cb93-11" aria-hidden="true" tabindex="-1"></a>                                      InVec2 y,</span>
-<span id="cb93-12"><a href="#cb93-12" aria-hidden="true" tabindex="-1"></a>                                      OutVec z<span class="op">)</span>;</span>
-<span id="cb93-13"><a href="#cb93-13" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb93-14"><a href="#cb93-14" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb93-15"><a href="#cb93-15" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat,</span>
-<span id="cb93-16"><a href="#cb93-16" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb93-17"><a href="#cb93-17" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb93-18"><a href="#cb93-18" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec1,</span>
-<span id="cb93-19"><a href="#cb93-19" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2,</span>
-<span id="cb93-20"><a href="#cb93-20" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec<span class="op">&gt;</span></span>
-<span id="cb93-21"><a href="#cb93-21" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_vector_product<span class="op">(</span>ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb93-22"><a href="#cb93-22" aria-hidden="true" tabindex="-1"></a>                                      InMat A,</span>
-<span id="cb93-23"><a href="#cb93-23" aria-hidden="true" tabindex="-1"></a>                                      Triangle t,</span>
-<span id="cb93-24"><a href="#cb93-24" aria-hidden="true" tabindex="-1"></a>                                      DiagonalStorage d,</span>
-<span id="cb93-25"><a href="#cb93-25" aria-hidden="true" tabindex="-1"></a>                                      InVec1 x,</span>
-<span id="cb93-26"><a href="#cb93-26" aria-hidden="true" tabindex="-1"></a>                                      InVec2 y,</span>
-<span id="cb93-27"><a href="#cb93-27" aria-hidden="true" tabindex="-1"></a>                                      OutVec z<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb100"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb100-1"><a href="#cb100-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat,</span>
+<span id="cb100-2"><a href="#cb100-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb100-3"><a href="#cb100-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb100-4"><a href="#cb100-4" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec1,</span>
+<span id="cb100-5"><a href="#cb100-5" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2,</span>
+<span id="cb100-6"><a href="#cb100-6" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec<span class="op">&gt;</span></span>
+<span id="cb100-7"><a href="#cb100-7" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_vector_product<span class="op">(</span>InMat A,</span>
+<span id="cb100-8"><a href="#cb100-8" aria-hidden="true" tabindex="-1"></a>                                      Triangle t,</span>
+<span id="cb100-9"><a href="#cb100-9" aria-hidden="true" tabindex="-1"></a>                                      DiagonalStorage d,</span>
+<span id="cb100-10"><a href="#cb100-10" aria-hidden="true" tabindex="-1"></a>                                      InVec1 x,</span>
+<span id="cb100-11"><a href="#cb100-11" aria-hidden="true" tabindex="-1"></a>                                      InVec2 y,</span>
+<span id="cb100-12"><a href="#cb100-12" aria-hidden="true" tabindex="-1"></a>                                      OutVec z<span class="op">)</span>;</span>
+<span id="cb100-13"><a href="#cb100-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb100-14"><a href="#cb100-14" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb100-15"><a href="#cb100-15" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat,</span>
+<span id="cb100-16"><a href="#cb100-16" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb100-17"><a href="#cb100-17" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb100-18"><a href="#cb100-18" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec1,</span>
+<span id="cb100-19"><a href="#cb100-19" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2,</span>
+<span id="cb100-20"><a href="#cb100-20" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec<span class="op">&gt;</span></span>
+<span id="cb100-21"><a href="#cb100-21" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_vector_product<span class="op">(</span>ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb100-22"><a href="#cb100-22" aria-hidden="true" tabindex="-1"></a>                                      InMat A,</span>
+<span id="cb100-23"><a href="#cb100-23" aria-hidden="true" tabindex="-1"></a>                                      Triangle t,</span>
+<span id="cb100-24"><a href="#cb100-24" aria-hidden="true" tabindex="-1"></a>                                      DiagonalStorage d,</span>
+<span id="cb100-25"><a href="#cb100-25" aria-hidden="true" tabindex="-1"></a>                                      InVec1 x,</span>
+<span id="cb100-26"><a href="#cb100-26" aria-hidden="true" tabindex="-1"></a>                                      InVec2 y,</span>
+<span id="cb100-27"><a href="#cb100-27" aria-hidden="true" tabindex="-1"></a>                                      OutVec z<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 <em>Effects:</em> Computes <span class="math inline"><em>z</em> = <em>y</em> + <em>A</em><em>x</em></span>.</p>
 <p><span class="marginalizedparent"><a class="marginalized">2</a></span>
@@ -8649,34 +8822,34 @@ that is linear in <code>b.extent(0)</code> times
 </ul>
 <h5 data-number="28.9.14.5.2" id="not-in-place-triangular-solve-linalg.algs.blas2.trsv.not-in-place"><span class="header-section-number">28.9.14.5.2</span> Not-in-place triangular
 solve [linalg.algs.blas2.trsv.not-in-place]<a href="#not-in-place-triangular-solve-linalg.algs.blas2.trsv.not-in-place" class="self-link"></a></h5>
-<div class="sourceCode" id="cb94"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb94-1"><a href="#cb94-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat,</span>
-<span id="cb94-2"><a href="#cb94-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb94-3"><a href="#cb94-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb94-4"><a href="#cb94-4" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
-<span id="cb94-5"><a href="#cb94-5" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec,</span>
-<span id="cb94-6"><a href="#cb94-6" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> BinaryDivideOp<span class="op">&gt;</span></span>
-<span id="cb94-7"><a href="#cb94-7" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_vector_solve<span class="op">(</span></span>
-<span id="cb94-8"><a href="#cb94-8" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
-<span id="cb94-9"><a href="#cb94-9" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb94-10"><a href="#cb94-10" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
-<span id="cb94-11"><a href="#cb94-11" aria-hidden="true" tabindex="-1"></a>  InVec b,</span>
-<span id="cb94-12"><a href="#cb94-12" aria-hidden="true" tabindex="-1"></a>  OutVec x,</span>
-<span id="cb94-13"><a href="#cb94-13" aria-hidden="true" tabindex="-1"></a>  BinaryDivideOp divide<span class="op">)</span>;</span>
-<span id="cb94-14"><a href="#cb94-14" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb94-15"><a href="#cb94-15" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat,</span>
-<span id="cb94-16"><a href="#cb94-16" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb94-17"><a href="#cb94-17" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb94-18"><a href="#cb94-18" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
-<span id="cb94-19"><a href="#cb94-19" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec,</span>
-<span id="cb94-20"><a href="#cb94-20" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> BinaryDivideOp<span class="op">&gt;</span></span>
-<span id="cb94-21"><a href="#cb94-21" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_vector_solve<span class="op">(</span></span>
-<span id="cb94-22"><a href="#cb94-22" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb94-23"><a href="#cb94-23" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
-<span id="cb94-24"><a href="#cb94-24" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb94-25"><a href="#cb94-25" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
-<span id="cb94-26"><a href="#cb94-26" aria-hidden="true" tabindex="-1"></a>  InVec b,</span>
-<span id="cb94-27"><a href="#cb94-27" aria-hidden="true" tabindex="-1"></a>  OutVec x,</span>
-<span id="cb94-28"><a href="#cb94-28" aria-hidden="true" tabindex="-1"></a>  BinaryDivideOp divide<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb101"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb101-1"><a href="#cb101-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat,</span>
+<span id="cb101-2"><a href="#cb101-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb101-3"><a href="#cb101-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb101-4"><a href="#cb101-4" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
+<span id="cb101-5"><a href="#cb101-5" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec,</span>
+<span id="cb101-6"><a href="#cb101-6" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> BinaryDivideOp<span class="op">&gt;</span></span>
+<span id="cb101-7"><a href="#cb101-7" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_vector_solve<span class="op">(</span></span>
+<span id="cb101-8"><a href="#cb101-8" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
+<span id="cb101-9"><a href="#cb101-9" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb101-10"><a href="#cb101-10" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
+<span id="cb101-11"><a href="#cb101-11" aria-hidden="true" tabindex="-1"></a>  InVec b,</span>
+<span id="cb101-12"><a href="#cb101-12" aria-hidden="true" tabindex="-1"></a>  OutVec x,</span>
+<span id="cb101-13"><a href="#cb101-13" aria-hidden="true" tabindex="-1"></a>  BinaryDivideOp divide<span class="op">)</span>;</span>
+<span id="cb101-14"><a href="#cb101-14" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb101-15"><a href="#cb101-15" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat,</span>
+<span id="cb101-16"><a href="#cb101-16" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb101-17"><a href="#cb101-17" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb101-18"><a href="#cb101-18" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
+<span id="cb101-19"><a href="#cb101-19" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec,</span>
+<span id="cb101-20"><a href="#cb101-20" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> BinaryDivideOp<span class="op">&gt;</span></span>
+<span id="cb101-21"><a href="#cb101-21" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_vector_solve<span class="op">(</span></span>
+<span id="cb101-22"><a href="#cb101-22" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb101-23"><a href="#cb101-23" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
+<span id="cb101-24"><a href="#cb101-24" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb101-25"><a href="#cb101-25" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
+<span id="cb101-26"><a href="#cb101-26" aria-hidden="true" tabindex="-1"></a>  InVec b,</span>
+<span id="cb101-27"><a href="#cb101-27" aria-hidden="true" tabindex="-1"></a>  OutVec x,</span>
+<span id="cb101-28"><a href="#cb101-28" aria-hidden="true" tabindex="-1"></a>  BinaryDivideOp divide<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 <em>Preconditions:</em> <code>A.extent(0)</code> equals
 <code>x.extent(0)</code>.</p>
@@ -8691,65 +8864,65 @@ such that <span class="math inline"><em>b</em> = <em>A</em><em>x</em>′</sp
 assigns each element of <span class="math inline"><em>x</em>′</span> to
 the corresponding element of <code>x</code>. If no such <span class="math inline"><em>x</em>′</span> exists, then the elements of
 <code>x</code> are valid but unspecified.</p>
-<div class="sourceCode" id="cb95"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb95-1"><a href="#cb95-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat,</span>
-<span id="cb95-2"><a href="#cb95-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb95-3"><a href="#cb95-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb95-4"><a href="#cb95-4" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
-<span id="cb95-5"><a href="#cb95-5" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec<span class="op">&gt;</span></span>
-<span id="cb95-6"><a href="#cb95-6" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_vector_solve<span class="op">(</span></span>
-<span id="cb95-7"><a href="#cb95-7" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
-<span id="cb95-8"><a href="#cb95-8" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb95-9"><a href="#cb95-9" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
-<span id="cb95-10"><a href="#cb95-10" aria-hidden="true" tabindex="-1"></a>  InVec b,</span>
-<span id="cb95-11"><a href="#cb95-11" aria-hidden="true" tabindex="-1"></a>  OutVec x<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb102"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb102-1"><a href="#cb102-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat,</span>
+<span id="cb102-2"><a href="#cb102-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb102-3"><a href="#cb102-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb102-4"><a href="#cb102-4" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
+<span id="cb102-5"><a href="#cb102-5" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec<span class="op">&gt;</span></span>
+<span id="cb102-6"><a href="#cb102-6" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_vector_solve<span class="op">(</span></span>
+<span id="cb102-7"><a href="#cb102-7" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
+<span id="cb102-8"><a href="#cb102-8" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb102-9"><a href="#cb102-9" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
+<span id="cb102-10"><a href="#cb102-10" aria-hidden="true" tabindex="-1"></a>  InVec b,</span>
+<span id="cb102-11"><a href="#cb102-11" aria-hidden="true" tabindex="-1"></a>  OutVec x<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 <em>Effects:</em> Equivalent to</p>
-<div class="sourceCode" id="cb96"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb96-1"><a href="#cb96-1" aria-hidden="true" tabindex="-1"></a>triangular_matrix_vector_solve<span class="op">(</span>A, t, d, b, x,</span>
-<span id="cb96-2"><a href="#cb96-2" aria-hidden="true" tabindex="-1"></a>  <span class="op">[](</span><span class="kw">const</span> <span class="kw">auto</span><span class="op">&amp;</span> A_ii, <span class="kw">const</span> <span class="kw">auto</span><span class="op">&amp;</span> b_i<span class="op">)</span> <span class="op">{</span> <span class="cf">return</span> A_ii <span class="op">/</span> b_i; <span class="op">})</span>;</span></code></pre></div>
-<div class="sourceCode" id="cb97"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb97-1"><a href="#cb97-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb97-2"><a href="#cb97-2" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat,</span>
-<span id="cb97-3"><a href="#cb97-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb97-4"><a href="#cb97-4" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb97-5"><a href="#cb97-5" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
-<span id="cb97-6"><a href="#cb97-6" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec<span class="op">&gt;</span></span>
-<span id="cb97-7"><a href="#cb97-7" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_vector_solve<span class="op">(</span></span>
-<span id="cb97-8"><a href="#cb97-8" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb97-9"><a href="#cb97-9" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
-<span id="cb97-10"><a href="#cb97-10" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb97-11"><a href="#cb97-11" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
-<span id="cb97-12"><a href="#cb97-12" aria-hidden="true" tabindex="-1"></a>  InVec b,</span>
-<span id="cb97-13"><a href="#cb97-13" aria-hidden="true" tabindex="-1"></a>  OutVec x<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb103"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb103-1"><a href="#cb103-1" aria-hidden="true" tabindex="-1"></a>triangular_matrix_vector_solve<span class="op">(</span>A, t, d, b, x,</span>
+<span id="cb103-2"><a href="#cb103-2" aria-hidden="true" tabindex="-1"></a>  <span class="op">[](</span><span class="kw">const</span> <span class="kw">auto</span><span class="op">&amp;</span> A_ii, <span class="kw">const</span> <span class="kw">auto</span><span class="op">&amp;</span> b_i<span class="op">)</span> <span class="op">{</span> <span class="cf">return</span> A_ii <span class="op">/</span> b_i; <span class="op">})</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb104"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb104-1"><a href="#cb104-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb104-2"><a href="#cb104-2" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat,</span>
+<span id="cb104-3"><a href="#cb104-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb104-4"><a href="#cb104-4" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb104-5"><a href="#cb104-5" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
+<span id="cb104-6"><a href="#cb104-6" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec<span class="op">&gt;</span></span>
+<span id="cb104-7"><a href="#cb104-7" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_vector_solve<span class="op">(</span></span>
+<span id="cb104-8"><a href="#cb104-8" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb104-9"><a href="#cb104-9" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
+<span id="cb104-10"><a href="#cb104-10" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb104-11"><a href="#cb104-11" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
+<span id="cb104-12"><a href="#cb104-12" aria-hidden="true" tabindex="-1"></a>  InVec b,</span>
+<span id="cb104-13"><a href="#cb104-13" aria-hidden="true" tabindex="-1"></a>  OutVec x<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 <em>Effects:</em> Equivalent to</p>
-<div class="sourceCode" id="cb98"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb98-1"><a href="#cb98-1" aria-hidden="true" tabindex="-1"></a>triangular_matrix_vector_solve<span class="op">(</span>forward<span class="op">&lt;</span>ExecutionPolicy<span class="op">&gt;(</span>exec<span class="op">)</span>,</span>
-<span id="cb98-2"><a href="#cb98-2" aria-hidden="true" tabindex="-1"></a>  A, t, d, b, x,</span>
-<span id="cb98-3"><a href="#cb98-3" aria-hidden="true" tabindex="-1"></a>  <span class="op">[](</span><span class="kw">const</span> <span class="kw">auto</span><span class="op">&amp;</span> A_ii, <span class="kw">const</span> <span class="kw">auto</span><span class="op">&amp;</span> b_i<span class="op">)</span> <span class="op">{</span> <span class="cf">return</span> A_ii <span class="op">/</span> b_i; <span class="op">})</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb105"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb105-1"><a href="#cb105-1" aria-hidden="true" tabindex="-1"></a>triangular_matrix_vector_solve<span class="op">(</span>forward<span class="op">&lt;</span>ExecutionPolicy<span class="op">&gt;(</span>exec<span class="op">)</span>,</span>
+<span id="cb105-2"><a href="#cb105-2" aria-hidden="true" tabindex="-1"></a>  A, t, d, b, x,</span>
+<span id="cb105-3"><a href="#cb105-3" aria-hidden="true" tabindex="-1"></a>  <span class="op">[](</span><span class="kw">const</span> <span class="kw">auto</span><span class="op">&amp;</span> A_ii, <span class="kw">const</span> <span class="kw">auto</span><span class="op">&amp;</span> b_i<span class="op">)</span> <span class="op">{</span> <span class="cf">return</span> A_ii <span class="op">/</span> b_i; <span class="op">})</span>;</span></code></pre></div>
 <h5 data-number="28.9.14.5.3" id="in-place-triangular-solve-linalg.algs.blas2.trsv.in-place"><span class="header-section-number">28.9.14.5.3</span> In-place triangular
 solve [linalg.algs.blas2.trsv.in-place]<a href="#in-place-triangular-solve-linalg.algs.blas2.trsv.in-place" class="self-link"></a></h5>
-<div class="sourceCode" id="cb99"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb99-1"><a href="#cb99-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat,</span>
-<span id="cb99-2"><a href="#cb99-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb99-3"><a href="#cb99-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb99-4"><a href="#cb99-4" aria-hidden="true" tabindex="-1"></a>         <em>inout-vector</em> InOutVec,</span>
-<span id="cb99-5"><a href="#cb99-5" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> BinaryDivideOp<span class="op">&gt;</span></span>
-<span id="cb99-6"><a href="#cb99-6" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_vector_solve<span class="op">(</span></span>
-<span id="cb99-7"><a href="#cb99-7" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
-<span id="cb99-8"><a href="#cb99-8" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb99-9"><a href="#cb99-9" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
-<span id="cb99-10"><a href="#cb99-10" aria-hidden="true" tabindex="-1"></a>  InOutVec b,</span>
-<span id="cb99-11"><a href="#cb99-11" aria-hidden="true" tabindex="-1"></a>  BinaryDivideOp divide<span class="op">)</span>;</span>
-<span id="cb99-12"><a href="#cb99-12" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb99-13"><a href="#cb99-13" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat,</span>
-<span id="cb99-14"><a href="#cb99-14" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb99-15"><a href="#cb99-15" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb99-16"><a href="#cb99-16" aria-hidden="true" tabindex="-1"></a>         <em>inout-vector</em> InOutVec,</span>
-<span id="cb99-17"><a href="#cb99-17" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> BinaryDivideOp<span class="op">&gt;</span></span>
-<span id="cb99-18"><a href="#cb99-18" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_vector_solve<span class="op">(</span></span>
-<span id="cb99-19"><a href="#cb99-19" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb99-20"><a href="#cb99-20" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
-<span id="cb99-21"><a href="#cb99-21" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb99-22"><a href="#cb99-22" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
-<span id="cb99-23"><a href="#cb99-23" aria-hidden="true" tabindex="-1"></a>  InOutVec b,</span>
-<span id="cb99-24"><a href="#cb99-24" aria-hidden="true" tabindex="-1"></a>  BinaryDivideOp divide<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb106"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb106-1"><a href="#cb106-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat,</span>
+<span id="cb106-2"><a href="#cb106-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb106-3"><a href="#cb106-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb106-4"><a href="#cb106-4" aria-hidden="true" tabindex="-1"></a>         <em>inout-vector</em> InOutVec,</span>
+<span id="cb106-5"><a href="#cb106-5" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> BinaryDivideOp<span class="op">&gt;</span></span>
+<span id="cb106-6"><a href="#cb106-6" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_vector_solve<span class="op">(</span></span>
+<span id="cb106-7"><a href="#cb106-7" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
+<span id="cb106-8"><a href="#cb106-8" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb106-9"><a href="#cb106-9" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
+<span id="cb106-10"><a href="#cb106-10" aria-hidden="true" tabindex="-1"></a>  InOutVec b,</span>
+<span id="cb106-11"><a href="#cb106-11" aria-hidden="true" tabindex="-1"></a>  BinaryDivideOp divide<span class="op">)</span>;</span>
+<span id="cb106-12"><a href="#cb106-12" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb106-13"><a href="#cb106-13" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat,</span>
+<span id="cb106-14"><a href="#cb106-14" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb106-15"><a href="#cb106-15" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb106-16"><a href="#cb106-16" aria-hidden="true" tabindex="-1"></a>         <em>inout-vector</em> InOutVec,</span>
+<span id="cb106-17"><a href="#cb106-17" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> BinaryDivideOp<span class="op">&gt;</span></span>
+<span id="cb106-18"><a href="#cb106-18" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_vector_solve<span class="op">(</span></span>
+<span id="cb106-19"><a href="#cb106-19" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb106-20"><a href="#cb106-20" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
+<span id="cb106-21"><a href="#cb106-21" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb106-22"><a href="#cb106-22" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
+<span id="cb106-23"><a href="#cb106-23" aria-hidden="true" tabindex="-1"></a>  InOutVec b,</span>
+<span id="cb106-24"><a href="#cb106-24" aria-hidden="true" tabindex="-1"></a>  BinaryDivideOp divide<span class="op">)</span>;</span></code></pre></div>
 <p><i>[Note:</i> Performing triangular solve in place hinders
 parallelization. However, other <code>ExecutionPolicy</code>-specific
 optimizations, such as vectorization, are still possible. <i>– end
@@ -8768,56 +8941,56 @@ such that <span class="math inline"><em>b</em> = <em>A</em><em>x</em>′</sp
 assigns each element of <span class="math inline"><em>x</em>′</span> to
 the corresponding element of <code>b</code>. If no such <span class="math inline"><em>x</em>′</span> exists, then the elements of
 <code>b</code> are valid but unspecified.</p>
-<div class="sourceCode" id="cb100"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb100-1"><a href="#cb100-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat,</span>
-<span id="cb100-2"><a href="#cb100-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb100-3"><a href="#cb100-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb100-4"><a href="#cb100-4" aria-hidden="true" tabindex="-1"></a>         <em>inout-vector</em> InOutVec<span class="op">&gt;</span></span>
-<span id="cb100-5"><a href="#cb100-5" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_vector_solve<span class="op">(</span></span>
-<span id="cb100-6"><a href="#cb100-6" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
-<span id="cb100-7"><a href="#cb100-7" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb100-8"><a href="#cb100-8" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
-<span id="cb100-9"><a href="#cb100-9" aria-hidden="true" tabindex="-1"></a>  InOutVec b<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb107"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb107-1"><a href="#cb107-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat,</span>
+<span id="cb107-2"><a href="#cb107-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb107-3"><a href="#cb107-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb107-4"><a href="#cb107-4" aria-hidden="true" tabindex="-1"></a>         <em>inout-vector</em> InOutVec<span class="op">&gt;</span></span>
+<span id="cb107-5"><a href="#cb107-5" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_vector_solve<span class="op">(</span></span>
+<span id="cb107-6"><a href="#cb107-6" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
+<span id="cb107-7"><a href="#cb107-7" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb107-8"><a href="#cb107-8" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
+<span id="cb107-9"><a href="#cb107-9" aria-hidden="true" tabindex="-1"></a>  InOutVec b<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 <em>Effects:</em> Equivalent to</p>
-<div class="sourceCode" id="cb101"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb101-1"><a href="#cb101-1" aria-hidden="true" tabindex="-1"></a>triangular_matrix_vector_solve<span class="op">(</span>A, t, d, b,</span>
-<span id="cb101-2"><a href="#cb101-2" aria-hidden="true" tabindex="-1"></a>  <span class="op">[](</span><span class="kw">const</span> <span class="kw">auto</span><span class="op">&amp;</span> A_ii, <span class="kw">const</span> <span class="kw">auto</span><span class="op">&amp;</span> b_i<span class="op">){</span> <span class="cf">return</span> A_ii <span class="op">/</span> b_i; <span class="op">})</span>;</span></code></pre></div>
-<div class="sourceCode" id="cb102"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb102-1"><a href="#cb102-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb102-2"><a href="#cb102-2" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat,</span>
-<span id="cb102-3"><a href="#cb102-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb102-4"><a href="#cb102-4" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb102-5"><a href="#cb102-5" aria-hidden="true" tabindex="-1"></a>         <em>inout-vector</em> InOutVec<span class="op">&gt;</span></span>
-<span id="cb102-6"><a href="#cb102-6" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_vector_solve<span class="op">(</span></span>
-<span id="cb102-7"><a href="#cb102-7" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb102-8"><a href="#cb102-8" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
-<span id="cb102-9"><a href="#cb102-9" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb102-10"><a href="#cb102-10" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
-<span id="cb102-11"><a href="#cb102-11" aria-hidden="true" tabindex="-1"></a>  InOutVec b<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb108"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb108-1"><a href="#cb108-1" aria-hidden="true" tabindex="-1"></a>triangular_matrix_vector_solve<span class="op">(</span>A, t, d, b,</span>
+<span id="cb108-2"><a href="#cb108-2" aria-hidden="true" tabindex="-1"></a>  <span class="op">[](</span><span class="kw">const</span> <span class="kw">auto</span><span class="op">&amp;</span> A_ii, <span class="kw">const</span> <span class="kw">auto</span><span class="op">&amp;</span> b_i<span class="op">){</span> <span class="cf">return</span> A_ii <span class="op">/</span> b_i; <span class="op">})</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb109"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb109-1"><a href="#cb109-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb109-2"><a href="#cb109-2" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat,</span>
+<span id="cb109-3"><a href="#cb109-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb109-4"><a href="#cb109-4" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb109-5"><a href="#cb109-5" aria-hidden="true" tabindex="-1"></a>         <em>inout-vector</em> InOutVec<span class="op">&gt;</span></span>
+<span id="cb109-6"><a href="#cb109-6" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_vector_solve<span class="op">(</span></span>
+<span id="cb109-7"><a href="#cb109-7" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb109-8"><a href="#cb109-8" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
+<span id="cb109-9"><a href="#cb109-9" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb109-10"><a href="#cb109-10" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
+<span id="cb109-11"><a href="#cb109-11" aria-hidden="true" tabindex="-1"></a>  InOutVec b<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 <em>Effects:</em> Equivalent to</p>
-<div class="sourceCode" id="cb103"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb103-1"><a href="#cb103-1" aria-hidden="true" tabindex="-1"></a>triangular_matrix_vector_solve<span class="op">(</span>forward<span class="op">&lt;</span>ExecutionPolicy<span class="op">&gt;(</span>exec<span class="op">)</span>,</span>
-<span id="cb103-2"><a href="#cb103-2" aria-hidden="true" tabindex="-1"></a>  A, t, d, b,</span>
-<span id="cb103-3"><a href="#cb103-3" aria-hidden="true" tabindex="-1"></a>  <span class="op">[](</span><span class="kw">const</span> <span class="kw">auto</span><span class="op">&amp;</span> A_ii, <span class="kw">const</span> <span class="kw">auto</span><span class="op">&amp;</span> b_i<span class="op">){</span> <span class="cf">return</span> A_ii <span class="op">/</span> b_i; <span class="op">})</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb110"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb110-1"><a href="#cb110-1" aria-hidden="true" tabindex="-1"></a>triangular_matrix_vector_solve<span class="op">(</span>forward<span class="op">&lt;</span>ExecutionPolicy<span class="op">&gt;(</span>exec<span class="op">)</span>,</span>
+<span id="cb110-2"><a href="#cb110-2" aria-hidden="true" tabindex="-1"></a>  A, t, d, b,</span>
+<span id="cb110-3"><a href="#cb110-3" aria-hidden="true" tabindex="-1"></a>  <span class="op">[](</span><span class="kw">const</span> <span class="kw">auto</span><span class="op">&amp;</span> A_ii, <span class="kw">const</span> <span class="kw">auto</span><span class="op">&amp;</span> b_i<span class="op">){</span> <span class="cf">return</span> A_ii <span class="op">/</span> b_i; <span class="op">})</span>;</span></code></pre></div>
 <h4 data-number="28.9.14.6" id="rank-1-outer-product-update-of-a-matrix-linalg.algs.blas2.rank1"><span class="header-section-number">28.9.14.6</span> Rank-1 (outer product)
 update of a matrix [linalg.algs.blas2.rank1]<a href="#rank-1-outer-product-update-of-a-matrix-linalg.algs.blas2.rank1" class="self-link"></a></h4>
 <h5 data-number="28.9.14.6.1" id="nonsymmetric-nonconjugated-rank-1-update-linalg.algs.blas2.rank1.geru"><span class="header-section-number">28.9.14.6.1</span> Nonsymmetric
 nonconjugated rank-1 update [linalg.algs.blas2.rank1.geru]<a href="#nonsymmetric-nonconjugated-rank-1-update-linalg.algs.blas2.rank1.geru" class="self-link"></a></h5>
-<div class="sourceCode" id="cb104"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb104-1"><a href="#cb104-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-vector</em> InVec1,</span>
-<span id="cb104-2"><a href="#cb104-2" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2,</span>
-<span id="cb104-3"><a href="#cb104-3" aria-hidden="true" tabindex="-1"></a>         <em>inout-matrix</em> InOutMat<span class="op">&gt;</span></span>
-<span id="cb104-4"><a href="#cb104-4" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> matrix_rank_1_update<span class="op">(</span></span>
-<span id="cb104-5"><a href="#cb104-5" aria-hidden="true" tabindex="-1"></a>  InVec1 x,</span>
-<span id="cb104-6"><a href="#cb104-6" aria-hidden="true" tabindex="-1"></a>  InVec2 y,</span>
-<span id="cb104-7"><a href="#cb104-7" aria-hidden="true" tabindex="-1"></a>  InOutMat A<span class="op">)</span>;</span>
-<span id="cb104-8"><a href="#cb104-8" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb104-9"><a href="#cb104-9" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb104-10"><a href="#cb104-10" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec1,</span>
-<span id="cb104-11"><a href="#cb104-11" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2,</span>
-<span id="cb104-12"><a href="#cb104-12" aria-hidden="true" tabindex="-1"></a>         <em>inout-matrix</em> InOutMat<span class="op">&gt;</span></span>
-<span id="cb104-13"><a href="#cb104-13" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> matrix_rank_1_update<span class="op">(</span></span>
-<span id="cb104-14"><a href="#cb104-14" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb104-15"><a href="#cb104-15" aria-hidden="true" tabindex="-1"></a>  InVec1 x,</span>
-<span id="cb104-16"><a href="#cb104-16" aria-hidden="true" tabindex="-1"></a>  InVec2 y,</span>
-<span id="cb104-17"><a href="#cb104-17" aria-hidden="true" tabindex="-1"></a>  InOutMat A<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb111"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb111-1"><a href="#cb111-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-vector</em> InVec1,</span>
+<span id="cb111-2"><a href="#cb111-2" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2,</span>
+<span id="cb111-3"><a href="#cb111-3" aria-hidden="true" tabindex="-1"></a>         <em>inout-matrix</em> InOutMat<span class="op">&gt;</span></span>
+<span id="cb111-4"><a href="#cb111-4" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> matrix_rank_1_update<span class="op">(</span></span>
+<span id="cb111-5"><a href="#cb111-5" aria-hidden="true" tabindex="-1"></a>  InVec1 x,</span>
+<span id="cb111-6"><a href="#cb111-6" aria-hidden="true" tabindex="-1"></a>  InVec2 y,</span>
+<span id="cb111-7"><a href="#cb111-7" aria-hidden="true" tabindex="-1"></a>  InOutMat A<span class="op">)</span>;</span>
+<span id="cb111-8"><a href="#cb111-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb111-9"><a href="#cb111-9" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb111-10"><a href="#cb111-10" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec1,</span>
+<span id="cb111-11"><a href="#cb111-11" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2,</span>
+<span id="cb111-12"><a href="#cb111-12" aria-hidden="true" tabindex="-1"></a>         <em>inout-matrix</em> InOutMat<span class="op">&gt;</span></span>
+<span id="cb111-13"><a href="#cb111-13" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> matrix_rank_1_update<span class="op">(</span></span>
+<span id="cb111-14"><a href="#cb111-14" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb111-15"><a href="#cb111-15" aria-hidden="true" tabindex="-1"></a>  InVec1 x,</span>
+<span id="cb111-16"><a href="#cb111-16" aria-hidden="true" tabindex="-1"></a>  InVec2 y,</span>
+<span id="cb111-17"><a href="#cb111-17" aria-hidden="true" tabindex="-1"></a>  InOutMat A<span class="op">)</span>;</span></code></pre></div>
 <p><i>[Note:</i> This function corresponds to the BLAS functions
 <code>xGER</code> (for real element types) and <code>xGERU</code> (for
 complex element types). <i>– end note]</i></p>
@@ -8857,23 +9030,23 @@ as the result of `conjugated`.  Alternately, they can use the shortcut
 -->
 <h5 data-number="28.9.14.6.2" id="nonsymmetric-conjugated-rank-1-update-linalg.algs.blas2.rank1.gerc"><span class="header-section-number">28.9.14.6.2</span> Nonsymmetric conjugated
 rank-1 update [linalg.algs.blas2.rank1.gerc]<a href="#nonsymmetric-conjugated-rank-1-update-linalg.algs.blas2.rank1.gerc" class="self-link"></a></h5>
-<div class="sourceCode" id="cb105"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb105-1"><a href="#cb105-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-vector</em> InVec1,</span>
-<span id="cb105-2"><a href="#cb105-2" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2,</span>
-<span id="cb105-3"><a href="#cb105-3" aria-hidden="true" tabindex="-1"></a>         <em>inout-matrix</em> InOutMat<span class="op">&gt;</span></span>
-<span id="cb105-4"><a href="#cb105-4" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> matrix_rank_1_update_c<span class="op">(</span></span>
-<span id="cb105-5"><a href="#cb105-5" aria-hidden="true" tabindex="-1"></a>  InVec1 x,</span>
-<span id="cb105-6"><a href="#cb105-6" aria-hidden="true" tabindex="-1"></a>  InVec2 y,</span>
-<span id="cb105-7"><a href="#cb105-7" aria-hidden="true" tabindex="-1"></a>  InOutMat A<span class="op">)</span>;</span>
-<span id="cb105-8"><a href="#cb105-8" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb105-9"><a href="#cb105-9" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb105-10"><a href="#cb105-10" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec1,</span>
-<span id="cb105-11"><a href="#cb105-11" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2,</span>
-<span id="cb105-12"><a href="#cb105-12" aria-hidden="true" tabindex="-1"></a>         <em>inout-matrix</em> InOutMat<span class="op">&gt;</span></span>
-<span id="cb105-13"><a href="#cb105-13" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> matrix_rank_1_update_c<span class="op">(</span></span>
-<span id="cb105-14"><a href="#cb105-14" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb105-15"><a href="#cb105-15" aria-hidden="true" tabindex="-1"></a>  InVec1 x,</span>
-<span id="cb105-16"><a href="#cb105-16" aria-hidden="true" tabindex="-1"></a>  InVec2 y,</span>
-<span id="cb105-17"><a href="#cb105-17" aria-hidden="true" tabindex="-1"></a>  InOutMat A<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb112"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb112-1"><a href="#cb112-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-vector</em> InVec1,</span>
+<span id="cb112-2"><a href="#cb112-2" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2,</span>
+<span id="cb112-3"><a href="#cb112-3" aria-hidden="true" tabindex="-1"></a>         <em>inout-matrix</em> InOutMat<span class="op">&gt;</span></span>
+<span id="cb112-4"><a href="#cb112-4" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> matrix_rank_1_update_c<span class="op">(</span></span>
+<span id="cb112-5"><a href="#cb112-5" aria-hidden="true" tabindex="-1"></a>  InVec1 x,</span>
+<span id="cb112-6"><a href="#cb112-6" aria-hidden="true" tabindex="-1"></a>  InVec2 y,</span>
+<span id="cb112-7"><a href="#cb112-7" aria-hidden="true" tabindex="-1"></a>  InOutMat A<span class="op">)</span>;</span>
+<span id="cb112-8"><a href="#cb112-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb112-9"><a href="#cb112-9" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb112-10"><a href="#cb112-10" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec1,</span>
+<span id="cb112-11"><a href="#cb112-11" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2,</span>
+<span id="cb112-12"><a href="#cb112-12" aria-hidden="true" tabindex="-1"></a>         <em>inout-matrix</em> InOutMat<span class="op">&gt;</span></span>
+<span id="cb112-13"><a href="#cb112-13" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> matrix_rank_1_update_c<span class="op">(</span></span>
+<span id="cb112-14"><a href="#cb112-14" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb112-15"><a href="#cb112-15" aria-hidden="true" tabindex="-1"></a>  InVec1 x,</span>
+<span id="cb112-16"><a href="#cb112-16" aria-hidden="true" tabindex="-1"></a>  InVec2 y,</span>
+<span id="cb112-17"><a href="#cb112-17" aria-hidden="true" tabindex="-1"></a>  InOutMat A<span class="op">)</span>;</span></code></pre></div>
 <p><i>[Note:</i> This function corresponds to the BLAS functions
 <code>xGER</code> (for real element types) and <code>xGERC</code> (for
 complex element types). <i>– end note]</i></p>
@@ -8882,42 +9055,42 @@ complex element types). <i>– end note]</i></p>
 <code>matrix_rank_1_update(x, conjugated(y), A);</code>.</p>
 <h5 data-number="28.9.14.6.3" id="rank-1-update-of-a-symmetric-matrix-linalg.algs.blas2.rank1.syr"><span class="header-section-number">28.9.14.6.3</span> Rank-1 update of a
 Symmetric matrix [linalg.algs.blas2.rank1.syr]<a href="#rank-1-update-of-a-symmetric-matrix-linalg.algs.blas2.rank1.syr" class="self-link"></a></h5>
-<div class="sourceCode" id="cb106"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb106-1"><a href="#cb106-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-vector</em> InVec,</span>
-<span id="cb106-2"><a href="#cb106-2" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
-<span id="cb106-3"><a href="#cb106-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
-<span id="cb106-4"><a href="#cb106-4" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_rank_1_update<span class="op">(</span></span>
-<span id="cb106-5"><a href="#cb106-5" aria-hidden="true" tabindex="-1"></a>  InVec x,</span>
-<span id="cb106-6"><a href="#cb106-6" aria-hidden="true" tabindex="-1"></a>  InOutMat A,</span>
-<span id="cb106-7"><a href="#cb106-7" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span>
-<span id="cb106-8"><a href="#cb106-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb106-9"><a href="#cb106-9" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
-<span id="cb106-10"><a href="#cb106-10" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
-<span id="cb106-11"><a href="#cb106-11" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
-<span id="cb106-12"><a href="#cb106-12" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_rank_1_update<span class="op">(</span></span>
-<span id="cb106-13"><a href="#cb106-13" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb106-14"><a href="#cb106-14" aria-hidden="true" tabindex="-1"></a>  InVec x,</span>
-<span id="cb106-15"><a href="#cb106-15" aria-hidden="true" tabindex="-1"></a>  InOutMat A,</span>
-<span id="cb106-16"><a href="#cb106-16" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span>
-<span id="cb106-17"><a href="#cb106-17" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Scalar,</span>
-<span id="cb106-18"><a href="#cb106-18" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
-<span id="cb106-19"><a href="#cb106-19" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
-<span id="cb106-20"><a href="#cb106-20" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
-<span id="cb106-21"><a href="#cb106-21" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_rank_1_update<span class="op">(</span></span>
-<span id="cb106-22"><a href="#cb106-22" aria-hidden="true" tabindex="-1"></a>  Scalar alpha,</span>
-<span id="cb106-23"><a href="#cb106-23" aria-hidden="true" tabindex="-1"></a>  InVec x,</span>
-<span id="cb106-24"><a href="#cb106-24" aria-hidden="true" tabindex="-1"></a>  InOutMat A,</span>
-<span id="cb106-25"><a href="#cb106-25" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span>
-<span id="cb106-26"><a href="#cb106-26" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb106-27"><a href="#cb106-27" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar,</span>
-<span id="cb106-28"><a href="#cb106-28" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
-<span id="cb106-29"><a href="#cb106-29" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
-<span id="cb106-30"><a href="#cb106-30" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
-<span id="cb106-31"><a href="#cb106-31" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_rank_1_update<span class="op">(</span></span>
-<span id="cb106-32"><a href="#cb106-32" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb106-33"><a href="#cb106-33" aria-hidden="true" tabindex="-1"></a>  Scalar alpha,</span>
-<span id="cb106-34"><a href="#cb106-34" aria-hidden="true" tabindex="-1"></a>  InVec x,</span>
-<span id="cb106-35"><a href="#cb106-35" aria-hidden="true" tabindex="-1"></a>  InOutMat A,</span>
-<span id="cb106-36"><a href="#cb106-36" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb113"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb113-1"><a href="#cb113-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-vector</em> InVec,</span>
+<span id="cb113-2"><a href="#cb113-2" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
+<span id="cb113-3"><a href="#cb113-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
+<span id="cb113-4"><a href="#cb113-4" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_rank_1_update<span class="op">(</span></span>
+<span id="cb113-5"><a href="#cb113-5" aria-hidden="true" tabindex="-1"></a>  InVec x,</span>
+<span id="cb113-6"><a href="#cb113-6" aria-hidden="true" tabindex="-1"></a>  InOutMat A,</span>
+<span id="cb113-7"><a href="#cb113-7" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span>
+<span id="cb113-8"><a href="#cb113-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb113-9"><a href="#cb113-9" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
+<span id="cb113-10"><a href="#cb113-10" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
+<span id="cb113-11"><a href="#cb113-11" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
+<span id="cb113-12"><a href="#cb113-12" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_rank_1_update<span class="op">(</span></span>
+<span id="cb113-13"><a href="#cb113-13" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb113-14"><a href="#cb113-14" aria-hidden="true" tabindex="-1"></a>  InVec x,</span>
+<span id="cb113-15"><a href="#cb113-15" aria-hidden="true" tabindex="-1"></a>  InOutMat A,</span>
+<span id="cb113-16"><a href="#cb113-16" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span>
+<span id="cb113-17"><a href="#cb113-17" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Scalar,</span>
+<span id="cb113-18"><a href="#cb113-18" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
+<span id="cb113-19"><a href="#cb113-19" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
+<span id="cb113-20"><a href="#cb113-20" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
+<span id="cb113-21"><a href="#cb113-21" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_rank_1_update<span class="op">(</span></span>
+<span id="cb113-22"><a href="#cb113-22" aria-hidden="true" tabindex="-1"></a>  Scalar alpha,</span>
+<span id="cb113-23"><a href="#cb113-23" aria-hidden="true" tabindex="-1"></a>  InVec x,</span>
+<span id="cb113-24"><a href="#cb113-24" aria-hidden="true" tabindex="-1"></a>  InOutMat A,</span>
+<span id="cb113-25"><a href="#cb113-25" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span>
+<span id="cb113-26"><a href="#cb113-26" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb113-27"><a href="#cb113-27" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar,</span>
+<span id="cb113-28"><a href="#cb113-28" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
+<span id="cb113-29"><a href="#cb113-29" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
+<span id="cb113-30"><a href="#cb113-30" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
+<span id="cb113-31"><a href="#cb113-31" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_rank_1_update<span class="op">(</span></span>
+<span id="cb113-32"><a href="#cb113-32" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb113-33"><a href="#cb113-33" aria-hidden="true" tabindex="-1"></a>  Scalar alpha,</span>
+<span id="cb113-34"><a href="#cb113-34" aria-hidden="true" tabindex="-1"></a>  InVec x,</span>
+<span id="cb113-35"><a href="#cb113-35" aria-hidden="true" tabindex="-1"></a>  InOutMat A,</span>
+<span id="cb113-36"><a href="#cb113-36" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span></code></pre></div>
 <p><i>[Note:</i> These functions correspond to the BLAS functions
 <code>xSYR</code> and <code>xSPR</code>. <i>– end note]</i></p>
 <!--
@@ -8969,44 +9142,47 @@ with <code>mdspan</code> parameters perform a count of
 linear in <code>x.extent(0)</code> times <code>x.extent(0)</code>.</p>
 <h5 data-number="28.9.14.6.4" id="rank-1-update-of-a-hermitian-matrix-linalg.algs.blas2.rank1.her"><span class="header-section-number">28.9.14.6.4</span> Rank-1 update of a
 Hermitian matrix [linalg.algs.blas2.rank1.her]<a href="#rank-1-update-of-a-hermitian-matrix-linalg.algs.blas2.rank1.her" class="self-link"></a></h5>
-<div class="sourceCode" id="cb107"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb107-1"><a href="#cb107-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-vector</em> InVec,</span>
-<span id="cb107-2"><a href="#cb107-2" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
-<span id="cb107-3"><a href="#cb107-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
-<span id="cb107-4"><a href="#cb107-4" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_rank_1_update<span class="op">(</span></span>
-<span id="cb107-5"><a href="#cb107-5" aria-hidden="true" tabindex="-1"></a>  InVec x,</span>
-<span id="cb107-6"><a href="#cb107-6" aria-hidden="true" tabindex="-1"></a>  InOutMat A,</span>
-<span id="cb107-7"><a href="#cb107-7" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span>
-<span id="cb107-8"><a href="#cb107-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb107-9"><a href="#cb107-9" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
-<span id="cb107-10"><a href="#cb107-10" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
-<span id="cb107-11"><a href="#cb107-11" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
-<span id="cb107-12"><a href="#cb107-12" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_rank_1_update<span class="op">(</span></span>
-<span id="cb107-13"><a href="#cb107-13" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb107-14"><a href="#cb107-14" aria-hidden="true" tabindex="-1"></a>  InVec x,</span>
-<span id="cb107-15"><a href="#cb107-15" aria-hidden="true" tabindex="-1"></a>  InOutMat A,</span>
-<span id="cb107-16"><a href="#cb107-16" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span>
-<span id="cb107-17"><a href="#cb107-17" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Scalar,</span>
-<span id="cb107-18"><a href="#cb107-18" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
-<span id="cb107-19"><a href="#cb107-19" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
-<span id="cb107-20"><a href="#cb107-20" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
-<span id="cb107-21"><a href="#cb107-21" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_rank_1_update<span class="op">(</span></span>
-<span id="cb107-22"><a href="#cb107-22" aria-hidden="true" tabindex="-1"></a>  Scalar alpha,</span>
-<span id="cb107-23"><a href="#cb107-23" aria-hidden="true" tabindex="-1"></a>  InVec x,</span>
-<span id="cb107-24"><a href="#cb107-24" aria-hidden="true" tabindex="-1"></a>  InOutMat A,</span>
-<span id="cb107-25"><a href="#cb107-25" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span>
-<span id="cb107-26"><a href="#cb107-26" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb107-27"><a href="#cb107-27" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar,</span>
-<span id="cb107-28"><a href="#cb107-28" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
-<span id="cb107-29"><a href="#cb107-29" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
-<span id="cb107-30"><a href="#cb107-30" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
-<span id="cb107-31"><a href="#cb107-31" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_rank_1_update<span class="op">(</span></span>
-<span id="cb107-32"><a href="#cb107-32" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb107-33"><a href="#cb107-33" aria-hidden="true" tabindex="-1"></a>  Scalar alpha,</span>
-<span id="cb107-34"><a href="#cb107-34" aria-hidden="true" tabindex="-1"></a>  InVec x,</span>
-<span id="cb107-35"><a href="#cb107-35" aria-hidden="true" tabindex="-1"></a>  InOutMat A,</span>
-<span id="cb107-36"><a href="#cb107-36" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb114"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb114-1"><a href="#cb114-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-vector</em> InVec,</span>
+<span id="cb114-2"><a href="#cb114-2" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
+<span id="cb114-3"><a href="#cb114-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
+<span id="cb114-4"><a href="#cb114-4" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_rank_1_update<span class="op">(</span></span>
+<span id="cb114-5"><a href="#cb114-5" aria-hidden="true" tabindex="-1"></a>  InVec x,</span>
+<span id="cb114-6"><a href="#cb114-6" aria-hidden="true" tabindex="-1"></a>  InOutMat A,</span>
+<span id="cb114-7"><a href="#cb114-7" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span>
+<span id="cb114-8"><a href="#cb114-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb114-9"><a href="#cb114-9" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
+<span id="cb114-10"><a href="#cb114-10" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
+<span id="cb114-11"><a href="#cb114-11" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
+<span id="cb114-12"><a href="#cb114-12" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_rank_1_update<span class="op">(</span></span>
+<span id="cb114-13"><a href="#cb114-13" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb114-14"><a href="#cb114-14" aria-hidden="true" tabindex="-1"></a>  InVec x,</span>
+<span id="cb114-15"><a href="#cb114-15" aria-hidden="true" tabindex="-1"></a>  InOutMat A,</span>
+<span id="cb114-16"><a href="#cb114-16" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span>
+<span id="cb114-17"><a href="#cb114-17" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Scalar,</span>
+<span id="cb114-18"><a href="#cb114-18" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
+<span id="cb114-19"><a href="#cb114-19" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
+<span id="cb114-20"><a href="#cb114-20" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
+<span id="cb114-21"><a href="#cb114-21" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_rank_1_update<span class="op">(</span></span>
+<span id="cb114-22"><a href="#cb114-22" aria-hidden="true" tabindex="-1"></a>  Scalar alpha,</span>
+<span id="cb114-23"><a href="#cb114-23" aria-hidden="true" tabindex="-1"></a>  InVec x,</span>
+<span id="cb114-24"><a href="#cb114-24" aria-hidden="true" tabindex="-1"></a>  InOutMat A,</span>
+<span id="cb114-25"><a href="#cb114-25" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span>
+<span id="cb114-26"><a href="#cb114-26" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb114-27"><a href="#cb114-27" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar,</span>
+<span id="cb114-28"><a href="#cb114-28" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
+<span id="cb114-29"><a href="#cb114-29" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
+<span id="cb114-30"><a href="#cb114-30" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
+<span id="cb114-31"><a href="#cb114-31" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_rank_1_update<span class="op">(</span></span>
+<span id="cb114-32"><a href="#cb114-32" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb114-33"><a href="#cb114-33" aria-hidden="true" tabindex="-1"></a>  Scalar alpha,</span>
+<span id="cb114-34"><a href="#cb114-34" aria-hidden="true" tabindex="-1"></a>  InVec x,</span>
+<span id="cb114-35"><a href="#cb114-35" aria-hidden="true" tabindex="-1"></a>  InOutMat A,</span>
+<span id="cb114-36"><a href="#cb114-36" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span></code></pre></div>
 <p><i>[Note:</i> These functions correspond to the BLAS functions
-<code>xHER</code> and <code>xHPR</code>.]</i></p>
+<code>xHER</code> and <code>xHPR</code>.</p>
+<p>They have overloads taking a scaling factor <code>alpha</code>,
+because it would be impossible to express the update <span class="math inline"><em>A</em> = <em>A</em> − <em>x</em><em>x</em><sup><em>H</em></sup></span>
+otherwise. <i>– end note]</i></p>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 <em>Preconditions:</em></p>
 <ul>
@@ -9053,27 +9229,27 @@ linear in <code>x.extent(0)</code> times <code>x.extent(0)</code>.</p>
 [linalg.algs.blas2.rank2]<a href="#rank-2-matrix-updates-linalg.algs.blas2.rank2" class="self-link"></a></h4>
 <h5 data-number="28.9.14.7.1" id="rank-2-update-of-a-symmetric-matrix-linalg.algs.blas2.rank2.syr2"><span class="header-section-number">28.9.14.7.1</span> Rank-2 update of a
 symmetric matrix [linalg.algs.blas2.rank2.syr2]<a href="#rank-2-update-of-a-symmetric-matrix-linalg.algs.blas2.rank2.syr2" class="self-link"></a></h5>
-<div class="sourceCode" id="cb108"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb108-1"><a href="#cb108-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-vector</em> InVec1,</span>
-<span id="cb108-2"><a href="#cb108-2" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2,</span>
-<span id="cb108-3"><a href="#cb108-3" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
-<span id="cb108-4"><a href="#cb108-4" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
-<span id="cb108-5"><a href="#cb108-5" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_rank_2_update<span class="op">(</span></span>
-<span id="cb108-6"><a href="#cb108-6" aria-hidden="true" tabindex="-1"></a>  InVec1 x,</span>
-<span id="cb108-7"><a href="#cb108-7" aria-hidden="true" tabindex="-1"></a>  InVec2 y,</span>
-<span id="cb108-8"><a href="#cb108-8" aria-hidden="true" tabindex="-1"></a>  InOutMat A,</span>
-<span id="cb108-9"><a href="#cb108-9" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span>
-<span id="cb108-10"><a href="#cb108-10" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb108-11"><a href="#cb108-11" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb108-12"><a href="#cb108-12" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec1,</span>
-<span id="cb108-13"><a href="#cb108-13" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2,</span>
-<span id="cb108-14"><a href="#cb108-14" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
-<span id="cb108-15"><a href="#cb108-15" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
-<span id="cb108-16"><a href="#cb108-16" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_rank_2_update<span class="op">(</span></span>
-<span id="cb108-17"><a href="#cb108-17" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb108-18"><a href="#cb108-18" aria-hidden="true" tabindex="-1"></a>  InVec1 x,</span>
-<span id="cb108-19"><a href="#cb108-19" aria-hidden="true" tabindex="-1"></a>  InVec2 y,</span>
-<span id="cb108-20"><a href="#cb108-20" aria-hidden="true" tabindex="-1"></a>  InOutMat A,</span>
-<span id="cb108-21"><a href="#cb108-21" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb115"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb115-1"><a href="#cb115-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-vector</em> InVec1,</span>
+<span id="cb115-2"><a href="#cb115-2" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2,</span>
+<span id="cb115-3"><a href="#cb115-3" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
+<span id="cb115-4"><a href="#cb115-4" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
+<span id="cb115-5"><a href="#cb115-5" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_rank_2_update<span class="op">(</span></span>
+<span id="cb115-6"><a href="#cb115-6" aria-hidden="true" tabindex="-1"></a>  InVec1 x,</span>
+<span id="cb115-7"><a href="#cb115-7" aria-hidden="true" tabindex="-1"></a>  InVec2 y,</span>
+<span id="cb115-8"><a href="#cb115-8" aria-hidden="true" tabindex="-1"></a>  InOutMat A,</span>
+<span id="cb115-9"><a href="#cb115-9" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span>
+<span id="cb115-10"><a href="#cb115-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb115-11"><a href="#cb115-11" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb115-12"><a href="#cb115-12" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec1,</span>
+<span id="cb115-13"><a href="#cb115-13" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2,</span>
+<span id="cb115-14"><a href="#cb115-14" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
+<span id="cb115-15"><a href="#cb115-15" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
+<span id="cb115-16"><a href="#cb115-16" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_rank_2_update<span class="op">(</span></span>
+<span id="cb115-17"><a href="#cb115-17" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb115-18"><a href="#cb115-18" aria-hidden="true" tabindex="-1"></a>  InVec1 x,</span>
+<span id="cb115-19"><a href="#cb115-19" aria-hidden="true" tabindex="-1"></a>  InVec2 y,</span>
+<span id="cb115-20"><a href="#cb115-20" aria-hidden="true" tabindex="-1"></a>  InOutMat A,</span>
+<span id="cb115-21"><a href="#cb115-21" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span></code></pre></div>
 <p><i>[Note:</i> These functions correspond to the BLAS functions
 <code>xSYR2</code> and <code>xSPR2</code>. <i>– end note]</i></p>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
@@ -9119,27 +9295,27 @@ with <code>mdspan</code> parameters perform a count of
 linear in <code>x.extent(0)</code> times <code>y.extent(0)</code>.</p>
 <h5 data-number="28.9.14.7.2" id="rank-2-update-of-a-hermitian-matrix-linalg.algs.blas2.rank2.her2"><span class="header-section-number">28.9.14.7.2</span> Rank-2 update of a
 Hermitian matrix [linalg.algs.blas2.rank2.her2]<a href="#rank-2-update-of-a-hermitian-matrix-linalg.algs.blas2.rank2.her2" class="self-link"></a></h5>
-<div class="sourceCode" id="cb109"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb109-1"><a href="#cb109-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-vector</em> InVec1,</span>
-<span id="cb109-2"><a href="#cb109-2" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2,</span>
-<span id="cb109-3"><a href="#cb109-3" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
-<span id="cb109-4"><a href="#cb109-4" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
-<span id="cb109-5"><a href="#cb109-5" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_rank_2_update<span class="op">(</span></span>
-<span id="cb109-6"><a href="#cb109-6" aria-hidden="true" tabindex="-1"></a>  InVec1 x,</span>
-<span id="cb109-7"><a href="#cb109-7" aria-hidden="true" tabindex="-1"></a>  InVec2 y,</span>
-<span id="cb109-8"><a href="#cb109-8" aria-hidden="true" tabindex="-1"></a>  InOutMat A,</span>
-<span id="cb109-9"><a href="#cb109-9" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span>
-<span id="cb109-10"><a href="#cb109-10" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb109-11"><a href="#cb109-11" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb109-12"><a href="#cb109-12" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec1,</span>
-<span id="cb109-13"><a href="#cb109-13" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2,</span>
-<span id="cb109-14"><a href="#cb109-14" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
-<span id="cb109-15"><a href="#cb109-15" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
-<span id="cb109-16"><a href="#cb109-16" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_rank_2_update<span class="op">(</span></span>
-<span id="cb109-17"><a href="#cb109-17" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb109-18"><a href="#cb109-18" aria-hidden="true" tabindex="-1"></a>  InVec1 x,</span>
-<span id="cb109-19"><a href="#cb109-19" aria-hidden="true" tabindex="-1"></a>  InVec2 y,</span>
-<span id="cb109-20"><a href="#cb109-20" aria-hidden="true" tabindex="-1"></a>  InOutMat A,</span>
-<span id="cb109-21"><a href="#cb109-21" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb116"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb116-1"><a href="#cb116-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-vector</em> InVec1,</span>
+<span id="cb116-2"><a href="#cb116-2" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2,</span>
+<span id="cb116-3"><a href="#cb116-3" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
+<span id="cb116-4"><a href="#cb116-4" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
+<span id="cb116-5"><a href="#cb116-5" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_rank_2_update<span class="op">(</span></span>
+<span id="cb116-6"><a href="#cb116-6" aria-hidden="true" tabindex="-1"></a>  InVec1 x,</span>
+<span id="cb116-7"><a href="#cb116-7" aria-hidden="true" tabindex="-1"></a>  InVec2 y,</span>
+<span id="cb116-8"><a href="#cb116-8" aria-hidden="true" tabindex="-1"></a>  InOutMat A,</span>
+<span id="cb116-9"><a href="#cb116-9" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span>
+<span id="cb116-10"><a href="#cb116-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb116-11"><a href="#cb116-11" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb116-12"><a href="#cb116-12" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec1,</span>
+<span id="cb116-13"><a href="#cb116-13" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec2,</span>
+<span id="cb116-14"><a href="#cb116-14" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
+<span id="cb116-15"><a href="#cb116-15" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
+<span id="cb116-16"><a href="#cb116-16" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_rank_2_update<span class="op">(</span></span>
+<span id="cb116-17"><a href="#cb116-17" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb116-18"><a href="#cb116-18" aria-hidden="true" tabindex="-1"></a>  InVec1 x,</span>
+<span id="cb116-19"><a href="#cb116-19" aria-hidden="true" tabindex="-1"></a>  InVec2 y,</span>
+<span id="cb116-20"><a href="#cb116-20" aria-hidden="true" tabindex="-1"></a>  InOutMat A,</span>
+<span id="cb116-21"><a href="#cb116-21" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span></code></pre></div>
 <p><i>[Note:</i> These functions correspond to the BLAS functions
 <code>xHER2</code> and <code>xHPR2</code>. <i>– end note]</i></p>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
@@ -9242,44 +9418,44 @@ array accesses and arithmetic operations that is linear in
 <code>A.extent(1)</code>.</p>
 <h5 data-number="28.9.15.1.2" id="overwriting-general-matrix-matrix-product"><span class="header-section-number">28.9.15.1.2</span> Overwriting general
 matrix-matrix product<a href="#overwriting-general-matrix-matrix-product" class="self-link"></a></h5>
-<div class="sourceCode" id="cb110"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb110-1"><a href="#cb110-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
-<span id="cb110-2"><a href="#cb110-2" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
-<span id="cb110-3"><a href="#cb110-3" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
-<span id="cb110-4"><a href="#cb110-4" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> matrix_product<span class="op">(</span>InMat1 A,</span>
-<span id="cb110-5"><a href="#cb110-5" aria-hidden="true" tabindex="-1"></a>                    InMat2 B,</span>
-<span id="cb110-6"><a href="#cb110-6" aria-hidden="true" tabindex="-1"></a>                    OutMat C<span class="op">)</span>;</span>
-<span id="cb110-7"><a href="#cb110-7" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb110-8"><a href="#cb110-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb110-9"><a href="#cb110-9" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
-<span id="cb110-10"><a href="#cb110-10" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
-<span id="cb110-11"><a href="#cb110-11" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
-<span id="cb110-12"><a href="#cb110-12" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> matrix_product<span class="op">(</span>ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb110-13"><a href="#cb110-13" aria-hidden="true" tabindex="-1"></a>                    InMat1 A,</span>
-<span id="cb110-14"><a href="#cb110-14" aria-hidden="true" tabindex="-1"></a>                    InMat2 B,</span>
-<span id="cb110-15"><a href="#cb110-15" aria-hidden="true" tabindex="-1"></a>                    OutMat C<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb117"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb117-1"><a href="#cb117-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
+<span id="cb117-2"><a href="#cb117-2" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
+<span id="cb117-3"><a href="#cb117-3" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
+<span id="cb117-4"><a href="#cb117-4" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> matrix_product<span class="op">(</span>InMat1 A,</span>
+<span id="cb117-5"><a href="#cb117-5" aria-hidden="true" tabindex="-1"></a>                    InMat2 B,</span>
+<span id="cb117-6"><a href="#cb117-6" aria-hidden="true" tabindex="-1"></a>                    OutMat C<span class="op">)</span>;</span>
+<span id="cb117-7"><a href="#cb117-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb117-8"><a href="#cb117-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb117-9"><a href="#cb117-9" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
+<span id="cb117-10"><a href="#cb117-10" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
+<span id="cb117-11"><a href="#cb117-11" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
+<span id="cb117-12"><a href="#cb117-12" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> matrix_product<span class="op">(</span>ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb117-13"><a href="#cb117-13" aria-hidden="true" tabindex="-1"></a>                    InMat1 A,</span>
+<span id="cb117-14"><a href="#cb117-14" aria-hidden="true" tabindex="-1"></a>                    InMat2 B,</span>
+<span id="cb117-15"><a href="#cb117-15" aria-hidden="true" tabindex="-1"></a>                    OutMat C<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 <em>Effects:</em> Computes <span class="math inline"><em>C</em> = <em>A</em><em>B</em></span>.</p>
 <h5 data-number="28.9.15.1.3" id="updating-general-matrix-matrix-product"><span class="header-section-number">28.9.15.1.3</span> Updating general
 matrix-matrix product<a href="#updating-general-matrix-matrix-product" class="self-link"></a></h5>
-<div class="sourceCode" id="cb111"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb111-1"><a href="#cb111-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
-<span id="cb111-2"><a href="#cb111-2" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
-<span id="cb111-3"><a href="#cb111-3" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat3,</span>
-<span id="cb111-4"><a href="#cb111-4" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
-<span id="cb111-5"><a href="#cb111-5" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> matrix_product<span class="op">(</span>InMat1 A,</span>
-<span id="cb111-6"><a href="#cb111-6" aria-hidden="true" tabindex="-1"></a>                    InMat2 B,</span>
-<span id="cb111-7"><a href="#cb111-7" aria-hidden="true" tabindex="-1"></a>                    InMat3 E,</span>
-<span id="cb111-8"><a href="#cb111-8" aria-hidden="true" tabindex="-1"></a>                    OutMat C<span class="op">)</span>;</span>
-<span id="cb111-9"><a href="#cb111-9" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb111-10"><a href="#cb111-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb111-11"><a href="#cb111-11" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
-<span id="cb111-12"><a href="#cb111-12" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
-<span id="cb111-13"><a href="#cb111-13" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat3,</span>
-<span id="cb111-14"><a href="#cb111-14" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
-<span id="cb111-15"><a href="#cb111-15" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> matrix_product<span class="op">(</span>ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb111-16"><a href="#cb111-16" aria-hidden="true" tabindex="-1"></a>                    InMat1 A,</span>
-<span id="cb111-17"><a href="#cb111-17" aria-hidden="true" tabindex="-1"></a>                    InMat2 B,</span>
-<span id="cb111-18"><a href="#cb111-18" aria-hidden="true" tabindex="-1"></a>                    InMat3 E,</span>
-<span id="cb111-19"><a href="#cb111-19" aria-hidden="true" tabindex="-1"></a>                    OutMat C<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb118"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb118-1"><a href="#cb118-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
+<span id="cb118-2"><a href="#cb118-2" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
+<span id="cb118-3"><a href="#cb118-3" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat3,</span>
+<span id="cb118-4"><a href="#cb118-4" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
+<span id="cb118-5"><a href="#cb118-5" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> matrix_product<span class="op">(</span>InMat1 A,</span>
+<span id="cb118-6"><a href="#cb118-6" aria-hidden="true" tabindex="-1"></a>                    InMat2 B,</span>
+<span id="cb118-7"><a href="#cb118-7" aria-hidden="true" tabindex="-1"></a>                    InMat3 E,</span>
+<span id="cb118-8"><a href="#cb118-8" aria-hidden="true" tabindex="-1"></a>                    OutMat C<span class="op">)</span>;</span>
+<span id="cb118-9"><a href="#cb118-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb118-10"><a href="#cb118-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb118-11"><a href="#cb118-11" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
+<span id="cb118-12"><a href="#cb118-12" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
+<span id="cb118-13"><a href="#cb118-13" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat3,</span>
+<span id="cb118-14"><a href="#cb118-14" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
+<span id="cb118-15"><a href="#cb118-15" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> matrix_product<span class="op">(</span>ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb118-16"><a href="#cb118-16" aria-hidden="true" tabindex="-1"></a>                    InMat1 A,</span>
+<span id="cb118-17"><a href="#cb118-17" aria-hidden="true" tabindex="-1"></a>                    InMat2 B,</span>
+<span id="cb118-18"><a href="#cb118-18" aria-hidden="true" tabindex="-1"></a>                    InMat3 E,</span>
+<span id="cb118-19"><a href="#cb118-19" aria-hidden="true" tabindex="-1"></a>                    OutMat C<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 <em>Effects:</em> Computes <span class="math inline"><em>C</em> = <em>E</em> + <em>A</em><em>B</em></span>.</p>
 <p><span class="marginalizedparent"><a class="marginalized">2</a></span>
@@ -9411,106 +9587,106 @@ array accesses and arithmetic operations that is linear in
 <code>B.extent(1)</code>.</p>
 <h5 data-number="28.9.15.2.2" id="overwriting-symmetric-matrix-matrix-left-product-linalg.algs.blas3.symm.ovleft"><span class="header-section-number">28.9.15.2.2</span> Overwriting symmetric
 matrix-matrix left product [linalg.algs.blas3.symm.ovleft]<a href="#overwriting-symmetric-matrix-matrix-left-product-linalg.algs.blas3.symm.ovleft" class="self-link"></a></h5>
-<div class="sourceCode" id="cb112"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb112-1"><a href="#cb112-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
-<span id="cb112-2"><a href="#cb112-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb112-3"><a href="#cb112-3" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
-<span id="cb112-4"><a href="#cb112-4" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
-<span id="cb112-5"><a href="#cb112-5" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_product<span class="op">(</span></span>
-<span id="cb112-6"><a href="#cb112-6" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb112-7"><a href="#cb112-7" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb112-8"><a href="#cb112-8" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
-<span id="cb112-9"><a href="#cb112-9" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span>
-<span id="cb112-10"><a href="#cb112-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb112-11"><a href="#cb112-11" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
-<span id="cb112-12"><a href="#cb112-12" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb112-13"><a href="#cb112-13" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
-<span id="cb112-14"><a href="#cb112-14" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
-<span id="cb112-15"><a href="#cb112-15" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_product<span class="op">(</span></span>
-<span id="cb112-16"><a href="#cb112-16" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb112-17"><a href="#cb112-17" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb112-18"><a href="#cb112-18" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb112-19"><a href="#cb112-19" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
-<span id="cb112-20"><a href="#cb112-20" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb119"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb119-1"><a href="#cb119-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
+<span id="cb119-2"><a href="#cb119-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb119-3"><a href="#cb119-3" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
+<span id="cb119-4"><a href="#cb119-4" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
+<span id="cb119-5"><a href="#cb119-5" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_product<span class="op">(</span></span>
+<span id="cb119-6"><a href="#cb119-6" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb119-7"><a href="#cb119-7" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb119-8"><a href="#cb119-8" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
+<span id="cb119-9"><a href="#cb119-9" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span>
+<span id="cb119-10"><a href="#cb119-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb119-11"><a href="#cb119-11" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
+<span id="cb119-12"><a href="#cb119-12" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb119-13"><a href="#cb119-13" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
+<span id="cb119-14"><a href="#cb119-14" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
+<span id="cb119-15"><a href="#cb119-15" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_product<span class="op">(</span></span>
+<span id="cb119-16"><a href="#cb119-16" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb119-17"><a href="#cb119-17" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb119-18"><a href="#cb119-18" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb119-19"><a href="#cb119-19" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
+<span id="cb119-20"><a href="#cb119-20" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 <em>Effects:</em> Computes <span class="math inline"><em>C</em> = <em>A</em><em>B</em></span>.</p>
 <h5 data-number="28.9.15.2.3" id="overwriting-symmetric-matrix-matrix-right-product-linalg.algs.blas3.symm.ovright"><span class="header-section-number">28.9.15.2.3</span> Overwriting symmetric
 matrix-matrix right product [linalg.algs.blas3.symm.ovright]<a href="#overwriting-symmetric-matrix-matrix-right-product-linalg.algs.blas3.symm.ovright" class="self-link"></a></h5>
-<div class="sourceCode" id="cb113"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb113-1"><a href="#cb113-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
-<span id="cb113-2"><a href="#cb113-2" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
-<span id="cb113-3"><a href="#cb113-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb113-4"><a href="#cb113-4" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
-<span id="cb113-5"><a href="#cb113-5" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_product<span class="op">(</span></span>
-<span id="cb113-6"><a href="#cb113-6" aria-hidden="true" tabindex="-1"></a>  InMat1 B,</span>
-<span id="cb113-7"><a href="#cb113-7" aria-hidden="true" tabindex="-1"></a>  InMat2 A,</span>
-<span id="cb113-8"><a href="#cb113-8" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb113-9"><a href="#cb113-9" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span>
-<span id="cb113-10"><a href="#cb113-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb113-11"><a href="#cb113-11" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
-<span id="cb113-12"><a href="#cb113-12" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
-<span id="cb113-13"><a href="#cb113-13" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb113-14"><a href="#cb113-14" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
-<span id="cb113-15"><a href="#cb113-15" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_product<span class="op">(</span></span>
-<span id="cb113-16"><a href="#cb113-16" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb113-17"><a href="#cb113-17" aria-hidden="true" tabindex="-1"></a>  InMat1 B,</span>
-<span id="cb113-18"><a href="#cb113-18" aria-hidden="true" tabindex="-1"></a>  InMat2 A,</span>
-<span id="cb113-19"><a href="#cb113-19" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb113-20"><a href="#cb113-20" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb120"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb120-1"><a href="#cb120-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
+<span id="cb120-2"><a href="#cb120-2" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
+<span id="cb120-3"><a href="#cb120-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb120-4"><a href="#cb120-4" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
+<span id="cb120-5"><a href="#cb120-5" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_product<span class="op">(</span></span>
+<span id="cb120-6"><a href="#cb120-6" aria-hidden="true" tabindex="-1"></a>  InMat1 B,</span>
+<span id="cb120-7"><a href="#cb120-7" aria-hidden="true" tabindex="-1"></a>  InMat2 A,</span>
+<span id="cb120-8"><a href="#cb120-8" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb120-9"><a href="#cb120-9" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span>
+<span id="cb120-10"><a href="#cb120-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb120-11"><a href="#cb120-11" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
+<span id="cb120-12"><a href="#cb120-12" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
+<span id="cb120-13"><a href="#cb120-13" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb120-14"><a href="#cb120-14" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
+<span id="cb120-15"><a href="#cb120-15" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_product<span class="op">(</span></span>
+<span id="cb120-16"><a href="#cb120-16" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb120-17"><a href="#cb120-17" aria-hidden="true" tabindex="-1"></a>  InMat1 B,</span>
+<span id="cb120-18"><a href="#cb120-18" aria-hidden="true" tabindex="-1"></a>  InMat2 A,</span>
+<span id="cb120-19"><a href="#cb120-19" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb120-20"><a href="#cb120-20" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 <em>Effects:</em> Computes <span class="math inline"><em>C</em> = <em>B</em><em>A</em></span>.</p>
 <h5 data-number="28.9.15.2.4" id="updating-symmetric-matrix-matrix-left-product-linalg.algs.blas3.symm.upleft"><span class="header-section-number">28.9.15.2.4</span> Updating symmetric
 matrix-matrix left product [linalg.algs.blas3.symm.upleft]<a href="#updating-symmetric-matrix-matrix-left-product-linalg.algs.blas3.symm.upleft" class="self-link"></a></h5>
-<div class="sourceCode" id="cb114"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb114-1"><a href="#cb114-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
-<span id="cb114-2"><a href="#cb114-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb114-3"><a href="#cb114-3" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
-<span id="cb114-4"><a href="#cb114-4" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat3,</span>
-<span id="cb114-5"><a href="#cb114-5" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
-<span id="cb114-6"><a href="#cb114-6" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_product<span class="op">(</span></span>
-<span id="cb114-7"><a href="#cb114-7" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb114-8"><a href="#cb114-8" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb114-9"><a href="#cb114-9" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
-<span id="cb114-10"><a href="#cb114-10" aria-hidden="true" tabindex="-1"></a>  InMat3 E,</span>
-<span id="cb114-11"><a href="#cb114-11" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span>
-<span id="cb114-12"><a href="#cb114-12" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb114-13"><a href="#cb114-13" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
-<span id="cb114-14"><a href="#cb114-14" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb114-15"><a href="#cb114-15" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
-<span id="cb114-16"><a href="#cb114-16" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat3,</span>
-<span id="cb114-17"><a href="#cb114-17" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
-<span id="cb114-18"><a href="#cb114-18" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_product<span class="op">(</span></span>
-<span id="cb114-19"><a href="#cb114-19" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb114-20"><a href="#cb114-20" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb114-21"><a href="#cb114-21" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb114-22"><a href="#cb114-22" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
-<span id="cb114-23"><a href="#cb114-23" aria-hidden="true" tabindex="-1"></a>  InMat3 E,</span>
-<span id="cb114-24"><a href="#cb114-24" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb121"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb121-1"><a href="#cb121-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
+<span id="cb121-2"><a href="#cb121-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb121-3"><a href="#cb121-3" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
+<span id="cb121-4"><a href="#cb121-4" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat3,</span>
+<span id="cb121-5"><a href="#cb121-5" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
+<span id="cb121-6"><a href="#cb121-6" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_product<span class="op">(</span></span>
+<span id="cb121-7"><a href="#cb121-7" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb121-8"><a href="#cb121-8" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb121-9"><a href="#cb121-9" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
+<span id="cb121-10"><a href="#cb121-10" aria-hidden="true" tabindex="-1"></a>  InMat3 E,</span>
+<span id="cb121-11"><a href="#cb121-11" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span>
+<span id="cb121-12"><a href="#cb121-12" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb121-13"><a href="#cb121-13" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
+<span id="cb121-14"><a href="#cb121-14" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb121-15"><a href="#cb121-15" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
+<span id="cb121-16"><a href="#cb121-16" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat3,</span>
+<span id="cb121-17"><a href="#cb121-17" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
+<span id="cb121-18"><a href="#cb121-18" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_product<span class="op">(</span></span>
+<span id="cb121-19"><a href="#cb121-19" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb121-20"><a href="#cb121-20" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb121-21"><a href="#cb121-21" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb121-22"><a href="#cb121-22" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
+<span id="cb121-23"><a href="#cb121-23" aria-hidden="true" tabindex="-1"></a>  InMat3 E,</span>
+<span id="cb121-24"><a href="#cb121-24" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 <em>Effects:</em> Computes <span class="math inline"><em>C</em> = <em>E</em> + <em>A</em><em>B</em></span>.</p>
 <h5 data-number="28.9.15.2.5" id="updating-symmetric-matrix-matrix-right-product-linalg.algs.blas3.symm.upright"><span class="header-section-number">28.9.15.2.5</span> Updating symmetric
 matrix-matrix right product [linalg.algs.blas3.symm.upright]<a href="#updating-symmetric-matrix-matrix-right-product-linalg.algs.blas3.symm.upright" class="self-link"></a></h5>
-<div class="sourceCode" id="cb115"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb115-1"><a href="#cb115-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
-<span id="cb115-2"><a href="#cb115-2" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
-<span id="cb115-3"><a href="#cb115-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb115-4"><a href="#cb115-4" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat3,</span>
-<span id="cb115-5"><a href="#cb115-5" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
-<span id="cb115-6"><a href="#cb115-6" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_product<span class="op">(</span></span>
-<span id="cb115-7"><a href="#cb115-7" aria-hidden="true" tabindex="-1"></a>  InMat1 B,</span>
-<span id="cb115-8"><a href="#cb115-8" aria-hidden="true" tabindex="-1"></a>  InMat2 A,</span>
-<span id="cb115-9"><a href="#cb115-9" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb115-10"><a href="#cb115-10" aria-hidden="true" tabindex="-1"></a>  InMat3 E,</span>
-<span id="cb115-11"><a href="#cb115-11" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span>
-<span id="cb115-12"><a href="#cb115-12" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb115-13"><a href="#cb115-13" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
-<span id="cb115-14"><a href="#cb115-14" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
-<span id="cb115-15"><a href="#cb115-15" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb115-16"><a href="#cb115-16" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat3,</span>
-<span id="cb115-17"><a href="#cb115-17" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
-<span id="cb115-18"><a href="#cb115-18" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_product<span class="op">(</span></span>
-<span id="cb115-19"><a href="#cb115-19" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb115-20"><a href="#cb115-20" aria-hidden="true" tabindex="-1"></a>  InMat1 B,</span>
-<span id="cb115-21"><a href="#cb115-21" aria-hidden="true" tabindex="-1"></a>  InMat2 A,</span>
-<span id="cb115-22"><a href="#cb115-22" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb115-23"><a href="#cb115-23" aria-hidden="true" tabindex="-1"></a>  InMat3 E,</span>
-<span id="cb115-24"><a href="#cb115-24" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb122"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb122-1"><a href="#cb122-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
+<span id="cb122-2"><a href="#cb122-2" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
+<span id="cb122-3"><a href="#cb122-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb122-4"><a href="#cb122-4" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat3,</span>
+<span id="cb122-5"><a href="#cb122-5" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
+<span id="cb122-6"><a href="#cb122-6" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_product<span class="op">(</span></span>
+<span id="cb122-7"><a href="#cb122-7" aria-hidden="true" tabindex="-1"></a>  InMat1 B,</span>
+<span id="cb122-8"><a href="#cb122-8" aria-hidden="true" tabindex="-1"></a>  InMat2 A,</span>
+<span id="cb122-9"><a href="#cb122-9" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb122-10"><a href="#cb122-10" aria-hidden="true" tabindex="-1"></a>  InMat3 E,</span>
+<span id="cb122-11"><a href="#cb122-11" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span>
+<span id="cb122-12"><a href="#cb122-12" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb122-13"><a href="#cb122-13" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
+<span id="cb122-14"><a href="#cb122-14" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
+<span id="cb122-15"><a href="#cb122-15" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb122-16"><a href="#cb122-16" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat3,</span>
+<span id="cb122-17"><a href="#cb122-17" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
+<span id="cb122-18"><a href="#cb122-18" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_product<span class="op">(</span></span>
+<span id="cb122-19"><a href="#cb122-19" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb122-20"><a href="#cb122-20" aria-hidden="true" tabindex="-1"></a>  InMat1 B,</span>
+<span id="cb122-21"><a href="#cb122-21" aria-hidden="true" tabindex="-1"></a>  InMat2 A,</span>
+<span id="cb122-22"><a href="#cb122-22" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb122-23"><a href="#cb122-23" aria-hidden="true" tabindex="-1"></a>  InMat3 E,</span>
+<span id="cb122-24"><a href="#cb122-24" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 <em>Effects:</em> Computes <span class="math inline"><em>C</em> = <em>E</em> + <em>B</em><em>A</em></span>.</p>
 <h4 data-number="28.9.15.3" id="hermitian-matrix-matrix-product-linalg.algs.blas3.hemm"><span class="header-section-number">28.9.15.3</span> Hermitian matrix-matrix
@@ -9640,106 +9816,106 @@ operations that is linear in <code>B.extent(0)</code> times
 <code>A.extent(1)</code> times <code>B.extent(1)</code>.</p>
 <h5 data-number="28.9.15.3.2" id="overwriting-hermitian-matrix-matrix-left-product-linalg.algs.blas3.hemm.ovleft"><span class="header-section-number">28.9.15.3.2</span> Overwriting Hermitian
 matrix-matrix left product [linalg.algs.blas3.hemm.ovleft]<a href="#overwriting-hermitian-matrix-matrix-left-product-linalg.algs.blas3.hemm.ovleft" class="self-link"></a></h5>
-<div class="sourceCode" id="cb116"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb116-1"><a href="#cb116-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
-<span id="cb116-2"><a href="#cb116-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb116-3"><a href="#cb116-3" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
-<span id="cb116-4"><a href="#cb116-4" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
-<span id="cb116-5"><a href="#cb116-5" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_product<span class="op">(</span></span>
-<span id="cb116-6"><a href="#cb116-6" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb116-7"><a href="#cb116-7" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb116-8"><a href="#cb116-8" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
-<span id="cb116-9"><a href="#cb116-9" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span>
-<span id="cb116-10"><a href="#cb116-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb116-11"><a href="#cb116-11" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
-<span id="cb116-12"><a href="#cb116-12" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb116-13"><a href="#cb116-13" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
-<span id="cb116-14"><a href="#cb116-14" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
-<span id="cb116-15"><a href="#cb116-15" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_product<span class="op">(</span></span>
-<span id="cb116-16"><a href="#cb116-16" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb116-17"><a href="#cb116-17" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb116-18"><a href="#cb116-18" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb116-19"><a href="#cb116-19" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
-<span id="cb116-20"><a href="#cb116-20" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb123"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb123-1"><a href="#cb123-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
+<span id="cb123-2"><a href="#cb123-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb123-3"><a href="#cb123-3" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
+<span id="cb123-4"><a href="#cb123-4" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
+<span id="cb123-5"><a href="#cb123-5" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_product<span class="op">(</span></span>
+<span id="cb123-6"><a href="#cb123-6" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb123-7"><a href="#cb123-7" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb123-8"><a href="#cb123-8" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
+<span id="cb123-9"><a href="#cb123-9" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span>
+<span id="cb123-10"><a href="#cb123-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb123-11"><a href="#cb123-11" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
+<span id="cb123-12"><a href="#cb123-12" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb123-13"><a href="#cb123-13" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
+<span id="cb123-14"><a href="#cb123-14" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
+<span id="cb123-15"><a href="#cb123-15" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_product<span class="op">(</span></span>
+<span id="cb123-16"><a href="#cb123-16" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb123-17"><a href="#cb123-17" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb123-18"><a href="#cb123-18" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb123-19"><a href="#cb123-19" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
+<span id="cb123-20"><a href="#cb123-20" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 <em>Effects:</em> Computes <span class="math inline"><em>C</em> = <em>A</em><em>B</em></span>.</p>
 <h5 data-number="28.9.15.3.3" id="overwriting-hermitian-matrix-matrix-right-product-linalg.algs.blas3.hemm.ovright"><span class="header-section-number">28.9.15.3.3</span> Overwriting Hermitian
 matrix-matrix right product [linalg.algs.blas3.hemm.ovright]<a href="#overwriting-hermitian-matrix-matrix-right-product-linalg.algs.blas3.hemm.ovright" class="self-link"></a></h5>
-<div class="sourceCode" id="cb117"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb117-1"><a href="#cb117-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
-<span id="cb117-2"><a href="#cb117-2" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
-<span id="cb117-3"><a href="#cb117-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb117-4"><a href="#cb117-4" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
-<span id="cb117-5"><a href="#cb117-5" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_product<span class="op">(</span></span>
-<span id="cb117-6"><a href="#cb117-6" aria-hidden="true" tabindex="-1"></a>  InMat1 B,</span>
-<span id="cb117-7"><a href="#cb117-7" aria-hidden="true" tabindex="-1"></a>  InMat2 A,</span>
-<span id="cb117-8"><a href="#cb117-8" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb117-9"><a href="#cb117-9" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span>
-<span id="cb117-10"><a href="#cb117-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb117-11"><a href="#cb117-11" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
-<span id="cb117-12"><a href="#cb117-12" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
-<span id="cb117-13"><a href="#cb117-13" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb117-14"><a href="#cb117-14" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
-<span id="cb117-15"><a href="#cb117-15" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_product<span class="op">(</span></span>
-<span id="cb117-16"><a href="#cb117-16" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb117-17"><a href="#cb117-17" aria-hidden="true" tabindex="-1"></a>  InMat1 B,</span>
-<span id="cb117-18"><a href="#cb117-18" aria-hidden="true" tabindex="-1"></a>  InMat2 A,</span>
-<span id="cb117-19"><a href="#cb117-19" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb117-20"><a href="#cb117-20" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb124"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb124-1"><a href="#cb124-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
+<span id="cb124-2"><a href="#cb124-2" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
+<span id="cb124-3"><a href="#cb124-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb124-4"><a href="#cb124-4" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
+<span id="cb124-5"><a href="#cb124-5" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_product<span class="op">(</span></span>
+<span id="cb124-6"><a href="#cb124-6" aria-hidden="true" tabindex="-1"></a>  InMat1 B,</span>
+<span id="cb124-7"><a href="#cb124-7" aria-hidden="true" tabindex="-1"></a>  InMat2 A,</span>
+<span id="cb124-8"><a href="#cb124-8" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb124-9"><a href="#cb124-9" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span>
+<span id="cb124-10"><a href="#cb124-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb124-11"><a href="#cb124-11" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
+<span id="cb124-12"><a href="#cb124-12" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
+<span id="cb124-13"><a href="#cb124-13" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb124-14"><a href="#cb124-14" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
+<span id="cb124-15"><a href="#cb124-15" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_product<span class="op">(</span></span>
+<span id="cb124-16"><a href="#cb124-16" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb124-17"><a href="#cb124-17" aria-hidden="true" tabindex="-1"></a>  InMat1 B,</span>
+<span id="cb124-18"><a href="#cb124-18" aria-hidden="true" tabindex="-1"></a>  InMat2 A,</span>
+<span id="cb124-19"><a href="#cb124-19" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb124-20"><a href="#cb124-20" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 <em>Effects:</em> Computes <span class="math inline"><em>C</em> = <em>B</em><em>A</em></span>.</p>
 <h5 data-number="28.9.15.3.4" id="updating-hermitian-matrix-matrix-left-product-linalg.algs.blas3.hemm.upleft"><span class="header-section-number">28.9.15.3.4</span> Updating Hermitian
 matrix-matrix left product [linalg.algs.blas3.hemm.upleft]<a href="#updating-hermitian-matrix-matrix-left-product-linalg.algs.blas3.hemm.upleft" class="self-link"></a></h5>
-<div class="sourceCode" id="cb118"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb118-1"><a href="#cb118-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
-<span id="cb118-2"><a href="#cb118-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb118-3"><a href="#cb118-3" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
-<span id="cb118-4"><a href="#cb118-4" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat3,</span>
-<span id="cb118-5"><a href="#cb118-5" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
-<span id="cb118-6"><a href="#cb118-6" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_product<span class="op">(</span></span>
-<span id="cb118-7"><a href="#cb118-7" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb118-8"><a href="#cb118-8" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb118-9"><a href="#cb118-9" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
-<span id="cb118-10"><a href="#cb118-10" aria-hidden="true" tabindex="-1"></a>  InMat3 E,</span>
-<span id="cb118-11"><a href="#cb118-11" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span>
-<span id="cb118-12"><a href="#cb118-12" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb118-13"><a href="#cb118-13" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
-<span id="cb118-14"><a href="#cb118-14" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb118-15"><a href="#cb118-15" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
-<span id="cb118-16"><a href="#cb118-16" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat3,</span>
-<span id="cb118-17"><a href="#cb118-17" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
-<span id="cb118-18"><a href="#cb118-18" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_product<span class="op">(</span></span>
-<span id="cb118-19"><a href="#cb118-19" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb118-20"><a href="#cb118-20" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb118-21"><a href="#cb118-21" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb118-22"><a href="#cb118-22" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
-<span id="cb118-23"><a href="#cb118-23" aria-hidden="true" tabindex="-1"></a>  InMat3 E,</span>
-<span id="cb118-24"><a href="#cb118-24" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb125"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb125-1"><a href="#cb125-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
+<span id="cb125-2"><a href="#cb125-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb125-3"><a href="#cb125-3" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
+<span id="cb125-4"><a href="#cb125-4" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat3,</span>
+<span id="cb125-5"><a href="#cb125-5" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
+<span id="cb125-6"><a href="#cb125-6" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_product<span class="op">(</span></span>
+<span id="cb125-7"><a href="#cb125-7" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb125-8"><a href="#cb125-8" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb125-9"><a href="#cb125-9" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
+<span id="cb125-10"><a href="#cb125-10" aria-hidden="true" tabindex="-1"></a>  InMat3 E,</span>
+<span id="cb125-11"><a href="#cb125-11" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span>
+<span id="cb125-12"><a href="#cb125-12" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb125-13"><a href="#cb125-13" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
+<span id="cb125-14"><a href="#cb125-14" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb125-15"><a href="#cb125-15" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
+<span id="cb125-16"><a href="#cb125-16" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat3,</span>
+<span id="cb125-17"><a href="#cb125-17" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
+<span id="cb125-18"><a href="#cb125-18" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_product<span class="op">(</span></span>
+<span id="cb125-19"><a href="#cb125-19" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb125-20"><a href="#cb125-20" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb125-21"><a href="#cb125-21" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb125-22"><a href="#cb125-22" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
+<span id="cb125-23"><a href="#cb125-23" aria-hidden="true" tabindex="-1"></a>  InMat3 E,</span>
+<span id="cb125-24"><a href="#cb125-24" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 <em>Effects:</em> Computes <span class="math inline"><em>C</em> = <em>E</em> + <em>A</em><em>B</em></span>.</p>
 <h5 data-number="28.9.15.3.5" id="updating-hermitian-matrix-matrix-right-product-linalg.algs.blas3.hemm.upright"><span class="header-section-number">28.9.15.3.5</span> Updating Hermitian
 matrix-matrix right product [linalg.algs.blas3.hemm.upright]<a href="#updating-hermitian-matrix-matrix-right-product-linalg.algs.blas3.hemm.upright" class="self-link"></a></h5>
-<div class="sourceCode" id="cb119"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb119-1"><a href="#cb119-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
-<span id="cb119-2"><a href="#cb119-2" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
-<span id="cb119-3"><a href="#cb119-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb119-4"><a href="#cb119-4" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat3,</span>
-<span id="cb119-5"><a href="#cb119-5" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
-<span id="cb119-6"><a href="#cb119-6" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_product<span class="op">(</span></span>
-<span id="cb119-7"><a href="#cb119-7" aria-hidden="true" tabindex="-1"></a>  InMat1 B,</span>
-<span id="cb119-8"><a href="#cb119-8" aria-hidden="true" tabindex="-1"></a>  InMat2 A,</span>
-<span id="cb119-9"><a href="#cb119-9" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb119-10"><a href="#cb119-10" aria-hidden="true" tabindex="-1"></a>  InMat3 E,</span>
-<span id="cb119-11"><a href="#cb119-11" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span>
-<span id="cb119-12"><a href="#cb119-12" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb119-13"><a href="#cb119-13" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
-<span id="cb119-14"><a href="#cb119-14" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
-<span id="cb119-15"><a href="#cb119-15" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb119-16"><a href="#cb119-16" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat3,</span>
-<span id="cb119-17"><a href="#cb119-17" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
-<span id="cb119-18"><a href="#cb119-18" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_product<span class="op">(</span></span>
-<span id="cb119-19"><a href="#cb119-19" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb119-20"><a href="#cb119-20" aria-hidden="true" tabindex="-1"></a>  InMat1 B,</span>
-<span id="cb119-21"><a href="#cb119-21" aria-hidden="true" tabindex="-1"></a>  InMat2 A,</span>
-<span id="cb119-22"><a href="#cb119-22" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb119-23"><a href="#cb119-23" aria-hidden="true" tabindex="-1"></a>  InMat3 E,</span>
-<span id="cb119-24"><a href="#cb119-24" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb126"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb126-1"><a href="#cb126-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
+<span id="cb126-2"><a href="#cb126-2" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
+<span id="cb126-3"><a href="#cb126-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb126-4"><a href="#cb126-4" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat3,</span>
+<span id="cb126-5"><a href="#cb126-5" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
+<span id="cb126-6"><a href="#cb126-6" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_product<span class="op">(</span></span>
+<span id="cb126-7"><a href="#cb126-7" aria-hidden="true" tabindex="-1"></a>  InMat1 B,</span>
+<span id="cb126-8"><a href="#cb126-8" aria-hidden="true" tabindex="-1"></a>  InMat2 A,</span>
+<span id="cb126-9"><a href="#cb126-9" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb126-10"><a href="#cb126-10" aria-hidden="true" tabindex="-1"></a>  InMat3 E,</span>
+<span id="cb126-11"><a href="#cb126-11" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span>
+<span id="cb126-12"><a href="#cb126-12" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb126-13"><a href="#cb126-13" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
+<span id="cb126-14"><a href="#cb126-14" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
+<span id="cb126-15"><a href="#cb126-15" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb126-16"><a href="#cb126-16" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat3,</span>
+<span id="cb126-17"><a href="#cb126-17" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
+<span id="cb126-18"><a href="#cb126-18" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_product<span class="op">(</span></span>
+<span id="cb126-19"><a href="#cb126-19" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb126-20"><a href="#cb126-20" aria-hidden="true" tabindex="-1"></a>  InMat1 B,</span>
+<span id="cb126-21"><a href="#cb126-21" aria-hidden="true" tabindex="-1"></a>  InMat2 A,</span>
+<span id="cb126-22"><a href="#cb126-22" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb126-23"><a href="#cb126-23" aria-hidden="true" tabindex="-1"></a>  InMat3 E,</span>
+<span id="cb126-24"><a href="#cb126-24" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 <em>Effects:</em> Computes <span class="math inline"><em>C</em> = <em>E</em> + <em>B</em><em>A</em></span>.</p>
 <h4 data-number="28.9.15.4" id="triangular-matrix-matrix-product-linalg.algs.blas3.trmm"><span class="header-section-number">28.9.15.4</span> Triangular matrix-matrix
@@ -9893,54 +10069,54 @@ that is linear in <code>C.extent(0)</code> times
 matrix-matrix left product [linalg.algs.blas3.trmm.ovleft]<a href="#overwriting-triangular-matrix-matrix-left-product-linalg.algs.blas3.trmm.ovleft" class="self-link"></a></h5>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 Not-in-place overwriting triangular matrix-matrix left product</p>
-<div class="sourceCode" id="cb120"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb120-1"><a href="#cb120-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
-<span id="cb120-2"><a href="#cb120-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb120-3"><a href="#cb120-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb120-4"><a href="#cb120-4" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
-<span id="cb120-5"><a href="#cb120-5" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
-<span id="cb120-6"><a href="#cb120-6" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_product<span class="op">(</span></span>
-<span id="cb120-7"><a href="#cb120-7" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb120-8"><a href="#cb120-8" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb120-9"><a href="#cb120-9" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
-<span id="cb120-10"><a href="#cb120-10" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
-<span id="cb120-11"><a href="#cb120-11" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span>
-<span id="cb120-12"><a href="#cb120-12" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb120-13"><a href="#cb120-13" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
-<span id="cb120-14"><a href="#cb120-14" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb120-15"><a href="#cb120-15" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb120-16"><a href="#cb120-16" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
-<span id="cb120-17"><a href="#cb120-17" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
-<span id="cb120-18"><a href="#cb120-18" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_product<span class="op">(</span></span>
-<span id="cb120-19"><a href="#cb120-19" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb120-20"><a href="#cb120-20" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb120-21"><a href="#cb120-21" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb120-22"><a href="#cb120-22" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
-<span id="cb120-23"><a href="#cb120-23" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
-<span id="cb120-24"><a href="#cb120-24" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb127"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb127-1"><a href="#cb127-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
+<span id="cb127-2"><a href="#cb127-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb127-3"><a href="#cb127-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb127-4"><a href="#cb127-4" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
+<span id="cb127-5"><a href="#cb127-5" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
+<span id="cb127-6"><a href="#cb127-6" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_product<span class="op">(</span></span>
+<span id="cb127-7"><a href="#cb127-7" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb127-8"><a href="#cb127-8" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb127-9"><a href="#cb127-9" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
+<span id="cb127-10"><a href="#cb127-10" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
+<span id="cb127-11"><a href="#cb127-11" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span>
+<span id="cb127-12"><a href="#cb127-12" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb127-13"><a href="#cb127-13" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
+<span id="cb127-14"><a href="#cb127-14" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb127-15"><a href="#cb127-15" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb127-16"><a href="#cb127-16" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
+<span id="cb127-17"><a href="#cb127-17" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
+<span id="cb127-18"><a href="#cb127-18" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_product<span class="op">(</span></span>
+<span id="cb127-19"><a href="#cb127-19" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb127-20"><a href="#cb127-20" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb127-21"><a href="#cb127-21" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb127-22"><a href="#cb127-22" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
+<span id="cb127-23"><a href="#cb127-23" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
+<span id="cb127-24"><a href="#cb127-24" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">2</a></span>
 <em>Effects:</em> Computes <span class="math inline"><em>C</em> = <em>A</em><em>B</em></span>.</p>
 <p><span class="marginalizedparent"><a class="marginalized">3</a></span>
 In-place overwriting triangular matrix-matrix left product</p>
-<div class="sourceCode" id="cb121"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb121-1"><a href="#cb121-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
-<span id="cb121-2"><a href="#cb121-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb121-3"><a href="#cb121-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb121-4"><a href="#cb121-4" aria-hidden="true" tabindex="-1"></a>         <em>inout-matrix</em> InOutMat<span class="op">&gt;</span></span>
-<span id="cb121-5"><a href="#cb121-5" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_left_product<span class="op">(</span></span>
-<span id="cb121-6"><a href="#cb121-6" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb121-7"><a href="#cb121-7" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb121-8"><a href="#cb121-8" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
-<span id="cb121-9"><a href="#cb121-9" aria-hidden="true" tabindex="-1"></a>  InOutMat C<span class="op">)</span>;</span>
-<span id="cb121-10"><a href="#cb121-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb121-11"><a href="#cb121-11" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
-<span id="cb121-12"><a href="#cb121-12" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb121-13"><a href="#cb121-13" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb121-14"><a href="#cb121-14" aria-hidden="true" tabindex="-1"></a>         <em>inout-matrix</em> InOutMat<span class="op">&gt;</span></span>
-<span id="cb121-15"><a href="#cb121-15" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_left_product<span class="op">(</span></span>
-<span id="cb121-16"><a href="#cb121-16" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb121-17"><a href="#cb121-17" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb121-18"><a href="#cb121-18" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb121-19"><a href="#cb121-19" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
-<span id="cb121-20"><a href="#cb121-20" aria-hidden="true" tabindex="-1"></a>  InOutMat C<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb128"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb128-1"><a href="#cb128-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
+<span id="cb128-2"><a href="#cb128-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb128-3"><a href="#cb128-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb128-4"><a href="#cb128-4" aria-hidden="true" tabindex="-1"></a>         <em>inout-matrix</em> InOutMat<span class="op">&gt;</span></span>
+<span id="cb128-5"><a href="#cb128-5" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_left_product<span class="op">(</span></span>
+<span id="cb128-6"><a href="#cb128-6" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb128-7"><a href="#cb128-7" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb128-8"><a href="#cb128-8" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
+<span id="cb128-9"><a href="#cb128-9" aria-hidden="true" tabindex="-1"></a>  InOutMat C<span class="op">)</span>;</span>
+<span id="cb128-10"><a href="#cb128-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb128-11"><a href="#cb128-11" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
+<span id="cb128-12"><a href="#cb128-12" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb128-13"><a href="#cb128-13" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb128-14"><a href="#cb128-14" aria-hidden="true" tabindex="-1"></a>         <em>inout-matrix</em> InOutMat<span class="op">&gt;</span></span>
+<span id="cb128-15"><a href="#cb128-15" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_left_product<span class="op">(</span></span>
+<span id="cb128-16"><a href="#cb128-16" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb128-17"><a href="#cb128-17" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb128-18"><a href="#cb128-18" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb128-19"><a href="#cb128-19" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
+<span id="cb128-20"><a href="#cb128-20" aria-hidden="true" tabindex="-1"></a>  InOutMat C<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">4</a></span>
 <em>Preconditions:</em> <code>A.extent(1)</code> equals
 <code>C.extent(0)</code>.</p>
@@ -9955,54 +10131,54 @@ In-place overwriting triangular matrix-matrix left product</p>
 matrix-matrix right product [linalg.algs.blas3.trmm.ovright]<a href="#overwriting-triangular-matrix-matrix-right-product-linalg.algs.blas3.trmm.ovright" class="self-link"></a></h5>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 Not-in-place overwriting triangular matrix-matrix right product</p>
-<div class="sourceCode" id="cb122"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb122-1"><a href="#cb122-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
-<span id="cb122-2"><a href="#cb122-2" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
-<span id="cb122-3"><a href="#cb122-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb122-4"><a href="#cb122-4" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb122-5"><a href="#cb122-5" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
-<span id="cb122-6"><a href="#cb122-6" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_product<span class="op">(</span></span>
-<span id="cb122-7"><a href="#cb122-7" aria-hidden="true" tabindex="-1"></a>  InMat1 B,</span>
-<span id="cb122-8"><a href="#cb122-8" aria-hidden="true" tabindex="-1"></a>  InMat2 A,</span>
-<span id="cb122-9"><a href="#cb122-9" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb122-10"><a href="#cb122-10" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
-<span id="cb122-11"><a href="#cb122-11" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span>
-<span id="cb122-12"><a href="#cb122-12" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb122-13"><a href="#cb122-13" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
-<span id="cb122-14"><a href="#cb122-14" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
-<span id="cb122-15"><a href="#cb122-15" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb122-16"><a href="#cb122-16" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb122-17"><a href="#cb122-17" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
-<span id="cb122-18"><a href="#cb122-18" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_product<span class="op">(</span></span>
-<span id="cb122-19"><a href="#cb122-19" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb122-20"><a href="#cb122-20" aria-hidden="true" tabindex="-1"></a>  InMat1 B,</span>
-<span id="cb122-21"><a href="#cb122-21" aria-hidden="true" tabindex="-1"></a>  InMat2 A,</span>
-<span id="cb122-22"><a href="#cb122-22" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb122-23"><a href="#cb122-23" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
-<span id="cb122-24"><a href="#cb122-24" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb129"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb129-1"><a href="#cb129-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
+<span id="cb129-2"><a href="#cb129-2" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
+<span id="cb129-3"><a href="#cb129-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb129-4"><a href="#cb129-4" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb129-5"><a href="#cb129-5" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
+<span id="cb129-6"><a href="#cb129-6" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_product<span class="op">(</span></span>
+<span id="cb129-7"><a href="#cb129-7" aria-hidden="true" tabindex="-1"></a>  InMat1 B,</span>
+<span id="cb129-8"><a href="#cb129-8" aria-hidden="true" tabindex="-1"></a>  InMat2 A,</span>
+<span id="cb129-9"><a href="#cb129-9" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb129-10"><a href="#cb129-10" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
+<span id="cb129-11"><a href="#cb129-11" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span>
+<span id="cb129-12"><a href="#cb129-12" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb129-13"><a href="#cb129-13" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
+<span id="cb129-14"><a href="#cb129-14" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
+<span id="cb129-15"><a href="#cb129-15" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb129-16"><a href="#cb129-16" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb129-17"><a href="#cb129-17" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
+<span id="cb129-18"><a href="#cb129-18" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_product<span class="op">(</span></span>
+<span id="cb129-19"><a href="#cb129-19" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb129-20"><a href="#cb129-20" aria-hidden="true" tabindex="-1"></a>  InMat1 B,</span>
+<span id="cb129-21"><a href="#cb129-21" aria-hidden="true" tabindex="-1"></a>  InMat2 A,</span>
+<span id="cb129-22"><a href="#cb129-22" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb129-23"><a href="#cb129-23" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
+<span id="cb129-24"><a href="#cb129-24" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">2</a></span>
 <em>Effects:</em> Computes <span class="math inline"><em>C</em> = <em>B</em><em>A</em></span>.</p>
 <p><span class="marginalizedparent"><a class="marginalized">3</a></span>
 In-place overwriting triangular matrix-matrix right product</p>
-<div class="sourceCode" id="cb123"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb123-1"><a href="#cb123-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
-<span id="cb123-2"><a href="#cb123-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb123-3"><a href="#cb123-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb123-4"><a href="#cb123-4" aria-hidden="true" tabindex="-1"></a>         <em>inout-matrix</em> InOutMat<span class="op">&gt;</span></span>
-<span id="cb123-5"><a href="#cb123-5" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_right_product<span class="op">(</span></span>
-<span id="cb123-6"><a href="#cb123-6" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb123-7"><a href="#cb123-7" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb123-8"><a href="#cb123-8" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
-<span id="cb123-9"><a href="#cb123-9" aria-hidden="true" tabindex="-1"></a>  InOutMat C<span class="op">)</span>;</span>
-<span id="cb123-10"><a href="#cb123-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb123-11"><a href="#cb123-11" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
-<span id="cb123-12"><a href="#cb123-12" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb123-13"><a href="#cb123-13" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb123-14"><a href="#cb123-14" aria-hidden="true" tabindex="-1"></a>         <em>inout-matrix</em> InOutMat<span class="op">&gt;</span></span>
-<span id="cb123-15"><a href="#cb123-15" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_right_product<span class="op">(</span></span>
-<span id="cb123-16"><a href="#cb123-16" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb123-17"><a href="#cb123-17" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb123-18"><a href="#cb123-18" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb123-19"><a href="#cb123-19" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
-<span id="cb123-20"><a href="#cb123-20" aria-hidden="true" tabindex="-1"></a>  InOutMat C<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb130"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb130-1"><a href="#cb130-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
+<span id="cb130-2"><a href="#cb130-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb130-3"><a href="#cb130-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb130-4"><a href="#cb130-4" aria-hidden="true" tabindex="-1"></a>         <em>inout-matrix</em> InOutMat<span class="op">&gt;</span></span>
+<span id="cb130-5"><a href="#cb130-5" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_right_product<span class="op">(</span></span>
+<span id="cb130-6"><a href="#cb130-6" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb130-7"><a href="#cb130-7" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb130-8"><a href="#cb130-8" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
+<span id="cb130-9"><a href="#cb130-9" aria-hidden="true" tabindex="-1"></a>  InOutMat C<span class="op">)</span>;</span>
+<span id="cb130-10"><a href="#cb130-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb130-11"><a href="#cb130-11" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
+<span id="cb130-12"><a href="#cb130-12" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb130-13"><a href="#cb130-13" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb130-14"><a href="#cb130-14" aria-hidden="true" tabindex="-1"></a>         <em>inout-matrix</em> InOutMat<span class="op">&gt;</span></span>
+<span id="cb130-15"><a href="#cb130-15" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_right_product<span class="op">(</span></span>
+<span id="cb130-16"><a href="#cb130-16" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb130-17"><a href="#cb130-17" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb130-18"><a href="#cb130-18" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb130-19"><a href="#cb130-19" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
+<span id="cb130-20"><a href="#cb130-20" aria-hidden="true" tabindex="-1"></a>  InOutMat C<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">4</a></span>
 <em>Preconditions:</em> <code>C.extent(1)</code> equals
 <code>A.extent(0)</code>.</p>
@@ -10015,66 +10191,66 @@ In-place overwriting triangular matrix-matrix right product</p>
 <em>Effects:</em> Computes <span class="math inline"><em>C</em> = <em>C</em><em>A</em></span>.</p>
 <h5 data-number="28.9.15.4.4" id="updating-triangular-matrix-matrix-left-product-linalg.algs.blas3.trmm.upleft"><span class="header-section-number">28.9.15.4.4</span> Updating triangular
 matrix-matrix left product [linalg.algs.blas3.trmm.upleft]<a href="#updating-triangular-matrix-matrix-left-product-linalg.algs.blas3.trmm.upleft" class="self-link"></a></h5>
-<div class="sourceCode" id="cb124"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb124-1"><a href="#cb124-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
-<span id="cb124-2"><a href="#cb124-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb124-3"><a href="#cb124-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb124-4"><a href="#cb124-4" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
-<span id="cb124-5"><a href="#cb124-5" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat3,</span>
-<span id="cb124-6"><a href="#cb124-6" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
-<span id="cb124-7"><a href="#cb124-7" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_product<span class="op">(</span></span>
-<span id="cb124-8"><a href="#cb124-8" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb124-9"><a href="#cb124-9" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb124-10"><a href="#cb124-10" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
-<span id="cb124-11"><a href="#cb124-11" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
-<span id="cb124-12"><a href="#cb124-12" aria-hidden="true" tabindex="-1"></a>  InMat3 E,</span>
-<span id="cb124-13"><a href="#cb124-13" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span>
-<span id="cb124-14"><a href="#cb124-14" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb124-15"><a href="#cb124-15" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
-<span id="cb124-16"><a href="#cb124-16" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb124-17"><a href="#cb124-17" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb124-18"><a href="#cb124-18" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
-<span id="cb124-19"><a href="#cb124-19" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat3,</span>
-<span id="cb124-20"><a href="#cb124-20" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
-<span id="cb124-21"><a href="#cb124-21" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_product<span class="op">(</span></span>
-<span id="cb124-22"><a href="#cb124-22" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb124-23"><a href="#cb124-23" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb124-24"><a href="#cb124-24" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb124-25"><a href="#cb124-25" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
-<span id="cb124-26"><a href="#cb124-26" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
-<span id="cb124-27"><a href="#cb124-27" aria-hidden="true" tabindex="-1"></a>  InMat3 E,</span>
-<span id="cb124-28"><a href="#cb124-28" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb131"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb131-1"><a href="#cb131-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
+<span id="cb131-2"><a href="#cb131-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb131-3"><a href="#cb131-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb131-4"><a href="#cb131-4" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
+<span id="cb131-5"><a href="#cb131-5" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat3,</span>
+<span id="cb131-6"><a href="#cb131-6" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
+<span id="cb131-7"><a href="#cb131-7" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_product<span class="op">(</span></span>
+<span id="cb131-8"><a href="#cb131-8" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb131-9"><a href="#cb131-9" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb131-10"><a href="#cb131-10" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
+<span id="cb131-11"><a href="#cb131-11" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
+<span id="cb131-12"><a href="#cb131-12" aria-hidden="true" tabindex="-1"></a>  InMat3 E,</span>
+<span id="cb131-13"><a href="#cb131-13" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span>
+<span id="cb131-14"><a href="#cb131-14" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb131-15"><a href="#cb131-15" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
+<span id="cb131-16"><a href="#cb131-16" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb131-17"><a href="#cb131-17" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb131-18"><a href="#cb131-18" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
+<span id="cb131-19"><a href="#cb131-19" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat3,</span>
+<span id="cb131-20"><a href="#cb131-20" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
+<span id="cb131-21"><a href="#cb131-21" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_product<span class="op">(</span></span>
+<span id="cb131-22"><a href="#cb131-22" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb131-23"><a href="#cb131-23" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb131-24"><a href="#cb131-24" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb131-25"><a href="#cb131-25" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
+<span id="cb131-26"><a href="#cb131-26" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
+<span id="cb131-27"><a href="#cb131-27" aria-hidden="true" tabindex="-1"></a>  InMat3 E,</span>
+<span id="cb131-28"><a href="#cb131-28" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 <em>Effects:</em> Computes <span class="math inline"><em>C</em> = <em>E</em> + <em>A</em><em>B</em></span>.</p>
 <h5 data-number="28.9.15.4.5" id="updating-triangular-matrix-matrix-right-product-linalg.algs.blas3.trmm.upright"><span class="header-section-number">28.9.15.4.5</span> Updating triangular
 matrix-matrix right product [linalg.algs.blas3.trmm.upright]<a href="#updating-triangular-matrix-matrix-right-product-linalg.algs.blas3.trmm.upright" class="self-link"></a></h5>
-<div class="sourceCode" id="cb125"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb125-1"><a href="#cb125-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
-<span id="cb125-2"><a href="#cb125-2" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
-<span id="cb125-3"><a href="#cb125-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb125-4"><a href="#cb125-4" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb125-5"><a href="#cb125-5" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat3,</span>
-<span id="cb125-6"><a href="#cb125-6" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
-<span id="cb125-7"><a href="#cb125-7" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_product<span class="op">(</span></span>
-<span id="cb125-8"><a href="#cb125-8" aria-hidden="true" tabindex="-1"></a>  InMat1 B,</span>
-<span id="cb125-9"><a href="#cb125-9" aria-hidden="true" tabindex="-1"></a>  InMat2 A,</span>
-<span id="cb125-10"><a href="#cb125-10" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb125-11"><a href="#cb125-11" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
-<span id="cb125-12"><a href="#cb125-12" aria-hidden="true" tabindex="-1"></a>  InMat3 E,</span>
-<span id="cb125-13"><a href="#cb125-13" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span>
-<span id="cb125-14"><a href="#cb125-14" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb125-15"><a href="#cb125-15" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
-<span id="cb125-16"><a href="#cb125-16" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
-<span id="cb125-17"><a href="#cb125-17" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb125-18"><a href="#cb125-18" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb125-19"><a href="#cb125-19" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat3,</span>
-<span id="cb125-20"><a href="#cb125-20" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
-<span id="cb125-21"><a href="#cb125-21" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_product<span class="op">(</span></span>
-<span id="cb125-22"><a href="#cb125-22" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb125-23"><a href="#cb125-23" aria-hidden="true" tabindex="-1"></a>  InMat1 B,</span>
-<span id="cb125-24"><a href="#cb125-24" aria-hidden="true" tabindex="-1"></a>  InMat2 A,</span>
-<span id="cb125-25"><a href="#cb125-25" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb125-26"><a href="#cb125-26" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
-<span id="cb125-27"><a href="#cb125-27" aria-hidden="true" tabindex="-1"></a>  InMat3 E,</span>
-<span id="cb125-28"><a href="#cb125-28" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb132"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb132-1"><a href="#cb132-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
+<span id="cb132-2"><a href="#cb132-2" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
+<span id="cb132-3"><a href="#cb132-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb132-4"><a href="#cb132-4" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb132-5"><a href="#cb132-5" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat3,</span>
+<span id="cb132-6"><a href="#cb132-6" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
+<span id="cb132-7"><a href="#cb132-7" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_product<span class="op">(</span></span>
+<span id="cb132-8"><a href="#cb132-8" aria-hidden="true" tabindex="-1"></a>  InMat1 B,</span>
+<span id="cb132-9"><a href="#cb132-9" aria-hidden="true" tabindex="-1"></a>  InMat2 A,</span>
+<span id="cb132-10"><a href="#cb132-10" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb132-11"><a href="#cb132-11" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
+<span id="cb132-12"><a href="#cb132-12" aria-hidden="true" tabindex="-1"></a>  InMat3 E,</span>
+<span id="cb132-13"><a href="#cb132-13" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span>
+<span id="cb132-14"><a href="#cb132-14" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb132-15"><a href="#cb132-15" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
+<span id="cb132-16"><a href="#cb132-16" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
+<span id="cb132-17"><a href="#cb132-17" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb132-18"><a href="#cb132-18" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb132-19"><a href="#cb132-19" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat3,</span>
+<span id="cb132-20"><a href="#cb132-20" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
+<span id="cb132-21"><a href="#cb132-21" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_product<span class="op">(</span></span>
+<span id="cb132-22"><a href="#cb132-22" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb132-23"><a href="#cb132-23" aria-hidden="true" tabindex="-1"></a>  InMat1 B,</span>
+<span id="cb132-24"><a href="#cb132-24" aria-hidden="true" tabindex="-1"></a>  InMat2 A,</span>
+<span id="cb132-25"><a href="#cb132-25" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb132-26"><a href="#cb132-26" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
+<span id="cb132-27"><a href="#cb132-27" aria-hidden="true" tabindex="-1"></a>  InMat3 E,</span>
+<span id="cb132-28"><a href="#cb132-28" aria-hidden="true" tabindex="-1"></a>  OutMat C<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
 <em>Effects:</em> Computes <span class="math inline"><em>C</em> = <em>E</em> + <em>B</em><em>A</em></span>.</p>
 <h4 data-number="28.9.15.5" id="rank-k-update-of-a-symmetric-or-hermitian-matrix-linalg.alg.blas3.rankk"><span class="header-section-number">28.9.15.5</span> Rank-k update of a
@@ -10095,42 +10271,42 @@ array accesses and arithmetic operations that is linear in
 <code>A.extent(0)</code>.</p>
 <h5 data-number="28.9.15.5.2" id="rank-k-symmetric-matrix-update-linalg.alg.blas3.rankk.syrk"><span class="header-section-number">28.9.15.5.2</span> Rank-k symmetric matrix
 update [linalg.alg.blas3.rankk.syrk]<a href="#rank-k-symmetric-matrix-update-linalg.alg.blas3.rankk.syrk" class="self-link"></a></h5>
-<div class="sourceCode" id="cb126"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb126-1"><a href="#cb126-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Scalar,</span>
-<span id="cb126-2"><a href="#cb126-2" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
-<span id="cb126-3"><a href="#cb126-3" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
-<span id="cb126-4"><a href="#cb126-4" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
-<span id="cb126-5"><a href="#cb126-5" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_rank_k_update<span class="op">(</span></span>
-<span id="cb126-6"><a href="#cb126-6" aria-hidden="true" tabindex="-1"></a>  Scalar alpha,</span>
-<span id="cb126-7"><a href="#cb126-7" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb126-8"><a href="#cb126-8" aria-hidden="true" tabindex="-1"></a>  InOutMat C,</span>
-<span id="cb126-9"><a href="#cb126-9" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span>
-<span id="cb126-10"><a href="#cb126-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb126-11"><a href="#cb126-11" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar,</span>
-<span id="cb126-12"><a href="#cb126-12" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
-<span id="cb126-13"><a href="#cb126-13" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
-<span id="cb126-14"><a href="#cb126-14" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
-<span id="cb126-15"><a href="#cb126-15" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_rank_k_update<span class="op">(</span></span>
-<span id="cb126-16"><a href="#cb126-16" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb126-17"><a href="#cb126-17" aria-hidden="true" tabindex="-1"></a>  Scalar alpha,</span>
-<span id="cb126-18"><a href="#cb126-18" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb126-19"><a href="#cb126-19" aria-hidden="true" tabindex="-1"></a>  InOutMat C,</span>
-<span id="cb126-20"><a href="#cb126-20" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span>
-<span id="cb126-21"><a href="#cb126-21" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
-<span id="cb126-22"><a href="#cb126-22" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
-<span id="cb126-23"><a href="#cb126-23" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
-<span id="cb126-24"><a href="#cb126-24" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_rank_k_update<span class="op">(</span></span>
-<span id="cb126-25"><a href="#cb126-25" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb126-26"><a href="#cb126-26" aria-hidden="true" tabindex="-1"></a>  InOutMat C,</span>
-<span id="cb126-27"><a href="#cb126-27" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span>
-<span id="cb126-28"><a href="#cb126-28" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb126-29"><a href="#cb126-29" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
-<span id="cb126-30"><a href="#cb126-30" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
-<span id="cb126-31"><a href="#cb126-31" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
-<span id="cb126-32"><a href="#cb126-32" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_rank_k_update<span class="op">(</span></span>
-<span id="cb126-33"><a href="#cb126-33" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb126-34"><a href="#cb126-34" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb126-35"><a href="#cb126-35" aria-hidden="true" tabindex="-1"></a>  InOutMat C,</span>
-<span id="cb126-36"><a href="#cb126-36" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb133"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb133-1"><a href="#cb133-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Scalar,</span>
+<span id="cb133-2"><a href="#cb133-2" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
+<span id="cb133-3"><a href="#cb133-3" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
+<span id="cb133-4"><a href="#cb133-4" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
+<span id="cb133-5"><a href="#cb133-5" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_rank_k_update<span class="op">(</span></span>
+<span id="cb133-6"><a href="#cb133-6" aria-hidden="true" tabindex="-1"></a>  Scalar alpha,</span>
+<span id="cb133-7"><a href="#cb133-7" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb133-8"><a href="#cb133-8" aria-hidden="true" tabindex="-1"></a>  InOutMat C,</span>
+<span id="cb133-9"><a href="#cb133-9" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span>
+<span id="cb133-10"><a href="#cb133-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb133-11"><a href="#cb133-11" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar,</span>
+<span id="cb133-12"><a href="#cb133-12" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
+<span id="cb133-13"><a href="#cb133-13" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
+<span id="cb133-14"><a href="#cb133-14" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
+<span id="cb133-15"><a href="#cb133-15" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_rank_k_update<span class="op">(</span></span>
+<span id="cb133-16"><a href="#cb133-16" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb133-17"><a href="#cb133-17" aria-hidden="true" tabindex="-1"></a>  Scalar alpha,</span>
+<span id="cb133-18"><a href="#cb133-18" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb133-19"><a href="#cb133-19" aria-hidden="true" tabindex="-1"></a>  InOutMat C,</span>
+<span id="cb133-20"><a href="#cb133-20" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span>
+<span id="cb133-21"><a href="#cb133-21" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
+<span id="cb133-22"><a href="#cb133-22" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
+<span id="cb133-23"><a href="#cb133-23" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
+<span id="cb133-24"><a href="#cb133-24" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_rank_k_update<span class="op">(</span></span>
+<span id="cb133-25"><a href="#cb133-25" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb133-26"><a href="#cb133-26" aria-hidden="true" tabindex="-1"></a>  InOutMat C,</span>
+<span id="cb133-27"><a href="#cb133-27" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span>
+<span id="cb133-28"><a href="#cb133-28" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb133-29"><a href="#cb133-29" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
+<span id="cb133-30"><a href="#cb133-30" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
+<span id="cb133-31"><a href="#cb133-31" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
+<span id="cb133-32"><a href="#cb133-32" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_rank_k_update<span class="op">(</span></span>
+<span id="cb133-33"><a href="#cb133-33" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb133-34"><a href="#cb133-34" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb133-35"><a href="#cb133-35" aria-hidden="true" tabindex="-1"></a>  InOutMat C,</span>
+<span id="cb133-36"><a href="#cb133-36" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span></code></pre></div>
 <p><i>[Note:</i> These functions correspond to the BLAS function
 <code>xSYRK</code>. <i>– end note]</i></p>
 <!--
@@ -10172,42 +10348,42 @@ where the scalar <span class="math inline"><em>α</em></span> is
 parameter compute <span class="math inline"><em>C</em> = <em>C</em> + <em>A</em><em>A</em><sup><em>T</em></sup></span>.</p>
 <h5 data-number="28.9.15.5.3" id="rank-k-hermitian-matrix-update-linalg.alg.blas3.rankk.herk"><span class="header-section-number">28.9.15.5.3</span> Rank-k Hermitian matrix
 update [linalg.alg.blas3.rankk.herk]<a href="#rank-k-hermitian-matrix-update-linalg.alg.blas3.rankk.herk" class="self-link"></a></h5>
-<div class="sourceCode" id="cb127"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb127-1"><a href="#cb127-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Scalar,</span>
-<span id="cb127-2"><a href="#cb127-2" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
-<span id="cb127-3"><a href="#cb127-3" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
-<span id="cb127-4"><a href="#cb127-4" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
-<span id="cb127-5"><a href="#cb127-5" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_rank_k_update<span class="op">(</span></span>
-<span id="cb127-6"><a href="#cb127-6" aria-hidden="true" tabindex="-1"></a>  Scalar alpha,</span>
-<span id="cb127-7"><a href="#cb127-7" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb127-8"><a href="#cb127-8" aria-hidden="true" tabindex="-1"></a>  InOutMat C,</span>
-<span id="cb127-9"><a href="#cb127-9" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span>
-<span id="cb127-10"><a href="#cb127-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb127-11"><a href="#cb127-11" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar,</span>
-<span id="cb127-12"><a href="#cb127-12" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
-<span id="cb127-13"><a href="#cb127-13" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
-<span id="cb127-14"><a href="#cb127-14" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
-<span id="cb127-15"><a href="#cb127-15" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_rank_k_update<span class="op">(</span></span>
-<span id="cb127-16"><a href="#cb127-16" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb127-17"><a href="#cb127-17" aria-hidden="true" tabindex="-1"></a>  Scalar alpha,</span>
-<span id="cb127-18"><a href="#cb127-18" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb127-19"><a href="#cb127-19" aria-hidden="true" tabindex="-1"></a>  InOutMat C,</span>
-<span id="cb127-20"><a href="#cb127-20" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span>
-<span id="cb127-21"><a href="#cb127-21" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
-<span id="cb127-22"><a href="#cb127-22" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
-<span id="cb127-23"><a href="#cb127-23" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
-<span id="cb127-24"><a href="#cb127-24" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_rank_k_update<span class="op">(</span></span>
-<span id="cb127-25"><a href="#cb127-25" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb127-26"><a href="#cb127-26" aria-hidden="true" tabindex="-1"></a>  InOutMat C,</span>
-<span id="cb127-27"><a href="#cb127-27" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span>
-<span id="cb127-28"><a href="#cb127-28" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb127-29"><a href="#cb127-29" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
-<span id="cb127-30"><a href="#cb127-30" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
-<span id="cb127-31"><a href="#cb127-31" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
-<span id="cb127-32"><a href="#cb127-32" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_rank_k_update<span class="op">(</span></span>
-<span id="cb127-33"><a href="#cb127-33" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb127-34"><a href="#cb127-34" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb127-35"><a href="#cb127-35" aria-hidden="true" tabindex="-1"></a>  InOutMat C,</span>
-<span id="cb127-36"><a href="#cb127-36" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb134"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb134-1"><a href="#cb134-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> Scalar,</span>
+<span id="cb134-2"><a href="#cb134-2" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
+<span id="cb134-3"><a href="#cb134-3" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
+<span id="cb134-4"><a href="#cb134-4" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
+<span id="cb134-5"><a href="#cb134-5" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_rank_k_update<span class="op">(</span></span>
+<span id="cb134-6"><a href="#cb134-6" aria-hidden="true" tabindex="-1"></a>  Scalar alpha,</span>
+<span id="cb134-7"><a href="#cb134-7" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb134-8"><a href="#cb134-8" aria-hidden="true" tabindex="-1"></a>  InOutMat C,</span>
+<span id="cb134-9"><a href="#cb134-9" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span>
+<span id="cb134-10"><a href="#cb134-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb134-11"><a href="#cb134-11" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Scalar,</span>
+<span id="cb134-12"><a href="#cb134-12" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
+<span id="cb134-13"><a href="#cb134-13" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
+<span id="cb134-14"><a href="#cb134-14" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
+<span id="cb134-15"><a href="#cb134-15" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_rank_k_update<span class="op">(</span></span>
+<span id="cb134-16"><a href="#cb134-16" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb134-17"><a href="#cb134-17" aria-hidden="true" tabindex="-1"></a>  Scalar alpha,</span>
+<span id="cb134-18"><a href="#cb134-18" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb134-19"><a href="#cb134-19" aria-hidden="true" tabindex="-1"></a>  InOutMat C,</span>
+<span id="cb134-20"><a href="#cb134-20" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span>
+<span id="cb134-21"><a href="#cb134-21" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
+<span id="cb134-22"><a href="#cb134-22" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
+<span id="cb134-23"><a href="#cb134-23" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
+<span id="cb134-24"><a href="#cb134-24" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_rank_k_update<span class="op">(</span></span>
+<span id="cb134-25"><a href="#cb134-25" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb134-26"><a href="#cb134-26" aria-hidden="true" tabindex="-1"></a>  InOutMat C,</span>
+<span id="cb134-27"><a href="#cb134-27" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span>
+<span id="cb134-28"><a href="#cb134-28" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb134-29"><a href="#cb134-29" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
+<span id="cb134-30"><a href="#cb134-30" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
+<span id="cb134-31"><a href="#cb134-31" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
+<span id="cb134-32"><a href="#cb134-32" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_rank_k_update<span class="op">(</span></span>
+<span id="cb134-33"><a href="#cb134-33" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb134-34"><a href="#cb134-34" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb134-35"><a href="#cb134-35" aria-hidden="true" tabindex="-1"></a>  InOutMat C,</span>
+<span id="cb134-36"><a href="#cb134-36" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span></code></pre></div>
 <p><i>[Note:</i> These functions correspond to the BLAS function
 <code>xHERK</code>. <i>– end note]</i></p>
 <!--
@@ -10266,26 +10442,26 @@ array accesses and arithmetic operations that is linear in
 <code>B.extent(1)</code>.</p>
 <h5 data-number="28.9.15.6.2" id="rank-2k-symmetric-matrix-update-linalg.alg.blas3.rank2k.syr2k"><span class="header-section-number">28.9.15.6.2</span> Rank-2k symmetric
 matrix update [linalg.alg.blas3.rank2k.syr2k]<a href="#rank-2k-symmetric-matrix-update-linalg.alg.blas3.rank2k.syr2k" class="self-link"></a></h5>
-<div class="sourceCode" id="cb128"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb128-1"><a href="#cb128-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
-<span id="cb128-2"><a href="#cb128-2" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
-<span id="cb128-3"><a href="#cb128-3" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
-<span id="cb128-4"><a href="#cb128-4" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
-<span id="cb128-5"><a href="#cb128-5" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_rank_2k_update<span class="op">(</span></span>
-<span id="cb128-6"><a href="#cb128-6" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb128-7"><a href="#cb128-7" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
-<span id="cb128-8"><a href="#cb128-8" aria-hidden="true" tabindex="-1"></a>  InOutMat C,</span>
-<span id="cb128-9"><a href="#cb128-9" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span>
-<span id="cb128-10"><a href="#cb128-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb128-11"><a href="#cb128-11" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
-<span id="cb128-12"><a href="#cb128-12" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
-<span id="cb128-13"><a href="#cb128-13" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
-<span id="cb128-14"><a href="#cb128-14" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
-<span id="cb128-15"><a href="#cb128-15" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_rank_2k_update<span class="op">(</span></span>
-<span id="cb128-16"><a href="#cb128-16" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb128-17"><a href="#cb128-17" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb128-18"><a href="#cb128-18" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
-<span id="cb128-19"><a href="#cb128-19" aria-hidden="true" tabindex="-1"></a>  InOutMat C,</span>
-<span id="cb128-20"><a href="#cb128-20" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb135"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb135-1"><a href="#cb135-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
+<span id="cb135-2"><a href="#cb135-2" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
+<span id="cb135-3"><a href="#cb135-3" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
+<span id="cb135-4"><a href="#cb135-4" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
+<span id="cb135-5"><a href="#cb135-5" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_rank_2k_update<span class="op">(</span></span>
+<span id="cb135-6"><a href="#cb135-6" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb135-7"><a href="#cb135-7" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
+<span id="cb135-8"><a href="#cb135-8" aria-hidden="true" tabindex="-1"></a>  InOutMat C,</span>
+<span id="cb135-9"><a href="#cb135-9" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span>
+<span id="cb135-10"><a href="#cb135-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb135-11"><a href="#cb135-11" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
+<span id="cb135-12"><a href="#cb135-12" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
+<span id="cb135-13"><a href="#cb135-13" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
+<span id="cb135-14"><a href="#cb135-14" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
+<span id="cb135-15"><a href="#cb135-15" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> symmetric_matrix_rank_2k_update<span class="op">(</span></span>
+<span id="cb135-16"><a href="#cb135-16" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb135-17"><a href="#cb135-17" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb135-18"><a href="#cb135-18" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
+<span id="cb135-19"><a href="#cb135-19" aria-hidden="true" tabindex="-1"></a>  InOutMat C,</span>
+<span id="cb135-20"><a href="#cb135-20" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span></code></pre></div>
 <p><i>[Note:</i> These functions correspond to the BLAS function
 <code>xSYR2K</code>. <i>– end note]</i> <!--
 The BLAS "quick reference" has a typo;
@@ -10330,27 +10506,27 @@ neither <code>A.static_extent(0)</code> nor
 <em>Effects:</em> Computes <span class="math inline"><em>C</em> = <em>C</em> + <em>A</em><em>B</em><sup><em>T</em></sup> + <em>B</em><em>A</em><sup><em>T</em></sup></span>.</p>
 <h5 data-number="28.9.15.6.3" id="rank-2k-hermitian-matrix-update-linalg.alg.blas3.rank2k.her2k"><span class="header-section-number">28.9.15.6.3</span> Rank-2k Hermitian
 matrix update [linalg.alg.blas3.rank2k.her2k]<a href="#rank-2k-hermitian-matrix-update-linalg.alg.blas3.rank2k.her2k" class="self-link"></a></h5>
-<div class="sourceCode" id="cb129"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb129-1"><a href="#cb129-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
-<span id="cb129-2"><a href="#cb129-2" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
-<span id="cb129-3"><a href="#cb129-3" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
-<span id="cb129-4"><a href="#cb129-4" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
-<span id="cb129-5"><a href="#cb129-5" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_rank_2k_update<span class="op">(</span></span>
-<span id="cb129-6"><a href="#cb129-6" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb129-7"><a href="#cb129-7" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
-<span id="cb129-8"><a href="#cb129-8" aria-hidden="true" tabindex="-1"></a>  InOutMat C,</span>
-<span id="cb129-9"><a href="#cb129-9" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span>
-<span id="cb129-10"><a href="#cb129-10" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb129-11"><a href="#cb129-11" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb129-12"><a href="#cb129-12" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
-<span id="cb129-13"><a href="#cb129-13" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
-<span id="cb129-14"><a href="#cb129-14" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
-<span id="cb129-15"><a href="#cb129-15" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
-<span id="cb129-16"><a href="#cb129-16" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_rank_2k_update<span class="op">(</span></span>
-<span id="cb129-17"><a href="#cb129-17" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb129-18"><a href="#cb129-18" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb129-19"><a href="#cb129-19" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
-<span id="cb129-20"><a href="#cb129-20" aria-hidden="true" tabindex="-1"></a>  InOutMat C,</span>
-<span id="cb129-21"><a href="#cb129-21" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb136"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb136-1"><a href="#cb136-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
+<span id="cb136-2"><a href="#cb136-2" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
+<span id="cb136-3"><a href="#cb136-3" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
+<span id="cb136-4"><a href="#cb136-4" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
+<span id="cb136-5"><a href="#cb136-5" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_rank_2k_update<span class="op">(</span></span>
+<span id="cb136-6"><a href="#cb136-6" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb136-7"><a href="#cb136-7" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
+<span id="cb136-8"><a href="#cb136-8" aria-hidden="true" tabindex="-1"></a>  InOutMat C,</span>
+<span id="cb136-9"><a href="#cb136-9" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span>
+<span id="cb136-10"><a href="#cb136-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb136-11"><a href="#cb136-11" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb136-12"><a href="#cb136-12" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
+<span id="cb136-13"><a href="#cb136-13" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
+<span id="cb136-14"><a href="#cb136-14" aria-hidden="true" tabindex="-1"></a>         <em>possibly-packed-inout-matrix</em> InOutMat,</span>
+<span id="cb136-15"><a href="#cb136-15" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
+<span id="cb136-16"><a href="#cb136-16" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hermitian_matrix_rank_2k_update<span class="op">(</span></span>
+<span id="cb136-17"><a href="#cb136-17" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb136-18"><a href="#cb136-18" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb136-19"><a href="#cb136-19" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
+<span id="cb136-20"><a href="#cb136-20" aria-hidden="true" tabindex="-1"></a>  InOutMat C,</span>
+<span id="cb136-21"><a href="#cb136-21" aria-hidden="true" tabindex="-1"></a>  Triangle t<span class="op">)</span>;</span></code></pre></div>
 <p><i>[Note:</i> These functions correspond to the BLAS function
 <code>xHER2K</code>. <i>– end note]</i></p>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
@@ -10450,59 +10626,59 @@ array accesses and arithmetic operations that is linear in
 <code>B.extent(1)</code>.</p>
 <p><span class="marginalizedparent"><a class="marginalized">2</a></span>
 Not-in-place left solve of multiple triangular systems</p>
-<div class="sourceCode" id="cb130"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb130-1"><a href="#cb130-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
-<span id="cb130-2"><a href="#cb130-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb130-3"><a href="#cb130-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb130-4"><a href="#cb130-4" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
-<span id="cb130-5"><a href="#cb130-5" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat,</span>
-<span id="cb130-6"><a href="#cb130-6" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> BinaryDivideOp<span class="op">&gt;</span></span>
-<span id="cb130-7"><a href="#cb130-7" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_matrix_left_solve<span class="op">(</span></span>
-<span id="cb130-8"><a href="#cb130-8" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb130-9"><a href="#cb130-9" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb130-10"><a href="#cb130-10" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
-<span id="cb130-11"><a href="#cb130-11" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
-<span id="cb130-12"><a href="#cb130-12" aria-hidden="true" tabindex="-1"></a>  OutMat X,</span>
-<span id="cb130-13"><a href="#cb130-13" aria-hidden="true" tabindex="-1"></a>  BinaryDivideOp divide<span class="op">)</span>;</span>
-<span id="cb130-14"><a href="#cb130-14" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb130-15"><a href="#cb130-15" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
-<span id="cb130-16"><a href="#cb130-16" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb130-17"><a href="#cb130-17" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb130-18"><a href="#cb130-18" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
-<span id="cb130-19"><a href="#cb130-19" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat,</span>
-<span id="cb130-20"><a href="#cb130-20" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> BinaryDivideOp<span class="op">&gt;</span></span>
-<span id="cb130-21"><a href="#cb130-21" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_matrix_left_solve<span class="op">(</span></span>
-<span id="cb130-22"><a href="#cb130-22" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb130-23"><a href="#cb130-23" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb130-24"><a href="#cb130-24" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb130-25"><a href="#cb130-25" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
-<span id="cb130-26"><a href="#cb130-26" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
-<span id="cb130-27"><a href="#cb130-27" aria-hidden="true" tabindex="-1"></a>  OutMat X,</span>
-<span id="cb130-28"><a href="#cb130-28" aria-hidden="true" tabindex="-1"></a>  BinaryDivideOp divide<span class="op">)</span>;</span>
-<span id="cb130-29"><a href="#cb130-29" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-30"><a href="#cb130-30" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
-<span id="cb130-31"><a href="#cb130-31" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb130-32"><a href="#cb130-32" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb130-33"><a href="#cb130-33" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
-<span id="cb130-34"><a href="#cb130-34" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
-<span id="cb130-35"><a href="#cb130-35" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_matrix_left_solve<span class="op">(</span></span>
-<span id="cb130-36"><a href="#cb130-36" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb130-37"><a href="#cb130-37" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb130-38"><a href="#cb130-38" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
-<span id="cb130-39"><a href="#cb130-39" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
-<span id="cb130-40"><a href="#cb130-40" aria-hidden="true" tabindex="-1"></a>  OutMat X<span class="op">)</span>;</span>
-<span id="cb130-41"><a href="#cb130-41" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb130-42"><a href="#cb130-42" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
-<span id="cb130-43"><a href="#cb130-43" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb130-44"><a href="#cb130-44" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb130-45"><a href="#cb130-45" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
-<span id="cb130-46"><a href="#cb130-46" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
-<span id="cb130-47"><a href="#cb130-47" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_matrix_left_solve<span class="op">(</span></span>
-<span id="cb130-48"><a href="#cb130-48" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb130-49"><a href="#cb130-49" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb130-50"><a href="#cb130-50" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb130-51"><a href="#cb130-51" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
-<span id="cb130-52"><a href="#cb130-52" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
-<span id="cb130-53"><a href="#cb130-53" aria-hidden="true" tabindex="-1"></a>  OutMat X<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb137"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb137-1"><a href="#cb137-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
+<span id="cb137-2"><a href="#cb137-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb137-3"><a href="#cb137-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb137-4"><a href="#cb137-4" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
+<span id="cb137-5"><a href="#cb137-5" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat,</span>
+<span id="cb137-6"><a href="#cb137-6" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> BinaryDivideOp<span class="op">&gt;</span></span>
+<span id="cb137-7"><a href="#cb137-7" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_matrix_left_solve<span class="op">(</span></span>
+<span id="cb137-8"><a href="#cb137-8" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb137-9"><a href="#cb137-9" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb137-10"><a href="#cb137-10" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
+<span id="cb137-11"><a href="#cb137-11" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
+<span id="cb137-12"><a href="#cb137-12" aria-hidden="true" tabindex="-1"></a>  OutMat X,</span>
+<span id="cb137-13"><a href="#cb137-13" aria-hidden="true" tabindex="-1"></a>  BinaryDivideOp divide<span class="op">)</span>;</span>
+<span id="cb137-14"><a href="#cb137-14" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb137-15"><a href="#cb137-15" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
+<span id="cb137-16"><a href="#cb137-16" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb137-17"><a href="#cb137-17" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb137-18"><a href="#cb137-18" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
+<span id="cb137-19"><a href="#cb137-19" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat,</span>
+<span id="cb137-20"><a href="#cb137-20" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> BinaryDivideOp<span class="op">&gt;</span></span>
+<span id="cb137-21"><a href="#cb137-21" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_matrix_left_solve<span class="op">(</span></span>
+<span id="cb137-22"><a href="#cb137-22" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb137-23"><a href="#cb137-23" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb137-24"><a href="#cb137-24" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb137-25"><a href="#cb137-25" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
+<span id="cb137-26"><a href="#cb137-26" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
+<span id="cb137-27"><a href="#cb137-27" aria-hidden="true" tabindex="-1"></a>  OutMat X,</span>
+<span id="cb137-28"><a href="#cb137-28" aria-hidden="true" tabindex="-1"></a>  BinaryDivideOp divide<span class="op">)</span>;</span>
+<span id="cb137-29"><a href="#cb137-29" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-30"><a href="#cb137-30" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
+<span id="cb137-31"><a href="#cb137-31" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb137-32"><a href="#cb137-32" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb137-33"><a href="#cb137-33" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
+<span id="cb137-34"><a href="#cb137-34" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
+<span id="cb137-35"><a href="#cb137-35" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_matrix_left_solve<span class="op">(</span></span>
+<span id="cb137-36"><a href="#cb137-36" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb137-37"><a href="#cb137-37" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb137-38"><a href="#cb137-38" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
+<span id="cb137-39"><a href="#cb137-39" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
+<span id="cb137-40"><a href="#cb137-40" aria-hidden="true" tabindex="-1"></a>  OutMat X<span class="op">)</span>;</span>
+<span id="cb137-41"><a href="#cb137-41" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb137-42"><a href="#cb137-42" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
+<span id="cb137-43"><a href="#cb137-43" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb137-44"><a href="#cb137-44" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb137-45"><a href="#cb137-45" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
+<span id="cb137-46"><a href="#cb137-46" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
+<span id="cb137-47"><a href="#cb137-47" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_matrix_left_solve<span class="op">(</span></span>
+<span id="cb137-48"><a href="#cb137-48" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb137-49"><a href="#cb137-49" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb137-50"><a href="#cb137-50" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb137-51"><a href="#cb137-51" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
+<span id="cb137-52"><a href="#cb137-52" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
+<span id="cb137-53"><a href="#cb137-53" aria-hidden="true" tabindex="-1"></a>  OutMat X<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">3</a></span>
 <em>Preconditions:</em> <code>A.extent(1)</code> equals
 <code>B.extent(0)</code>.</p>
@@ -10524,53 +10700,56 @@ inverse of the second argument) and the first argument, in that order.
 <i>– end note]</i></p>
 <p><span class="marginalizedparent"><a class="marginalized">6</a></span>
 In-place left solve of multiple triangular systems</p>
-<div class="sourceCode" id="cb131"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb131-1"><a href="#cb131-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
-<span id="cb131-2"><a href="#cb131-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb131-3"><a href="#cb131-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb131-4"><a href="#cb131-4" aria-hidden="true" tabindex="-1"></a>         <em>inout-matrix</em> InOutMat,</span>
-<span id="cb131-5"><a href="#cb131-5" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> BinaryDivideOp<span class="op">&gt;</span></span>
-<span id="cb131-6"><a href="#cb131-6" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_matrix_left_solve<span class="op">(</span></span>
-<span id="cb131-7"><a href="#cb131-7" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb131-8"><a href="#cb131-8" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb131-9"><a href="#cb131-9" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
-<span id="cb131-10"><a href="#cb131-10" aria-hidden="true" tabindex="-1"></a>  InOutMat B,</span>
-<span id="cb131-11"><a href="#cb131-11" aria-hidden="true" tabindex="-1"></a>  BinaryDivideOp divide<span class="op">)</span>;</span>
-<span id="cb131-12"><a href="#cb131-12" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb131-13"><a href="#cb131-13" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
-<span id="cb131-14"><a href="#cb131-14" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb131-15"><a href="#cb131-15" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb131-16"><a href="#cb131-16" aria-hidden="true" tabindex="-1"></a>         <em>inout-matrix</em> InOutMat,</span>
-<span id="cb131-17"><a href="#cb131-17" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> BinaryDivideOp<span class="op">&gt;</span></span>
-<span id="cb131-18"><a href="#cb131-18" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_matrix_left_solve<span class="op">(</span></span>
-<span id="cb131-19"><a href="#cb131-19" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb131-20"><a href="#cb131-20" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb131-21"><a href="#cb131-21" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb131-22"><a href="#cb131-22" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
-<span id="cb131-23"><a href="#cb131-23" aria-hidden="true" tabindex="-1"></a>  InOutMat B,</span>
-<span id="cb131-24"><a href="#cb131-24" aria-hidden="true" tabindex="-1"></a>  BinaryDivideOp divide<span class="op">)</span>;</span>
-<span id="cb131-25"><a href="#cb131-25" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-26"><a href="#cb131-26" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
-<span id="cb131-27"><a href="#cb131-27" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb131-28"><a href="#cb131-28" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb131-29"><a href="#cb131-29" aria-hidden="true" tabindex="-1"></a>         <em>inout-matrix</em> InOutMat<span class="op">&gt;</span></span>
-<span id="cb131-30"><a href="#cb131-30" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_matrix_left_solve<span class="op">(</span></span>
-<span id="cb131-31"><a href="#cb131-31" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb131-32"><a href="#cb131-32" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb131-33"><a href="#cb131-33" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
-<span id="cb131-34"><a href="#cb131-34" aria-hidden="true" tabindex="-1"></a>  InOutMat B<span class="op">)</span>;</span>
-<span id="cb131-35"><a href="#cb131-35" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb131-36"><a href="#cb131-36" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
-<span id="cb131-37"><a href="#cb131-37" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb131-38"><a href="#cb131-38" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb131-39"><a href="#cb131-39" aria-hidden="true" tabindex="-1"></a>         <em>inout-matrix</em> InOutMat<span class="op">&gt;</span></span>
-<span id="cb131-40"><a href="#cb131-40" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_matrix_left_solve<span class="op">(</span></span>
-<span id="cb131-41"><a href="#cb131-41" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb131-42"><a href="#cb131-42" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb131-43"><a href="#cb131-43" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb131-44"><a href="#cb131-44" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
-<span id="cb131-45"><a href="#cb131-45" aria-hidden="true" tabindex="-1"></a>  InOutMat B<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb138"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb138-1"><a href="#cb138-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
+<span id="cb138-2"><a href="#cb138-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb138-3"><a href="#cb138-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb138-4"><a href="#cb138-4" aria-hidden="true" tabindex="-1"></a>         <em>inout-matrix</em> InOutMat,</span>
+<span id="cb138-5"><a href="#cb138-5" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> BinaryDivideOp<span class="op">&gt;</span></span>
+<span id="cb138-6"><a href="#cb138-6" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_matrix_left_solve<span class="op">(</span></span>
+<span id="cb138-7"><a href="#cb138-7" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb138-8"><a href="#cb138-8" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb138-9"><a href="#cb138-9" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
+<span id="cb138-10"><a href="#cb138-10" aria-hidden="true" tabindex="-1"></a>  InOutMat B,</span>
+<span id="cb138-11"><a href="#cb138-11" aria-hidden="true" tabindex="-1"></a>  BinaryDivideOp divide<span class="op">)</span>;</span>
+<span id="cb138-12"><a href="#cb138-12" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb138-13"><a href="#cb138-13" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
+<span id="cb138-14"><a href="#cb138-14" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb138-15"><a href="#cb138-15" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb138-16"><a href="#cb138-16" aria-hidden="true" tabindex="-1"></a>         <em>inout-matrix</em> InOutMat,</span>
+<span id="cb138-17"><a href="#cb138-17" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> BinaryDivideOp<span class="op">&gt;</span></span>
+<span id="cb138-18"><a href="#cb138-18" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_matrix_left_solve<span class="op">(</span></span>
+<span id="cb138-19"><a href="#cb138-19" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb138-20"><a href="#cb138-20" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb138-21"><a href="#cb138-21" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb138-22"><a href="#cb138-22" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
+<span id="cb138-23"><a href="#cb138-23" aria-hidden="true" tabindex="-1"></a>  InOutMat B,</span>
+<span id="cb138-24"><a href="#cb138-24" aria-hidden="true" tabindex="-1"></a>  BinaryDivideOp divide<span class="op">)</span>;</span>
+<span id="cb138-25"><a href="#cb138-25" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-26"><a href="#cb138-26" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
+<span id="cb138-27"><a href="#cb138-27" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb138-28"><a href="#cb138-28" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb138-29"><a href="#cb138-29" aria-hidden="true" tabindex="-1"></a>         <em>inout-matrix</em> InOutMat<span class="op">&gt;</span></span>
+<span id="cb138-30"><a href="#cb138-30" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_matrix_left_solve<span class="op">(</span></span>
+<span id="cb138-31"><a href="#cb138-31" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb138-32"><a href="#cb138-32" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb138-33"><a href="#cb138-33" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
+<span id="cb138-34"><a href="#cb138-34" aria-hidden="true" tabindex="-1"></a>  InOutMat B<span class="op">)</span>;</span>
+<span id="cb138-35"><a href="#cb138-35" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb138-36"><a href="#cb138-36" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
+<span id="cb138-37"><a href="#cb138-37" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb138-38"><a href="#cb138-38" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb138-39"><a href="#cb138-39" aria-hidden="true" tabindex="-1"></a>         <em>inout-matrix</em> InOutMat<span class="op">&gt;</span></span>
+<span id="cb138-40"><a href="#cb138-40" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_matrix_left_solve<span class="op">(</span></span>
+<span id="cb138-41"><a href="#cb138-41" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb138-42"><a href="#cb138-42" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb138-43"><a href="#cb138-43" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb138-44"><a href="#cb138-44" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
+<span id="cb138-45"><a href="#cb138-45" aria-hidden="true" tabindex="-1"></a>  InOutMat B<span class="op">)</span>;</span></code></pre></div>
 <p><i>[Note:</i> This algorithm makes it possible to compute
-factorizations like Cholesky and LU in place.]</i></p>
+factorizations like Cholesky and LU in place.</p>
+<p>Performing triangular solve in place hinders parallelization.
+However, other <code>ExecutionPolicy</code>-specific optimizations, such
+as vectorization, are still possible. <i>– end note]</i></p>
 <p><span class="marginalizedparent"><a class="marginalized">7</a></span>
 <em>Preconditions:</em> <code>A.extent(1)</code> equals
 <code>B.extent(0)</code>.</p>
@@ -10601,59 +10780,59 @@ linear in <code>B.extent(0)</code> times <code>B.extent(1)</code> times
 <code>A.extent(1)</code>.</p>
 <p><span class="marginalizedparent"><a class="marginalized">2</a></span>
 Not-in-place right solve of multiple triangular systems</p>
-<div class="sourceCode" id="cb132"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb132-1"><a href="#cb132-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
-<span id="cb132-2"><a href="#cb132-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb132-3"><a href="#cb132-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb132-4"><a href="#cb132-4" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
-<span id="cb132-5"><a href="#cb132-5" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat,</span>
-<span id="cb132-6"><a href="#cb132-6" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> BinaryDivideOp<span class="op">&gt;</span></span>
-<span id="cb132-7"><a href="#cb132-7" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_matrix_right_solve<span class="op">(</span></span>
-<span id="cb132-8"><a href="#cb132-8" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb132-9"><a href="#cb132-9" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb132-10"><a href="#cb132-10" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
-<span id="cb132-11"><a href="#cb132-11" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
-<span id="cb132-12"><a href="#cb132-12" aria-hidden="true" tabindex="-1"></a>  OutMat X,</span>
-<span id="cb132-13"><a href="#cb132-13" aria-hidden="true" tabindex="-1"></a>  BinaryDivideOp divide<span class="op">)</span>;</span>
-<span id="cb132-14"><a href="#cb132-14" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb132-15"><a href="#cb132-15" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
-<span id="cb132-16"><a href="#cb132-16" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb132-17"><a href="#cb132-17" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb132-18"><a href="#cb132-18" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
-<span id="cb132-19"><a href="#cb132-19" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat,</span>
-<span id="cb132-20"><a href="#cb132-20" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> BinaryDivideOp<span class="op">&gt;</span></span>
-<span id="cb132-21"><a href="#cb132-21" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_matrix_right_solve<span class="op">(</span></span>
-<span id="cb132-22"><a href="#cb132-22" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb132-23"><a href="#cb132-23" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb132-24"><a href="#cb132-24" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb132-25"><a href="#cb132-25" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
-<span id="cb132-26"><a href="#cb132-26" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
-<span id="cb132-27"><a href="#cb132-27" aria-hidden="true" tabindex="-1"></a>  OutMat X,</span>
-<span id="cb132-28"><a href="#cb132-28" aria-hidden="true" tabindex="-1"></a>  BinaryDivideOp divide<span class="op">)</span>;</span>
-<span id="cb132-29"><a href="#cb132-29" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb132-30"><a href="#cb132-30" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
-<span id="cb132-31"><a href="#cb132-31" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb132-32"><a href="#cb132-32" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb132-33"><a href="#cb132-33" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
-<span id="cb132-34"><a href="#cb132-34" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
-<span id="cb132-35"><a href="#cb132-35" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_matrix_right_solve<span class="op">(</span></span>
-<span id="cb132-36"><a href="#cb132-36" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb132-37"><a href="#cb132-37" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb132-38"><a href="#cb132-38" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
-<span id="cb132-39"><a href="#cb132-39" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
-<span id="cb132-40"><a href="#cb132-40" aria-hidden="true" tabindex="-1"></a>  OutMat X<span class="op">)</span>;</span>
-<span id="cb132-41"><a href="#cb132-41" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb132-42"><a href="#cb132-42" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
-<span id="cb132-43"><a href="#cb132-43" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb132-44"><a href="#cb132-44" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb132-45"><a href="#cb132-45" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
-<span id="cb132-46"><a href="#cb132-46" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
-<span id="cb132-47"><a href="#cb132-47" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_matrix_right_solve<span class="op">(</span></span>
-<span id="cb132-48"><a href="#cb132-48" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb132-49"><a href="#cb132-49" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb132-50"><a href="#cb132-50" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb132-51"><a href="#cb132-51" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
-<span id="cb132-52"><a href="#cb132-52" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
-<span id="cb132-53"><a href="#cb132-53" aria-hidden="true" tabindex="-1"></a>  OutMat X<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb139"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb139-1"><a href="#cb139-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
+<span id="cb139-2"><a href="#cb139-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb139-3"><a href="#cb139-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb139-4"><a href="#cb139-4" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
+<span id="cb139-5"><a href="#cb139-5" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat,</span>
+<span id="cb139-6"><a href="#cb139-6" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> BinaryDivideOp<span class="op">&gt;</span></span>
+<span id="cb139-7"><a href="#cb139-7" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_matrix_right_solve<span class="op">(</span></span>
+<span id="cb139-8"><a href="#cb139-8" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb139-9"><a href="#cb139-9" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb139-10"><a href="#cb139-10" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
+<span id="cb139-11"><a href="#cb139-11" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
+<span id="cb139-12"><a href="#cb139-12" aria-hidden="true" tabindex="-1"></a>  OutMat X,</span>
+<span id="cb139-13"><a href="#cb139-13" aria-hidden="true" tabindex="-1"></a>  BinaryDivideOp divide<span class="op">)</span>;</span>
+<span id="cb139-14"><a href="#cb139-14" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb139-15"><a href="#cb139-15" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
+<span id="cb139-16"><a href="#cb139-16" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb139-17"><a href="#cb139-17" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb139-18"><a href="#cb139-18" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
+<span id="cb139-19"><a href="#cb139-19" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat,</span>
+<span id="cb139-20"><a href="#cb139-20" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> BinaryDivideOp<span class="op">&gt;</span></span>
+<span id="cb139-21"><a href="#cb139-21" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_matrix_right_solve<span class="op">(</span></span>
+<span id="cb139-22"><a href="#cb139-22" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb139-23"><a href="#cb139-23" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb139-24"><a href="#cb139-24" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb139-25"><a href="#cb139-25" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
+<span id="cb139-26"><a href="#cb139-26" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
+<span id="cb139-27"><a href="#cb139-27" aria-hidden="true" tabindex="-1"></a>  OutMat X,</span>
+<span id="cb139-28"><a href="#cb139-28" aria-hidden="true" tabindex="-1"></a>  BinaryDivideOp divide<span class="op">)</span>;</span>
+<span id="cb139-29"><a href="#cb139-29" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-30"><a href="#cb139-30" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
+<span id="cb139-31"><a href="#cb139-31" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb139-32"><a href="#cb139-32" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb139-33"><a href="#cb139-33" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
+<span id="cb139-34"><a href="#cb139-34" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
+<span id="cb139-35"><a href="#cb139-35" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_matrix_right_solve<span class="op">(</span></span>
+<span id="cb139-36"><a href="#cb139-36" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb139-37"><a href="#cb139-37" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb139-38"><a href="#cb139-38" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
+<span id="cb139-39"><a href="#cb139-39" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
+<span id="cb139-40"><a href="#cb139-40" aria-hidden="true" tabindex="-1"></a>  OutMat X<span class="op">)</span>;</span>
+<span id="cb139-41"><a href="#cb139-41" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb139-42"><a href="#cb139-42" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
+<span id="cb139-43"><a href="#cb139-43" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb139-44"><a href="#cb139-44" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb139-45"><a href="#cb139-45" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat2,</span>
+<span id="cb139-46"><a href="#cb139-46" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
+<span id="cb139-47"><a href="#cb139-47" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_matrix_right_solve<span class="op">(</span></span>
+<span id="cb139-48"><a href="#cb139-48" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb139-49"><a href="#cb139-49" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb139-50"><a href="#cb139-50" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb139-51"><a href="#cb139-51" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
+<span id="cb139-52"><a href="#cb139-52" aria-hidden="true" tabindex="-1"></a>  InMat2 B,</span>
+<span id="cb139-53"><a href="#cb139-53" aria-hidden="true" tabindex="-1"></a>  OutMat X<span class="op">)</span>;</span></code></pre></div>
 <!--
 One can derive what these algorithms do
 from the `triangular_matrix_matrix_left_solve()` algorithm,
@@ -10688,53 +10867,56 @@ first argument, and (the inverse of the second argument), in that order.
 <i>– end note]</i></p>
 <p><span class="marginalizedparent"><a class="marginalized">6</a></span>
 In-place right solve of multiple triangular systems</p>
-<div class="sourceCode" id="cb133"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb133-1"><a href="#cb133-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
-<span id="cb133-2"><a href="#cb133-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb133-3"><a href="#cb133-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb133-4"><a href="#cb133-4" aria-hidden="true" tabindex="-1"></a>         <em>inout-matrix</em> InOutMat,</span>
-<span id="cb133-5"><a href="#cb133-5" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> BinaryDivideOp<span class="op">&gt;</span></span>
-<span id="cb133-6"><a href="#cb133-6" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_matrix_right_solve<span class="op">(</span></span>
-<span id="cb133-7"><a href="#cb133-7" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb133-8"><a href="#cb133-8" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb133-9"><a href="#cb133-9" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
-<span id="cb133-10"><a href="#cb133-10" aria-hidden="true" tabindex="-1"></a>  InOutMat B,</span>
-<span id="cb133-11"><a href="#cb133-11" aria-hidden="true" tabindex="-1"></a>  BinaryDivideOp divide<span class="op">)</span>;</span>
-<span id="cb133-12"><a href="#cb133-12" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb133-13"><a href="#cb133-13" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
-<span id="cb133-14"><a href="#cb133-14" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb133-15"><a href="#cb133-15" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb133-16"><a href="#cb133-16" aria-hidden="true" tabindex="-1"></a>         <em>inout-matrix</em> InOutMat,</span>
-<span id="cb133-17"><a href="#cb133-17" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> BinaryDivideOp<span class="op">&gt;</span></span>
-<span id="cb133-18"><a href="#cb133-18" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_matrix_right_solve<span class="op">(</span></span>
-<span id="cb133-19"><a href="#cb133-19" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb133-20"><a href="#cb133-20" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb133-21"><a href="#cb133-21" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb133-22"><a href="#cb133-22" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
-<span id="cb133-23"><a href="#cb133-23" aria-hidden="true" tabindex="-1"></a>  InOutMat B,</span>
-<span id="cb133-24"><a href="#cb133-24" aria-hidden="true" tabindex="-1"></a>  BinaryDivideOp divide<span class="op">)</span>;  </span>
-<span id="cb133-25"><a href="#cb133-25" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-26"><a href="#cb133-26" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
-<span id="cb133-27"><a href="#cb133-27" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb133-28"><a href="#cb133-28" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb133-29"><a href="#cb133-29" aria-hidden="true" tabindex="-1"></a>         <em>inout-matrix</em> InOutMat<span class="op">&gt;</span></span>
-<span id="cb133-30"><a href="#cb133-30" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_matrix_right_solve<span class="op">(</span></span>
-<span id="cb133-31"><a href="#cb133-31" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb133-32"><a href="#cb133-32" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb133-33"><a href="#cb133-33" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
-<span id="cb133-34"><a href="#cb133-34" aria-hidden="true" tabindex="-1"></a>  InOutMat B<span class="op">)</span>;</span>
-<span id="cb133-35"><a href="#cb133-35" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
-<span id="cb133-36"><a href="#cb133-36" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
-<span id="cb133-37"><a href="#cb133-37" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb133-38"><a href="#cb133-38" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
-<span id="cb133-39"><a href="#cb133-39" aria-hidden="true" tabindex="-1"></a>         <em>inout-matrix</em> InOutMat<span class="op">&gt;</span></span>
-<span id="cb133-40"><a href="#cb133-40" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_matrix_right_solve<span class="op">(</span></span>
-<span id="cb133-41"><a href="#cb133-41" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
-<span id="cb133-42"><a href="#cb133-42" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
-<span id="cb133-43"><a href="#cb133-43" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb133-44"><a href="#cb133-44" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
-<span id="cb133-45"><a href="#cb133-45" aria-hidden="true" tabindex="-1"></a>  InOutMat B<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb140"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb140-1"><a href="#cb140-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
+<span id="cb140-2"><a href="#cb140-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb140-3"><a href="#cb140-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb140-4"><a href="#cb140-4" aria-hidden="true" tabindex="-1"></a>         <em>inout-matrix</em> InOutMat,</span>
+<span id="cb140-5"><a href="#cb140-5" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> BinaryDivideOp<span class="op">&gt;</span></span>
+<span id="cb140-6"><a href="#cb140-6" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_matrix_right_solve<span class="op">(</span></span>
+<span id="cb140-7"><a href="#cb140-7" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb140-8"><a href="#cb140-8" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb140-9"><a href="#cb140-9" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
+<span id="cb140-10"><a href="#cb140-10" aria-hidden="true" tabindex="-1"></a>  InOutMat B,</span>
+<span id="cb140-11"><a href="#cb140-11" aria-hidden="true" tabindex="-1"></a>  BinaryDivideOp divide<span class="op">)</span>;</span>
+<span id="cb140-12"><a href="#cb140-12" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb140-13"><a href="#cb140-13" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
+<span id="cb140-14"><a href="#cb140-14" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb140-15"><a href="#cb140-15" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb140-16"><a href="#cb140-16" aria-hidden="true" tabindex="-1"></a>         <em>inout-matrix</em> InOutMat,</span>
+<span id="cb140-17"><a href="#cb140-17" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> BinaryDivideOp<span class="op">&gt;</span></span>
+<span id="cb140-18"><a href="#cb140-18" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_matrix_right_solve<span class="op">(</span></span>
+<span id="cb140-19"><a href="#cb140-19" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb140-20"><a href="#cb140-20" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb140-21"><a href="#cb140-21" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb140-22"><a href="#cb140-22" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
+<span id="cb140-23"><a href="#cb140-23" aria-hidden="true" tabindex="-1"></a>  InOutMat B,</span>
+<span id="cb140-24"><a href="#cb140-24" aria-hidden="true" tabindex="-1"></a>  BinaryDivideOp divide<span class="op">)</span>;  </span>
+<span id="cb140-25"><a href="#cb140-25" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb140-26"><a href="#cb140-26" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat1,</span>
+<span id="cb140-27"><a href="#cb140-27" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb140-28"><a href="#cb140-28" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb140-29"><a href="#cb140-29" aria-hidden="true" tabindex="-1"></a>         <em>inout-matrix</em> InOutMat<span class="op">&gt;</span></span>
+<span id="cb140-30"><a href="#cb140-30" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_matrix_right_solve<span class="op">(</span></span>
+<span id="cb140-31"><a href="#cb140-31" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb140-32"><a href="#cb140-32" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb140-33"><a href="#cb140-33" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
+<span id="cb140-34"><a href="#cb140-34" aria-hidden="true" tabindex="-1"></a>  InOutMat B<span class="op">)</span>;</span>
+<span id="cb140-35"><a href="#cb140-35" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ExecutionPolicy,</span>
+<span id="cb140-36"><a href="#cb140-36" aria-hidden="true" tabindex="-1"></a>         <em>in-matrix</em> InMat1,</span>
+<span id="cb140-37"><a href="#cb140-37" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb140-38"><a href="#cb140-38" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> DiagonalStorage,</span>
+<span id="cb140-39"><a href="#cb140-39" aria-hidden="true" tabindex="-1"></a>         <em>inout-matrix</em> InOutMat<span class="op">&gt;</span></span>
+<span id="cb140-40"><a href="#cb140-40" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> triangular_matrix_matrix_right_solve<span class="op">(</span></span>
+<span id="cb140-41"><a href="#cb140-41" aria-hidden="true" tabindex="-1"></a>  ExecutionPolicy<span class="op">&amp;&amp;</span> exec,</span>
+<span id="cb140-42"><a href="#cb140-42" aria-hidden="true" tabindex="-1"></a>  InMat1 A,</span>
+<span id="cb140-43"><a href="#cb140-43" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb140-44"><a href="#cb140-44" aria-hidden="true" tabindex="-1"></a>  DiagonalStorage d,</span>
+<span id="cb140-45"><a href="#cb140-45" aria-hidden="true" tabindex="-1"></a>  InOutMat B<span class="op">)</span>;</span></code></pre></div>
 <p><i>[Note:</i> This algorithm makes it possible to compute
-factorizations like Cholesky and LU in place.]</i></p>
+factorizations like Cholesky and LU in place.</p>
+<p>Performing triangular solve in place hinders parallelization.
+However, other <code>ExecutionPolicy</code>-specific optimizations, such
+as vectorization, are still possible. <i>– end note]</i></p>
 <p><span class="marginalizedparent"><a class="marginalized">7</a></span>
 <em>Preconditions:</em> <code>A.extent(1)</code> equals
 <code>B.extent(1)</code>.</p>
@@ -10767,98 +10949,98 @@ it computes the factorization <span class="math inline"><em>A</em> = <em>L</
 in place, with L stored in the lower triangle of A on output. The
 function returns 0 if success, else k+1 if row/column k has a zero or
 NaN (not a number) diagonal entry.</p>
-<div class="sourceCode" id="cb134"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb134-1"><a href="#cb134-1" aria-hidden="true" tabindex="-1"></a><span class="pp">#include </span><span class="im">&lt;linalg&gt;</span></span>
-<span id="cb134-2"><a href="#cb134-2" aria-hidden="true" tabindex="-1"></a><span class="pp">#include </span><span class="im">&lt;cmath&gt;</span></span>
-<span id="cb134-3"><a href="#cb134-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb134-4"><a href="#cb134-4" aria-hidden="true" tabindex="-1"></a><span class="co">// Flip upper to lower, and lower to upper</span></span>
-<span id="cb134-5"><a href="#cb134-5" aria-hidden="true" tabindex="-1"></a>lower_triangular_t opposite_triangle<span class="op">(</span>upper_triangular_t<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb134-6"><a href="#cb134-6" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <span class="op">{}</span></span>
-<span id="cb134-7"><a href="#cb134-7" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
-<span id="cb134-8"><a href="#cb134-8" aria-hidden="true" tabindex="-1"></a>upper_triangular_t opposite_triangle<span class="op">(</span>lower_triangular_t<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb134-9"><a href="#cb134-9" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <span class="op">{}</span></span>
-<span id="cb134-10"><a href="#cb134-10" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
-<span id="cb134-11"><a href="#cb134-11" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb134-12"><a href="#cb134-12" aria-hidden="true" tabindex="-1"></a><span class="co">// Returns nullopt if no bad pivots,</span></span>
-<span id="cb134-13"><a href="#cb134-13" aria-hidden="true" tabindex="-1"></a><span class="co">// else the index of the first bad pivot.</span></span>
-<span id="cb134-14"><a href="#cb134-14" aria-hidden="true" tabindex="-1"></a><span class="co">// A &quot;bad&quot; pivot is zero or NaN.</span></span>
-<span id="cb134-15"><a href="#cb134-15" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>inout-matrix</em> InOutMat,</span>
-<span id="cb134-16"><a href="#cb134-16" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
-<span id="cb134-17"><a href="#cb134-17" aria-hidden="true" tabindex="-1"></a>std<span class="op">::</span>optional<span class="op">&lt;</span><span class="kw">typename</span> InOutMat<span class="op">::</span>size_type<span class="op">&gt;</span></span>
-<span id="cb134-18"><a href="#cb134-18" aria-hidden="true" tabindex="-1"></a>cholesky_factor<span class="op">(</span>InOutMat A, Triangle t<span class="op">)</span></span>
-<span id="cb134-19"><a href="#cb134-19" aria-hidden="true" tabindex="-1"></a><span class="op">{</span></span>
-<span id="cb134-20"><a href="#cb134-20" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> std<span class="op">::</span>submdspan;</span>
-<span id="cb134-21"><a href="#cb134-21" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> std<span class="op">::</span>tuple;</span>
-<span id="cb134-22"><a href="#cb134-22" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> value_type <span class="op">=</span> <span class="kw">typename</span> InOutMat<span class="op">::</span>value_type;</span>
-<span id="cb134-23"><a href="#cb134-23" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> size_type <span class="op">=</span> <span class="kw">typename</span> InOutMat<span class="op">::</span>size_type;</span>
-<span id="cb134-24"><a href="#cb134-24" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb134-25"><a href="#cb134-25" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> value_type ZERO <span class="op">{}</span>;</span>
-<span id="cb134-26"><a href="#cb134-26" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> value_type ONE <span class="op">(</span><span class="fl">1.0</span><span class="op">)</span>;</span>
-<span id="cb134-27"><a href="#cb134-27" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> size_type n <span class="op">=</span> A<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span>;</span>
-<span id="cb134-28"><a href="#cb134-28" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb134-29"><a href="#cb134-29" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>n <span class="op">==</span> <span class="dv">0</span><span class="op">)</span> <span class="op">{</span></span>
-<span id="cb134-30"><a href="#cb134-30" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> std<span class="op">::</span>nullopt;</span>
-<span id="cb134-31"><a href="#cb134-31" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
-<span id="cb134-32"><a href="#cb134-32" aria-hidden="true" tabindex="-1"></a>  <span class="cf">else</span> <span class="cf">if</span> <span class="op">(</span>n <span class="op">==</span> <span class="dv">1</span><span class="op">)</span> <span class="op">{</span></span>
-<span id="cb134-33"><a href="#cb134-33" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> <span class="op">(</span>A<span class="op">[</span><span class="dv">0</span>,<span class="dv">0</span><span class="op">]</span> <span class="op">&lt;=</span> ZERO <span class="op">||</span> std<span class="op">::</span>isnan<span class="op">(</span>A<span class="op">[</span><span class="dv">0</span>,<span class="dv">0</span><span class="op">]))</span> <span class="op">{</span></span>
-<span id="cb134-34"><a href="#cb134-34" aria-hidden="true" tabindex="-1"></a>      <span class="cf">return</span> <span class="op">{</span>size_type<span class="op">(</span><span class="dv">1</span><span class="op">)}</span>;</span>
-<span id="cb134-35"><a href="#cb134-35" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
-<span id="cb134-36"><a href="#cb134-36" aria-hidden="true" tabindex="-1"></a>    A<span class="op">[</span><span class="dv">0</span>,<span class="dv">0</span><span class="op">]</span> <span class="op">=</span> std<span class="op">::</span>sqrt<span class="op">(</span>A<span class="op">[</span><span class="dv">0</span>,<span class="dv">0</span><span class="op">])</span>;</span>
-<span id="cb134-37"><a href="#cb134-37" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
-<span id="cb134-38"><a href="#cb134-38" aria-hidden="true" tabindex="-1"></a>  <span class="cf">else</span> <span class="op">{</span></span>
-<span id="cb134-39"><a href="#cb134-39" aria-hidden="true" tabindex="-1"></a>    <span class="co">// Partition A into [A11, A12,</span></span>
-<span id="cb134-40"><a href="#cb134-40" aria-hidden="true" tabindex="-1"></a>    <span class="co">//                   A21, A22],</span></span>
-<span id="cb134-41"><a href="#cb134-41" aria-hidden="true" tabindex="-1"></a>    <span class="co">// where A21 is the transpose of A12.</span></span>
-<span id="cb134-42"><a href="#cb134-42" aria-hidden="true" tabindex="-1"></a>    <span class="kw">const</span> size_type n1 <span class="op">=</span> n <span class="op">/</span> <span class="dv">2</span>;</span>
-<span id="cb134-43"><a href="#cb134-43" aria-hidden="true" tabindex="-1"></a>    <span class="kw">const</span> size_type n2 <span class="op">=</span> n <span class="op">-</span> n1;</span>
-<span id="cb134-44"><a href="#cb134-44" aria-hidden="true" tabindex="-1"></a>    <span class="kw">auto</span> A11 <span class="op">=</span> submdspan<span class="op">(</span>A, pair<span class="op">{</span><span class="dv">0</span>, n1<span class="op">}</span>, pair<span class="op">{</span><span class="dv">0</span>, n1<span class="op">})</span>;</span>
-<span id="cb134-45"><a href="#cb134-45" aria-hidden="true" tabindex="-1"></a>    <span class="kw">auto</span> A22 <span class="op">=</span> submdspan<span class="op">(</span>A, pair<span class="op">{</span>n1, n<span class="op">}</span>, pair<span class="op">{</span>n1, n<span class="op">})</span>;</span>
-<span id="cb134-46"><a href="#cb134-46" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb134-47"><a href="#cb134-47" aria-hidden="true" tabindex="-1"></a>    <span class="co">// Factor A11</span></span>
-<span id="cb134-48"><a href="#cb134-48" aria-hidden="true" tabindex="-1"></a>    <span class="kw">const</span> <span class="kw">auto</span> info1 <span class="op">=</span> cholesky_factor<span class="op">(</span>A11, t<span class="op">)</span>;</span>
-<span id="cb134-49"><a href="#cb134-49" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> <span class="op">(</span>info1<span class="op">.</span>has_value<span class="op">())</span> <span class="op">{</span></span>
-<span id="cb134-50"><a href="#cb134-50" aria-hidden="true" tabindex="-1"></a>      <span class="cf">return</span> info1;</span>
-<span id="cb134-51"><a href="#cb134-51" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
-<span id="cb134-52"><a href="#cb134-52" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb134-53"><a href="#cb134-53" aria-hidden="true" tabindex="-1"></a>    <span class="kw">using</span> std<span class="op">::</span>linalg<span class="op">::</span>explicit_diagonal;</span>
-<span id="cb134-54"><a href="#cb134-54" aria-hidden="true" tabindex="-1"></a>    <span class="kw">using</span> std<span class="op">::</span>linalg<span class="op">::</span>symmetric_matrix_rank_k_update;</span>
-<span id="cb134-55"><a href="#cb134-55" aria-hidden="true" tabindex="-1"></a>    <span class="kw">using</span> std<span class="op">::</span>linalg<span class="op">::</span>transposed;</span>
-<span id="cb134-56"><a href="#cb134-56" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> <span class="kw">constexpr</span> <span class="op">(</span>std<span class="op">::</span>is_same_v<span class="op">&lt;</span>Triangle, upper_triangle_t<span class="op">&gt;)</span> <span class="op">{</span></span>
-<span id="cb134-57"><a href="#cb134-57" aria-hidden="true" tabindex="-1"></a>      <span class="co">// Update and scale A12</span></span>
-<span id="cb134-58"><a href="#cb134-58" aria-hidden="true" tabindex="-1"></a>      <span class="kw">auto</span> A12 <span class="op">=</span> submdspan<span class="op">(</span>A, tuple<span class="op">{</span><span class="dv">0</span>, n1<span class="op">}</span>, tuple<span class="op">{</span>n1, n<span class="op">})</span>;</span>
-<span id="cb134-59"><a href="#cb134-59" aria-hidden="true" tabindex="-1"></a>      <span class="kw">using</span> std<span class="op">::</span>linalg<span class="op">::</span>triangular_matrix_matrix_left_solve;</span>
-<span id="cb134-60"><a href="#cb134-60" aria-hidden="true" tabindex="-1"></a>      <span class="co">// BLAS would use original triangle; we need to flip it</span></span>
-<span id="cb134-61"><a href="#cb134-61" aria-hidden="true" tabindex="-1"></a>      triangular_matrix_matrix_left_solve<span class="op">(</span>transposed<span class="op">(</span>A11<span class="op">)</span>,</span>
-<span id="cb134-62"><a href="#cb134-62" aria-hidden="true" tabindex="-1"></a>        opposite_triangle<span class="op">(</span>t<span class="op">)</span>, explicit_diagonal, A12<span class="op">)</span>;</span>
-<span id="cb134-63"><a href="#cb134-63" aria-hidden="true" tabindex="-1"></a>      <span class="co">// A22 = A22 - A12^T * A12</span></span>
-<span id="cb134-64"><a href="#cb134-64" aria-hidden="true" tabindex="-1"></a>      <span class="co">//</span></span>
-<span id="cb134-65"><a href="#cb134-65" aria-hidden="true" tabindex="-1"></a>      <span class="co">// The Triangle argument applies to A22,</span></span>
-<span id="cb134-66"><a href="#cb134-66" aria-hidden="true" tabindex="-1"></a>      <span class="co">// not transposed(A12), so we don&#39;t flip it.</span></span>
-<span id="cb134-67"><a href="#cb134-67" aria-hidden="true" tabindex="-1"></a>      symmetric_matrix_rank_k_update<span class="op">(-</span>ONE, transposed<span class="op">(</span>A12<span class="op">)</span>,</span>
-<span id="cb134-68"><a href="#cb134-68" aria-hidden="true" tabindex="-1"></a>                                     A22, t<span class="op">)</span>;</span>
-<span id="cb134-69"><a href="#cb134-69" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
-<span id="cb134-70"><a href="#cb134-70" aria-hidden="true" tabindex="-1"></a>    <span class="cf">else</span> <span class="op">{</span></span>
-<span id="cb134-71"><a href="#cb134-71" aria-hidden="true" tabindex="-1"></a>      <span class="co">//</span></span>
-<span id="cb134-72"><a href="#cb134-72" aria-hidden="true" tabindex="-1"></a>      <span class="co">// Compute the Cholesky factorization A = L * L^T</span></span>
-<span id="cb134-73"><a href="#cb134-73" aria-hidden="true" tabindex="-1"></a>      <span class="co">//</span></span>
-<span id="cb134-74"><a href="#cb134-74" aria-hidden="true" tabindex="-1"></a>      <span class="co">// Update and scale A21</span></span>
-<span id="cb134-75"><a href="#cb134-75" aria-hidden="true" tabindex="-1"></a>      <span class="kw">auto</span> A21 <span class="op">=</span> submdspan<span class="op">(</span>A, tuple<span class="op">{</span>n1, n<span class="op">}</span>, tuple<span class="op">{</span><span class="dv">0</span>, n1<span class="op">})</span>;</span>
-<span id="cb134-76"><a href="#cb134-76" aria-hidden="true" tabindex="-1"></a>      <span class="kw">using</span> std<span class="op">::</span>linalg<span class="op">::</span>triangular_matrix_matrix_right_solve;</span>
-<span id="cb134-77"><a href="#cb134-77" aria-hidden="true" tabindex="-1"></a>      <span class="co">// BLAS would use original triangle; we need to flip it</span></span>
-<span id="cb134-78"><a href="#cb134-78" aria-hidden="true" tabindex="-1"></a>      triangular_matrix_matrix_right_solve<span class="op">(</span>transposed<span class="op">(</span>A11<span class="op">)</span>,</span>
-<span id="cb134-79"><a href="#cb134-79" aria-hidden="true" tabindex="-1"></a>        opposite_triangle<span class="op">(</span>t<span class="op">)</span>, explicit_diagonal, A21<span class="op">)</span>;</span>
-<span id="cb134-80"><a href="#cb134-80" aria-hidden="true" tabindex="-1"></a>      <span class="co">// A22 = A22 - A21 * A21^T</span></span>
-<span id="cb134-81"><a href="#cb134-81" aria-hidden="true" tabindex="-1"></a>      symmetric_matrix_rank_k_update<span class="op">(-</span>ONE, A21, A22, t<span class="op">)</span>;</span>
-<span id="cb134-82"><a href="#cb134-82" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
-<span id="cb134-83"><a href="#cb134-83" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb134-84"><a href="#cb134-84" aria-hidden="true" tabindex="-1"></a>    <span class="co">// Factor A22</span></span>
-<span id="cb134-85"><a href="#cb134-85" aria-hidden="true" tabindex="-1"></a>    <span class="kw">const</span> <span class="kw">auto</span> info2 <span class="op">=</span> cholesky_factor<span class="op">(</span>A22, t<span class="op">)</span>;</span>
-<span id="cb134-86"><a href="#cb134-86" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> <span class="op">(</span>info2<span class="op">.</span>has_value<span class="op">())</span> <span class="op">{</span></span>
-<span id="cb134-87"><a href="#cb134-87" aria-hidden="true" tabindex="-1"></a>      <span class="cf">return</span> <span class="op">{</span>info2<span class="op">.</span>value<span class="op">()</span> <span class="op">+</span> n1<span class="op">}</span>;</span>
-<span id="cb134-88"><a href="#cb134-88" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
-<span id="cb134-89"><a href="#cb134-89" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
-<span id="cb134-90"><a href="#cb134-90" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb134-91"><a href="#cb134-91" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> std<span class="op">::</span>nullopt;</span>
-<span id="cb134-92"><a href="#cb134-92" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb141"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb141-1"><a href="#cb141-1" aria-hidden="true" tabindex="-1"></a><span class="pp">#include </span><span class="im">&lt;linalg&gt;</span></span>
+<span id="cb141-2"><a href="#cb141-2" aria-hidden="true" tabindex="-1"></a><span class="pp">#include </span><span class="im">&lt;cmath&gt;</span></span>
+<span id="cb141-3"><a href="#cb141-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb141-4"><a href="#cb141-4" aria-hidden="true" tabindex="-1"></a><span class="co">// Flip upper to lower, and lower to upper</span></span>
+<span id="cb141-5"><a href="#cb141-5" aria-hidden="true" tabindex="-1"></a>lower_triangular_t opposite_triangle<span class="op">(</span>upper_triangular_t<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb141-6"><a href="#cb141-6" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <span class="op">{}</span></span>
+<span id="cb141-7"><a href="#cb141-7" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
+<span id="cb141-8"><a href="#cb141-8" aria-hidden="true" tabindex="-1"></a>upper_triangular_t opposite_triangle<span class="op">(</span>lower_triangular_t<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb141-9"><a href="#cb141-9" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <span class="op">{}</span></span>
+<span id="cb141-10"><a href="#cb141-10" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
+<span id="cb141-11"><a href="#cb141-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb141-12"><a href="#cb141-12" aria-hidden="true" tabindex="-1"></a><span class="co">// Returns nullopt if no bad pivots,</span></span>
+<span id="cb141-13"><a href="#cb141-13" aria-hidden="true" tabindex="-1"></a><span class="co">// else the index of the first bad pivot.</span></span>
+<span id="cb141-14"><a href="#cb141-14" aria-hidden="true" tabindex="-1"></a><span class="co">// A &quot;bad&quot; pivot is zero or NaN.</span></span>
+<span id="cb141-15"><a href="#cb141-15" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>inout-matrix</em> InOutMat,</span>
+<span id="cb141-16"><a href="#cb141-16" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle<span class="op">&gt;</span></span>
+<span id="cb141-17"><a href="#cb141-17" aria-hidden="true" tabindex="-1"></a>std<span class="op">::</span>optional<span class="op">&lt;</span><span class="kw">typename</span> InOutMat<span class="op">::</span>size_type<span class="op">&gt;</span></span>
+<span id="cb141-18"><a href="#cb141-18" aria-hidden="true" tabindex="-1"></a>cholesky_factor<span class="op">(</span>InOutMat A, Triangle t<span class="op">)</span></span>
+<span id="cb141-19"><a href="#cb141-19" aria-hidden="true" tabindex="-1"></a><span class="op">{</span></span>
+<span id="cb141-20"><a href="#cb141-20" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> std<span class="op">::</span>submdspan;</span>
+<span id="cb141-21"><a href="#cb141-21" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> std<span class="op">::</span>tuple;</span>
+<span id="cb141-22"><a href="#cb141-22" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> value_type <span class="op">=</span> <span class="kw">typename</span> InOutMat<span class="op">::</span>value_type;</span>
+<span id="cb141-23"><a href="#cb141-23" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> size_type <span class="op">=</span> <span class="kw">typename</span> InOutMat<span class="op">::</span>size_type;</span>
+<span id="cb141-24"><a href="#cb141-24" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb141-25"><a href="#cb141-25" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> value_type ZERO <span class="op">{}</span>;</span>
+<span id="cb141-26"><a href="#cb141-26" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> value_type ONE <span class="op">(</span><span class="fl">1.0</span><span class="op">)</span>;</span>
+<span id="cb141-27"><a href="#cb141-27" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> size_type n <span class="op">=</span> A<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span>;</span>
+<span id="cb141-28"><a href="#cb141-28" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb141-29"><a href="#cb141-29" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>n <span class="op">==</span> <span class="dv">0</span><span class="op">)</span> <span class="op">{</span></span>
+<span id="cb141-30"><a href="#cb141-30" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> std<span class="op">::</span>nullopt;</span>
+<span id="cb141-31"><a href="#cb141-31" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb141-32"><a href="#cb141-32" aria-hidden="true" tabindex="-1"></a>  <span class="cf">else</span> <span class="cf">if</span> <span class="op">(</span>n <span class="op">==</span> <span class="dv">1</span><span class="op">)</span> <span class="op">{</span></span>
+<span id="cb141-33"><a href="#cb141-33" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> <span class="op">(</span>A<span class="op">[</span><span class="dv">0</span>,<span class="dv">0</span><span class="op">]</span> <span class="op">&lt;=</span> ZERO <span class="op">||</span> std<span class="op">::</span>isnan<span class="op">(</span>A<span class="op">[</span><span class="dv">0</span>,<span class="dv">0</span><span class="op">]))</span> <span class="op">{</span></span>
+<span id="cb141-34"><a href="#cb141-34" aria-hidden="true" tabindex="-1"></a>      <span class="cf">return</span> <span class="op">{</span>size_type<span class="op">(</span><span class="dv">1</span><span class="op">)}</span>;</span>
+<span id="cb141-35"><a href="#cb141-35" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb141-36"><a href="#cb141-36" aria-hidden="true" tabindex="-1"></a>    A<span class="op">[</span><span class="dv">0</span>,<span class="dv">0</span><span class="op">]</span> <span class="op">=</span> std<span class="op">::</span>sqrt<span class="op">(</span>A<span class="op">[</span><span class="dv">0</span>,<span class="dv">0</span><span class="op">])</span>;</span>
+<span id="cb141-37"><a href="#cb141-37" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb141-38"><a href="#cb141-38" aria-hidden="true" tabindex="-1"></a>  <span class="cf">else</span> <span class="op">{</span></span>
+<span id="cb141-39"><a href="#cb141-39" aria-hidden="true" tabindex="-1"></a>    <span class="co">// Partition A into [A11, A12,</span></span>
+<span id="cb141-40"><a href="#cb141-40" aria-hidden="true" tabindex="-1"></a>    <span class="co">//                   A21, A22],</span></span>
+<span id="cb141-41"><a href="#cb141-41" aria-hidden="true" tabindex="-1"></a>    <span class="co">// where A21 is the transpose of A12.</span></span>
+<span id="cb141-42"><a href="#cb141-42" aria-hidden="true" tabindex="-1"></a>    <span class="kw">const</span> size_type n1 <span class="op">=</span> n <span class="op">/</span> <span class="dv">2</span>;</span>
+<span id="cb141-43"><a href="#cb141-43" aria-hidden="true" tabindex="-1"></a>    <span class="kw">const</span> size_type n2 <span class="op">=</span> n <span class="op">-</span> n1;</span>
+<span id="cb141-44"><a href="#cb141-44" aria-hidden="true" tabindex="-1"></a>    <span class="kw">auto</span> A11 <span class="op">=</span> submdspan<span class="op">(</span>A, pair<span class="op">{</span><span class="dv">0</span>, n1<span class="op">}</span>, pair<span class="op">{</span><span class="dv">0</span>, n1<span class="op">})</span>;</span>
+<span id="cb141-45"><a href="#cb141-45" aria-hidden="true" tabindex="-1"></a>    <span class="kw">auto</span> A22 <span class="op">=</span> submdspan<span class="op">(</span>A, pair<span class="op">{</span>n1, n<span class="op">}</span>, pair<span class="op">{</span>n1, n<span class="op">})</span>;</span>
+<span id="cb141-46"><a href="#cb141-46" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb141-47"><a href="#cb141-47" aria-hidden="true" tabindex="-1"></a>    <span class="co">// Factor A11</span></span>
+<span id="cb141-48"><a href="#cb141-48" aria-hidden="true" tabindex="-1"></a>    <span class="kw">const</span> <span class="kw">auto</span> info1 <span class="op">=</span> cholesky_factor<span class="op">(</span>A11, t<span class="op">)</span>;</span>
+<span id="cb141-49"><a href="#cb141-49" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> <span class="op">(</span>info1<span class="op">.</span>has_value<span class="op">())</span> <span class="op">{</span></span>
+<span id="cb141-50"><a href="#cb141-50" aria-hidden="true" tabindex="-1"></a>      <span class="cf">return</span> info1;</span>
+<span id="cb141-51"><a href="#cb141-51" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb141-52"><a href="#cb141-52" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb141-53"><a href="#cb141-53" aria-hidden="true" tabindex="-1"></a>    <span class="kw">using</span> std<span class="op">::</span>linalg<span class="op">::</span>explicit_diagonal;</span>
+<span id="cb141-54"><a href="#cb141-54" aria-hidden="true" tabindex="-1"></a>    <span class="kw">using</span> std<span class="op">::</span>linalg<span class="op">::</span>symmetric_matrix_rank_k_update;</span>
+<span id="cb141-55"><a href="#cb141-55" aria-hidden="true" tabindex="-1"></a>    <span class="kw">using</span> std<span class="op">::</span>linalg<span class="op">::</span>transposed;</span>
+<span id="cb141-56"><a href="#cb141-56" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> <span class="kw">constexpr</span> <span class="op">(</span>std<span class="op">::</span>is_same_v<span class="op">&lt;</span>Triangle, upper_triangle_t<span class="op">&gt;)</span> <span class="op">{</span></span>
+<span id="cb141-57"><a href="#cb141-57" aria-hidden="true" tabindex="-1"></a>      <span class="co">// Update and scale A12</span></span>
+<span id="cb141-58"><a href="#cb141-58" aria-hidden="true" tabindex="-1"></a>      <span class="kw">auto</span> A12 <span class="op">=</span> submdspan<span class="op">(</span>A, tuple<span class="op">{</span><span class="dv">0</span>, n1<span class="op">}</span>, tuple<span class="op">{</span>n1, n<span class="op">})</span>;</span>
+<span id="cb141-59"><a href="#cb141-59" aria-hidden="true" tabindex="-1"></a>      <span class="kw">using</span> std<span class="op">::</span>linalg<span class="op">::</span>triangular_matrix_matrix_left_solve;</span>
+<span id="cb141-60"><a href="#cb141-60" aria-hidden="true" tabindex="-1"></a>      <span class="co">// BLAS would use original triangle; we need to flip it</span></span>
+<span id="cb141-61"><a href="#cb141-61" aria-hidden="true" tabindex="-1"></a>      triangular_matrix_matrix_left_solve<span class="op">(</span>transposed<span class="op">(</span>A11<span class="op">)</span>,</span>
+<span id="cb141-62"><a href="#cb141-62" aria-hidden="true" tabindex="-1"></a>        opposite_triangle<span class="op">(</span>t<span class="op">)</span>, explicit_diagonal, A12<span class="op">)</span>;</span>
+<span id="cb141-63"><a href="#cb141-63" aria-hidden="true" tabindex="-1"></a>      <span class="co">// A22 = A22 - A12^T * A12</span></span>
+<span id="cb141-64"><a href="#cb141-64" aria-hidden="true" tabindex="-1"></a>      <span class="co">//</span></span>
+<span id="cb141-65"><a href="#cb141-65" aria-hidden="true" tabindex="-1"></a>      <span class="co">// The Triangle argument applies to A22,</span></span>
+<span id="cb141-66"><a href="#cb141-66" aria-hidden="true" tabindex="-1"></a>      <span class="co">// not transposed(A12), so we don&#39;t flip it.</span></span>
+<span id="cb141-67"><a href="#cb141-67" aria-hidden="true" tabindex="-1"></a>      symmetric_matrix_rank_k_update<span class="op">(-</span>ONE, transposed<span class="op">(</span>A12<span class="op">)</span>,</span>
+<span id="cb141-68"><a href="#cb141-68" aria-hidden="true" tabindex="-1"></a>                                     A22, t<span class="op">)</span>;</span>
+<span id="cb141-69"><a href="#cb141-69" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb141-70"><a href="#cb141-70" aria-hidden="true" tabindex="-1"></a>    <span class="cf">else</span> <span class="op">{</span></span>
+<span id="cb141-71"><a href="#cb141-71" aria-hidden="true" tabindex="-1"></a>      <span class="co">//</span></span>
+<span id="cb141-72"><a href="#cb141-72" aria-hidden="true" tabindex="-1"></a>      <span class="co">// Compute the Cholesky factorization A = L * L^T</span></span>
+<span id="cb141-73"><a href="#cb141-73" aria-hidden="true" tabindex="-1"></a>      <span class="co">//</span></span>
+<span id="cb141-74"><a href="#cb141-74" aria-hidden="true" tabindex="-1"></a>      <span class="co">// Update and scale A21</span></span>
+<span id="cb141-75"><a href="#cb141-75" aria-hidden="true" tabindex="-1"></a>      <span class="kw">auto</span> A21 <span class="op">=</span> submdspan<span class="op">(</span>A, tuple<span class="op">{</span>n1, n<span class="op">}</span>, tuple<span class="op">{</span><span class="dv">0</span>, n1<span class="op">})</span>;</span>
+<span id="cb141-76"><a href="#cb141-76" aria-hidden="true" tabindex="-1"></a>      <span class="kw">using</span> std<span class="op">::</span>linalg<span class="op">::</span>triangular_matrix_matrix_right_solve;</span>
+<span id="cb141-77"><a href="#cb141-77" aria-hidden="true" tabindex="-1"></a>      <span class="co">// BLAS would use original triangle; we need to flip it</span></span>
+<span id="cb141-78"><a href="#cb141-78" aria-hidden="true" tabindex="-1"></a>      triangular_matrix_matrix_right_solve<span class="op">(</span>transposed<span class="op">(</span>A11<span class="op">)</span>,</span>
+<span id="cb141-79"><a href="#cb141-79" aria-hidden="true" tabindex="-1"></a>        opposite_triangle<span class="op">(</span>t<span class="op">)</span>, explicit_diagonal, A21<span class="op">)</span>;</span>
+<span id="cb141-80"><a href="#cb141-80" aria-hidden="true" tabindex="-1"></a>      <span class="co">// A22 = A22 - A21 * A21^T</span></span>
+<span id="cb141-81"><a href="#cb141-81" aria-hidden="true" tabindex="-1"></a>      symmetric_matrix_rank_k_update<span class="op">(-</span>ONE, A21, A22, t<span class="op">)</span>;</span>
+<span id="cb141-82"><a href="#cb141-82" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb141-83"><a href="#cb141-83" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb141-84"><a href="#cb141-84" aria-hidden="true" tabindex="-1"></a>    <span class="co">// Factor A22</span></span>
+<span id="cb141-85"><a href="#cb141-85" aria-hidden="true" tabindex="-1"></a>    <span class="kw">const</span> <span class="kw">auto</span> info2 <span class="op">=</span> cholesky_factor<span class="op">(</span>A22, t<span class="op">)</span>;</span>
+<span id="cb141-86"><a href="#cb141-86" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> <span class="op">(</span>info2<span class="op">.</span>has_value<span class="op">())</span> <span class="op">{</span></span>
+<span id="cb141-87"><a href="#cb141-87" aria-hidden="true" tabindex="-1"></a>      <span class="cf">return</span> <span class="op">{</span>info2<span class="op">.</span>value<span class="op">()</span> <span class="op">+</span> n1<span class="op">}</span>;</span>
+<span id="cb141-88"><a href="#cb141-88" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb141-89"><a href="#cb141-89" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb141-90"><a href="#cb141-90" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb141-91"><a href="#cb141-91" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> std<span class="op">::</span>nullopt;</span>
+<span id="cb141-92"><a href="#cb141-92" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <h2 data-number="29.2" id="solve-linear-system-using-cholesky-factorization"><span class="header-section-number">29.2</span> Solve linear system using
 Cholesky factorization<a href="#solve-linear-system-using-cholesky-factorization" class="self-link"></a></h2>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
@@ -10868,39 +11050,39 @@ Cholesky factorization computed in the previous example in-place in the
 matrix <code>A</code>. The example assumes that
 <code>cholesky_factor(A, t)</code> returned <code>nullopt</code>,
 indicating no zero or NaN pivots.</p>
-<div class="sourceCode" id="cb135"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb135-1"><a href="#cb135-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat,</span>
-<span id="cb135-2"><a href="#cb135-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
-<span id="cb135-3"><a href="#cb135-3" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
-<span id="cb135-4"><a href="#cb135-4" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec<span class="op">&gt;</span></span>
-<span id="cb135-5"><a href="#cb135-5" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> cholesky_solve<span class="op">(</span></span>
-<span id="cb135-6"><a href="#cb135-6" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
-<span id="cb135-7"><a href="#cb135-7" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
-<span id="cb135-8"><a href="#cb135-8" aria-hidden="true" tabindex="-1"></a>  InVec b,</span>
-<span id="cb135-9"><a href="#cb135-9" aria-hidden="true" tabindex="-1"></a>  OutVec x<span class="op">)</span></span>
-<span id="cb135-10"><a href="#cb135-10" aria-hidden="true" tabindex="-1"></a><span class="op">{</span></span>
-<span id="cb135-11"><a href="#cb135-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> std<span class="op">::</span>linalg<span class="op">::</span>explicit_diagonal;</span>
-<span id="cb135-12"><a href="#cb135-12" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> std<span class="op">::</span>linalg<span class="op">::</span>transposed;</span>
-<span id="cb135-13"><a href="#cb135-13" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> std<span class="op">::</span>linalg<span class="op">::</span>triangular_matrix_vector_solve;</span>
-<span id="cb135-14"><a href="#cb135-14" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb135-15"><a href="#cb135-15" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="kw">constexpr</span> <span class="op">(</span>std<span class="op">::</span>is_same_v<span class="op">&lt;</span>Triangle, upper_triangle_t<span class="op">&gt;)</span> <span class="op">{</span></span>
-<span id="cb135-16"><a href="#cb135-16" aria-hidden="true" tabindex="-1"></a>    <span class="co">// Solve Ax=b where A = U^T U</span></span>
-<span id="cb135-17"><a href="#cb135-17" aria-hidden="true" tabindex="-1"></a>    <span class="co">//</span></span>
-<span id="cb135-18"><a href="#cb135-18" aria-hidden="true" tabindex="-1"></a>    <span class="co">// Solve U^T c = b, using x to store c.</span></span>
-<span id="cb135-19"><a href="#cb135-19" aria-hidden="true" tabindex="-1"></a>    triangular_matrix_vector_solve<span class="op">(</span>transposed<span class="op">(</span>A<span class="op">)</span>,</span>
-<span id="cb135-20"><a href="#cb135-20" aria-hidden="true" tabindex="-1"></a>      opposite_triangle<span class="op">(</span>t<span class="op">)</span>, explicit_diagonal, b, x<span class="op">)</span>;</span>
-<span id="cb135-21"><a href="#cb135-21" aria-hidden="true" tabindex="-1"></a>    <span class="co">// Solve U x = c, overwriting x with result.</span></span>
-<span id="cb135-22"><a href="#cb135-22" aria-hidden="true" tabindex="-1"></a>    triangular_matrix_vector_solve<span class="op">(</span>A, t, explicit_diagonal, x<span class="op">)</span>;</span>
-<span id="cb135-23"><a href="#cb135-23" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
-<span id="cb135-24"><a href="#cb135-24" aria-hidden="true" tabindex="-1"></a>  <span class="cf">else</span> <span class="op">{</span></span>
-<span id="cb135-25"><a href="#cb135-25" aria-hidden="true" tabindex="-1"></a>    <span class="co">// Solve Ax=b where A = L L^T</span></span>
-<span id="cb135-26"><a href="#cb135-26" aria-hidden="true" tabindex="-1"></a>    <span class="co">//</span></span>
-<span id="cb135-27"><a href="#cb135-27" aria-hidden="true" tabindex="-1"></a>    <span class="co">// Solve L c = b, using x to store c.</span></span>
-<span id="cb135-28"><a href="#cb135-28" aria-hidden="true" tabindex="-1"></a>    triangular_matrix_vector_solve<span class="op">(</span>A, t, explicit_diagonal, b, x<span class="op">)</span>;</span>
-<span id="cb135-29"><a href="#cb135-29" aria-hidden="true" tabindex="-1"></a>    <span class="co">// Solve L^T x = c, overwriting x with result.</span></span>
-<span id="cb135-30"><a href="#cb135-30" aria-hidden="true" tabindex="-1"></a>    triangular_matrix_vector_solve<span class="op">(</span>transposed<span class="op">(</span>A<span class="op">)</span>,</span>
-<span id="cb135-31"><a href="#cb135-31" aria-hidden="true" tabindex="-1"></a>      opposite_triangle<span class="op">(</span>t<span class="op">)</span>, explicit_diagonal, x<span class="op">)</span>;</span>
-<span id="cb135-32"><a href="#cb135-32" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
-<span id="cb135-33"><a href="#cb135-33" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb142"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb142-1"><a href="#cb142-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat,</span>
+<span id="cb142-2"><a href="#cb142-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Triangle,</span>
+<span id="cb142-3"><a href="#cb142-3" aria-hidden="true" tabindex="-1"></a>         <em>in-vector</em> InVec,</span>
+<span id="cb142-4"><a href="#cb142-4" aria-hidden="true" tabindex="-1"></a>         <em>out-vector</em> OutVec<span class="op">&gt;</span></span>
+<span id="cb142-5"><a href="#cb142-5" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> cholesky_solve<span class="op">(</span></span>
+<span id="cb142-6"><a href="#cb142-6" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
+<span id="cb142-7"><a href="#cb142-7" aria-hidden="true" tabindex="-1"></a>  Triangle t,</span>
+<span id="cb142-8"><a href="#cb142-8" aria-hidden="true" tabindex="-1"></a>  InVec b,</span>
+<span id="cb142-9"><a href="#cb142-9" aria-hidden="true" tabindex="-1"></a>  OutVec x<span class="op">)</span></span>
+<span id="cb142-10"><a href="#cb142-10" aria-hidden="true" tabindex="-1"></a><span class="op">{</span></span>
+<span id="cb142-11"><a href="#cb142-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> std<span class="op">::</span>linalg<span class="op">::</span>explicit_diagonal;</span>
+<span id="cb142-12"><a href="#cb142-12" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> std<span class="op">::</span>linalg<span class="op">::</span>transposed;</span>
+<span id="cb142-13"><a href="#cb142-13" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> std<span class="op">::</span>linalg<span class="op">::</span>triangular_matrix_vector_solve;</span>
+<span id="cb142-14"><a href="#cb142-14" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb142-15"><a href="#cb142-15" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="kw">constexpr</span> <span class="op">(</span>std<span class="op">::</span>is_same_v<span class="op">&lt;</span>Triangle, upper_triangle_t<span class="op">&gt;)</span> <span class="op">{</span></span>
+<span id="cb142-16"><a href="#cb142-16" aria-hidden="true" tabindex="-1"></a>    <span class="co">// Solve Ax=b where A = U^T U</span></span>
+<span id="cb142-17"><a href="#cb142-17" aria-hidden="true" tabindex="-1"></a>    <span class="co">//</span></span>
+<span id="cb142-18"><a href="#cb142-18" aria-hidden="true" tabindex="-1"></a>    <span class="co">// Solve U^T c = b, using x to store c.</span></span>
+<span id="cb142-19"><a href="#cb142-19" aria-hidden="true" tabindex="-1"></a>    triangular_matrix_vector_solve<span class="op">(</span>transposed<span class="op">(</span>A<span class="op">)</span>,</span>
+<span id="cb142-20"><a href="#cb142-20" aria-hidden="true" tabindex="-1"></a>      opposite_triangle<span class="op">(</span>t<span class="op">)</span>, explicit_diagonal, b, x<span class="op">)</span>;</span>
+<span id="cb142-21"><a href="#cb142-21" aria-hidden="true" tabindex="-1"></a>    <span class="co">// Solve U x = c, overwriting x with result.</span></span>
+<span id="cb142-22"><a href="#cb142-22" aria-hidden="true" tabindex="-1"></a>    triangular_matrix_vector_solve<span class="op">(</span>A, t, explicit_diagonal, x<span class="op">)</span>;</span>
+<span id="cb142-23"><a href="#cb142-23" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb142-24"><a href="#cb142-24" aria-hidden="true" tabindex="-1"></a>  <span class="cf">else</span> <span class="op">{</span></span>
+<span id="cb142-25"><a href="#cb142-25" aria-hidden="true" tabindex="-1"></a>    <span class="co">// Solve Ax=b where A = L L^T</span></span>
+<span id="cb142-26"><a href="#cb142-26" aria-hidden="true" tabindex="-1"></a>    <span class="co">//</span></span>
+<span id="cb142-27"><a href="#cb142-27" aria-hidden="true" tabindex="-1"></a>    <span class="co">// Solve L c = b, using x to store c.</span></span>
+<span id="cb142-28"><a href="#cb142-28" aria-hidden="true" tabindex="-1"></a>    triangular_matrix_vector_solve<span class="op">(</span>A, t, explicit_diagonal, b, x<span class="op">)</span>;</span>
+<span id="cb142-29"><a href="#cb142-29" aria-hidden="true" tabindex="-1"></a>    <span class="co">// Solve L^T x = c, overwriting x with result.</span></span>
+<span id="cb142-30"><a href="#cb142-30" aria-hidden="true" tabindex="-1"></a>    triangular_matrix_vector_solve<span class="op">(</span>transposed<span class="op">(</span>A<span class="op">)</span>,</span>
+<span id="cb142-31"><a href="#cb142-31" aria-hidden="true" tabindex="-1"></a>      opposite_triangle<span class="op">(</span>t<span class="op">)</span>, explicit_diagonal, x<span class="op">)</span>;</span>
+<span id="cb142-32"><a href="#cb142-32" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb142-33"><a href="#cb142-33" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <h2 data-number="29.3" id="compute-qr-factorization-of-a-tall-skinny-matrix"><span class="header-section-number">29.3</span> Compute QR factorization of a
 tall skinny matrix<a href="#compute-qr-factorization-of-a-tall-skinny-matrix" class="self-link"></a></h2>
 <p><span class="marginalizedparent"><a class="marginalized">1</a></span>
@@ -10908,100 +11090,100 @@ This example shows how to compute the QR factorization of a “tall and
 skinny” matrix <code>V</code>, using a cache-blocked algorithm based on
 rank-k symmetric matrix update and Cholesky factorization. “Tall and
 skinny” means that the matrix has many more rows than columns.</p>
-<div class="sourceCode" id="cb136"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb136-1"><a href="#cb136-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Compute QR factorization A = Q R, with A storing Q.</span></span>
-<span id="cb136-2"><a href="#cb136-2" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>inout-matrix</em> InOutMat,</span>
-<span id="cb136-3"><a href="#cb136-3" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
-<span id="cb136-4"><a href="#cb136-4" aria-hidden="true" tabindex="-1"></a>std<span class="op">::</span>optional<span class="op">&lt;</span><span class="kw">typename</span> InOutMat<span class="op">::</span>size_type<span class="op">&gt;</span></span>
-<span id="cb136-5"><a href="#cb136-5" aria-hidden="true" tabindex="-1"></a>cholesky_tsqr_one_step<span class="op">(</span></span>
-<span id="cb136-6"><a href="#cb136-6" aria-hidden="true" tabindex="-1"></a>  InOutMat A, <span class="co">// A on input, Q on output</span></span>
-<span id="cb136-7"><a href="#cb136-7" aria-hidden="true" tabindex="-1"></a>  OutMat R<span class="op">)</span></span>
-<span id="cb136-8"><a href="#cb136-8" aria-hidden="true" tabindex="-1"></a><span class="op">{</span></span>
-<span id="cb136-9"><a href="#cb136-9" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> std<span class="op">::</span>full_extent;</span>
-<span id="cb136-10"><a href="#cb136-10" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> std<span class="op">::</span>submdspan;</span>
-<span id="cb136-11"><a href="#cb136-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> std<span class="op">::</span>tuple;</span>
-<span id="cb136-12"><a href="#cb136-12" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> size_type <span class="op">=</span> <span class="kw">typename</span> InOutMat<span class="op">::</span>size_type;</span>
-<span id="cb136-13"><a href="#cb136-13" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb136-14"><a href="#cb136-14" aria-hidden="true" tabindex="-1"></a>  <span class="co">// One might use cache size, sizeof(element_type), and A.extent(1)</span></span>
-<span id="cb136-15"><a href="#cb136-15" aria-hidden="true" tabindex="-1"></a>  <span class="co">// to pick the number of rows per block.  For now, we just pick</span></span>
-<span id="cb136-16"><a href="#cb136-16" aria-hidden="true" tabindex="-1"></a>  <span class="co">// some constant.</span></span>
-<span id="cb136-17"><a href="#cb136-17" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> size_type max_num_rows_per_block <span class="op">=</span> <span class="dv">500</span>;</span>
-<span id="cb136-18"><a href="#cb136-18" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb136-19"><a href="#cb136-19" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> R_value_type <span class="op">=</span> <span class="kw">typename</span> OutMat<span class="op">::</span>value_type;</span>
-<span id="cb136-20"><a href="#cb136-20" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> R_element_type ZERO <span class="op">{}</span>;</span>
-<span id="cb136-21"><a href="#cb136-21" aria-hidden="true" tabindex="-1"></a>  <span class="cf">for</span><span class="op">(</span>size_type j <span class="op">=</span> <span class="dv">0</span>; j <span class="op">&lt;</span> R<span class="op">.</span>extent<span class="op">(</span><span class="dv">1</span><span class="op">)</span>; <span class="op">++</span>j<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb136-22"><a href="#cb136-22" aria-hidden="true" tabindex="-1"></a>    <span class="cf">for</span><span class="op">(</span>size_type i <span class="op">=</span> <span class="dv">0</span>; i <span class="op">&lt;</span> R<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span>; <span class="op">++</span>i<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb136-23"><a href="#cb136-23" aria-hidden="true" tabindex="-1"></a>      R<span class="op">[</span>i,j<span class="op">]</span> <span class="op">=</span> ZERO;</span>
-<span id="cb136-24"><a href="#cb136-24" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
-<span id="cb136-25"><a href="#cb136-25" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
-<span id="cb136-26"><a href="#cb136-26" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb136-27"><a href="#cb136-27" aria-hidden="true" tabindex="-1"></a>  <span class="co">// Cache-blocked version of R = R + A^T * A.</span></span>
-<span id="cb136-28"><a href="#cb136-28" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> <span class="kw">auto</span> num_rows <span class="op">=</span> A<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span>;</span>
-<span id="cb136-29"><a href="#cb136-29" aria-hidden="true" tabindex="-1"></a>  <span class="kw">auto</span> rest_num_rows <span class="op">=</span> num_rows;</span>
-<span id="cb136-30"><a href="#cb136-30" aria-hidden="true" tabindex="-1"></a>  <span class="kw">auto</span> A_rest <span class="op">=</span> A;</span>
-<span id="cb136-31"><a href="#cb136-31" aria-hidden="true" tabindex="-1"></a>  <span class="cf">while</span><span class="op">(</span>A_rest<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">&gt;</span> <span class="dv">0</span><span class="op">)</span> <span class="op">{</span></span>
-<span id="cb136-32"><a href="#cb136-32" aria-hidden="true" tabindex="-1"></a>    <span class="kw">const</span> size_type num_rows_per_block <span class="op">=</span></span>
-<span id="cb136-33"><a href="#cb136-33" aria-hidden="true" tabindex="-1"></a>      std<span class="op">::</span>min<span class="op">(</span>A<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span>, max_num_rows_per_block<span class="op">)</span>;</span>
-<span id="cb136-34"><a href="#cb136-34" aria-hidden="true" tabindex="-1"></a>    <span class="kw">auto</span> A_cur <span class="op">=</span> submdspan<span class="op">(</span>A_rest,</span>
-<span id="cb136-35"><a href="#cb136-35" aria-hidden="true" tabindex="-1"></a>      tuple<span class="op">{</span><span class="dv">0</span>, num_rows_per_block<span class="op">}</span>,</span>
-<span id="cb136-36"><a href="#cb136-36" aria-hidden="true" tabindex="-1"></a>      full_extent<span class="op">)</span>;</span>
-<span id="cb136-37"><a href="#cb136-37" aria-hidden="true" tabindex="-1"></a>    A_rest <span class="op">=</span> submdspan<span class="op">(</span>A_rest,</span>
-<span id="cb136-38"><a href="#cb136-38" aria-hidden="true" tabindex="-1"></a>      tuple<span class="op">{</span>num_rows_per_block, A_rest<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)}</span>,</span>
-<span id="cb136-39"><a href="#cb136-39" aria-hidden="true" tabindex="-1"></a>      full_extent<span class="op">)</span>;</span>
-<span id="cb136-40"><a href="#cb136-40" aria-hidden="true" tabindex="-1"></a>    <span class="co">// R = R + A_cur^T * A_cur</span></span>
-<span id="cb136-41"><a href="#cb136-41" aria-hidden="true" tabindex="-1"></a>    <span class="kw">using</span> std<span class="op">::</span>linalg<span class="op">::</span>symmetric_matrix_rank_k_update;</span>
-<span id="cb136-42"><a href="#cb136-42" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> R_element_type ONE<span class="op">(</span><span class="fl">1.0</span><span class="op">)</span>;</span>
-<span id="cb136-43"><a href="#cb136-43" aria-hidden="true" tabindex="-1"></a>    <span class="co">// The Triangle argument applies to R,</span></span>
-<span id="cb136-44"><a href="#cb136-44" aria-hidden="true" tabindex="-1"></a>    <span class="co">// not transposed(A_cur), so we don&#39;t flip it.</span></span>
-<span id="cb136-45"><a href="#cb136-45" aria-hidden="true" tabindex="-1"></a>    symmetric_matrix_rank_k_update<span class="op">(</span>ONE,</span>
-<span id="cb136-46"><a href="#cb136-46" aria-hidden="true" tabindex="-1"></a>      std<span class="op">::</span>linalg<span class="op">::</span>transposed<span class="op">(</span>A_cur<span class="op">)</span>,</span>
-<span id="cb136-47"><a href="#cb136-47" aria-hidden="true" tabindex="-1"></a>      R, upper_triangle<span class="op">)</span>;</span>
-<span id="cb136-48"><a href="#cb136-48" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
-<span id="cb136-49"><a href="#cb136-49" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb136-50"><a href="#cb136-50" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> <span class="kw">auto</span> info <span class="op">=</span> cholesky_factor<span class="op">(</span>R, upper_triangle<span class="op">)</span>;</span>
-<span id="cb136-51"><a href="#cb136-51" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span><span class="op">(</span>info<span class="op">.</span>has_value<span class="op">())</span> <span class="op">{</span></span>
-<span id="cb136-52"><a href="#cb136-52" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> info;</span>
-<span id="cb136-53"><a href="#cb136-53" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
-<span id="cb136-54"><a href="#cb136-54" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> std<span class="op">::</span>linalg<span class="op">::</span>triangular_matrix_matrix_left_solve;</span>
-<span id="cb136-55"><a href="#cb136-55" aria-hidden="true" tabindex="-1"></a>  triangular_matrix_matrix_left_solve<span class="op">(</span>R, upper_triangle, A<span class="op">)</span>;</span>
-<span id="cb136-56"><a href="#cb136-56" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> std<span class="op">::</span>nullopt;</span>
-<span id="cb136-57"><a href="#cb136-57" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
-<span id="cb136-58"><a href="#cb136-58" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb136-59"><a href="#cb136-59" aria-hidden="true" tabindex="-1"></a><span class="co">// Compute QR factorization A = Q R.</span></span>
-<span id="cb136-60"><a href="#cb136-60" aria-hidden="true" tabindex="-1"></a><span class="co">// Use R_tmp as temporary R factor storage</span></span>
-<span id="cb136-61"><a href="#cb136-61" aria-hidden="true" tabindex="-1"></a><span class="co">// for iterative refinement.</span></span>
-<span id="cb136-62"><a href="#cb136-62" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat,</span>
-<span id="cb136-63"><a href="#cb136-63" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat1,</span>
-<span id="cb136-64"><a href="#cb136-64" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat2,</span>
-<span id="cb136-65"><a href="#cb136-65" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat3<span class="op">&gt;</span></span>
-<span id="cb136-66"><a href="#cb136-66" aria-hidden="true" tabindex="-1"></a>std<span class="op">::</span>optional<span class="op">&lt;</span><span class="kw">typename</span> OutMat1<span class="op">::</span>size_type<span class="op">&gt;</span></span>
-<span id="cb136-67"><a href="#cb136-67" aria-hidden="true" tabindex="-1"></a>cholesky_tsqr<span class="op">(</span></span>
-<span id="cb136-68"><a href="#cb136-68" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
-<span id="cb136-69"><a href="#cb136-69" aria-hidden="true" tabindex="-1"></a>  OutMat1 Q,</span>
-<span id="cb136-70"><a href="#cb136-70" aria-hidden="true" tabindex="-1"></a>  OutMat2 R_tmp,</span>
-<span id="cb136-71"><a href="#cb136-71" aria-hidden="true" tabindex="-1"></a>  OutMat3 R<span class="op">)</span></span>
-<span id="cb136-72"><a href="#cb136-72" aria-hidden="true" tabindex="-1"></a><span class="op">{</span></span>
-<span id="cb136-73"><a href="#cb136-73" aria-hidden="true" tabindex="-1"></a>  <span class="ot">assert</span><span class="op">(</span>R<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">==</span> R<span class="op">.</span>extent<span class="op">(</span><span class="dv">1</span><span class="op">))</span>;</span>
-<span id="cb136-74"><a href="#cb136-74" aria-hidden="true" tabindex="-1"></a>  <span class="ot">assert</span><span class="op">(</span>A<span class="op">.</span>extent<span class="op">(</span><span class="dv">1</span><span class="op">)</span> <span class="op">==</span> R<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">))</span>;</span>
-<span id="cb136-75"><a href="#cb136-75" aria-hidden="true" tabindex="-1"></a>  <span class="ot">assert</span><span class="op">(</span>R_tmp<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">==</span> R_tmp<span class="op">.</span>extent<span class="op">(</span><span class="dv">1</span><span class="op">))</span>;</span>
-<span id="cb136-76"><a href="#cb136-76" aria-hidden="true" tabindex="-1"></a>  <span class="ot">assert</span><span class="op">(</span>A<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">==</span> Q<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">))</span>;</span>
-<span id="cb136-77"><a href="#cb136-77" aria-hidden="true" tabindex="-1"></a>  <span class="ot">assert</span><span class="op">(</span>A<span class="op">.</span>extent<span class="op">(</span><span class="dv">1</span><span class="op">)</span> <span class="op">==</span> Q<span class="op">.</span>extent<span class="op">(</span><span class="dv">1</span><span class="op">))</span>;</span>
-<span id="cb136-78"><a href="#cb136-78" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb136-79"><a href="#cb136-79" aria-hidden="true" tabindex="-1"></a>  std<span class="op">::</span>linalg<span class="op">::</span>copy<span class="op">(</span>A, Q<span class="op">)</span>;</span>
-<span id="cb136-80"><a href="#cb136-80" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> <span class="kw">auto</span> info1 <span class="op">=</span> cholesky_tsqr_one_step<span class="op">(</span>Q, R<span class="op">)</span>;</span>
-<span id="cb136-81"><a href="#cb136-81" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span><span class="op">(</span>info1<span class="op">.</span>has_value<span class="op">())</span> <span class="op">{</span></span>
-<span id="cb136-82"><a href="#cb136-82" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> info1;</span>
-<span id="cb136-83"><a href="#cb136-83" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
-<span id="cb136-84"><a href="#cb136-84" aria-hidden="true" tabindex="-1"></a>  <span class="co">// Use one step of iterative refinement to improve accuracy.</span></span>
-<span id="cb136-85"><a href="#cb136-85" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> <span class="kw">auto</span> info2 <span class="op">=</span> cholesky_tsqr_one_step<span class="op">(</span>Q, R_tmp<span class="op">)</span>;</span>
-<span id="cb136-86"><a href="#cb136-86" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span><span class="op">(</span>info2<span class="op">.</span>has_value<span class="op">())</span> <span class="op">{</span></span>
-<span id="cb136-87"><a href="#cb136-87" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> info2;</span>
-<span id="cb136-88"><a href="#cb136-88" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
-<span id="cb136-89"><a href="#cb136-89" aria-hidden="true" tabindex="-1"></a>  <span class="co">// R = R_tmp * R</span></span>
-<span id="cb136-90"><a href="#cb136-90" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> std<span class="op">::</span>linalg<span class="op">::</span>triangular_matrix_product;</span>
-<span id="cb136-91"><a href="#cb136-91" aria-hidden="true" tabindex="-1"></a>  triangular_matrix_product<span class="op">(</span>R_tmp, upper_triangle,</span>
-<span id="cb136-92"><a href="#cb136-92" aria-hidden="true" tabindex="-1"></a>                            explicit_diagonal, R<span class="op">)</span>;</span>
-<span id="cb136-93"><a href="#cb136-93" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> std<span class="op">::</span>nullopt;</span>
-<span id="cb136-94"><a href="#cb136-94" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb143"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb143-1"><a href="#cb143-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Compute QR factorization A = Q R, with A storing Q.</span></span>
+<span id="cb143-2"><a href="#cb143-2" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>inout-matrix</em> InOutMat,</span>
+<span id="cb143-3"><a href="#cb143-3" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat<span class="op">&gt;</span></span>
+<span id="cb143-4"><a href="#cb143-4" aria-hidden="true" tabindex="-1"></a>std<span class="op">::</span>optional<span class="op">&lt;</span><span class="kw">typename</span> InOutMat<span class="op">::</span>size_type<span class="op">&gt;</span></span>
+<span id="cb143-5"><a href="#cb143-5" aria-hidden="true" tabindex="-1"></a>cholesky_tsqr_one_step<span class="op">(</span></span>
+<span id="cb143-6"><a href="#cb143-6" aria-hidden="true" tabindex="-1"></a>  InOutMat A, <span class="co">// A on input, Q on output</span></span>
+<span id="cb143-7"><a href="#cb143-7" aria-hidden="true" tabindex="-1"></a>  OutMat R<span class="op">)</span></span>
+<span id="cb143-8"><a href="#cb143-8" aria-hidden="true" tabindex="-1"></a><span class="op">{</span></span>
+<span id="cb143-9"><a href="#cb143-9" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> std<span class="op">::</span>full_extent;</span>
+<span id="cb143-10"><a href="#cb143-10" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> std<span class="op">::</span>submdspan;</span>
+<span id="cb143-11"><a href="#cb143-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> std<span class="op">::</span>tuple;</span>
+<span id="cb143-12"><a href="#cb143-12" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> size_type <span class="op">=</span> <span class="kw">typename</span> InOutMat<span class="op">::</span>size_type;</span>
+<span id="cb143-13"><a href="#cb143-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb143-14"><a href="#cb143-14" aria-hidden="true" tabindex="-1"></a>  <span class="co">// One might use cache size, sizeof(element_type), and A.extent(1)</span></span>
+<span id="cb143-15"><a href="#cb143-15" aria-hidden="true" tabindex="-1"></a>  <span class="co">// to pick the number of rows per block.  For now, we just pick</span></span>
+<span id="cb143-16"><a href="#cb143-16" aria-hidden="true" tabindex="-1"></a>  <span class="co">// some constant.</span></span>
+<span id="cb143-17"><a href="#cb143-17" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> size_type max_num_rows_per_block <span class="op">=</span> <span class="dv">500</span>;</span>
+<span id="cb143-18"><a href="#cb143-18" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb143-19"><a href="#cb143-19" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> R_value_type <span class="op">=</span> <span class="kw">typename</span> OutMat<span class="op">::</span>value_type;</span>
+<span id="cb143-20"><a href="#cb143-20" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> R_element_type ZERO <span class="op">{}</span>;</span>
+<span id="cb143-21"><a href="#cb143-21" aria-hidden="true" tabindex="-1"></a>  <span class="cf">for</span><span class="op">(</span>size_type j <span class="op">=</span> <span class="dv">0</span>; j <span class="op">&lt;</span> R<span class="op">.</span>extent<span class="op">(</span><span class="dv">1</span><span class="op">)</span>; <span class="op">++</span>j<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb143-22"><a href="#cb143-22" aria-hidden="true" tabindex="-1"></a>    <span class="cf">for</span><span class="op">(</span>size_type i <span class="op">=</span> <span class="dv">0</span>; i <span class="op">&lt;</span> R<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span>; <span class="op">++</span>i<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb143-23"><a href="#cb143-23" aria-hidden="true" tabindex="-1"></a>      R<span class="op">[</span>i,j<span class="op">]</span> <span class="op">=</span> ZERO;</span>
+<span id="cb143-24"><a href="#cb143-24" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb143-25"><a href="#cb143-25" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb143-26"><a href="#cb143-26" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb143-27"><a href="#cb143-27" aria-hidden="true" tabindex="-1"></a>  <span class="co">// Cache-blocked version of R = R + A^T * A.</span></span>
+<span id="cb143-28"><a href="#cb143-28" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> <span class="kw">auto</span> num_rows <span class="op">=</span> A<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span>;</span>
+<span id="cb143-29"><a href="#cb143-29" aria-hidden="true" tabindex="-1"></a>  <span class="kw">auto</span> rest_num_rows <span class="op">=</span> num_rows;</span>
+<span id="cb143-30"><a href="#cb143-30" aria-hidden="true" tabindex="-1"></a>  <span class="kw">auto</span> A_rest <span class="op">=</span> A;</span>
+<span id="cb143-31"><a href="#cb143-31" aria-hidden="true" tabindex="-1"></a>  <span class="cf">while</span><span class="op">(</span>A_rest<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">&gt;</span> <span class="dv">0</span><span class="op">)</span> <span class="op">{</span></span>
+<span id="cb143-32"><a href="#cb143-32" aria-hidden="true" tabindex="-1"></a>    <span class="kw">const</span> size_type num_rows_per_block <span class="op">=</span></span>
+<span id="cb143-33"><a href="#cb143-33" aria-hidden="true" tabindex="-1"></a>      std<span class="op">::</span>min<span class="op">(</span>A<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span>, max_num_rows_per_block<span class="op">)</span>;</span>
+<span id="cb143-34"><a href="#cb143-34" aria-hidden="true" tabindex="-1"></a>    <span class="kw">auto</span> A_cur <span class="op">=</span> submdspan<span class="op">(</span>A_rest,</span>
+<span id="cb143-35"><a href="#cb143-35" aria-hidden="true" tabindex="-1"></a>      tuple<span class="op">{</span><span class="dv">0</span>, num_rows_per_block<span class="op">}</span>,</span>
+<span id="cb143-36"><a href="#cb143-36" aria-hidden="true" tabindex="-1"></a>      full_extent<span class="op">)</span>;</span>
+<span id="cb143-37"><a href="#cb143-37" aria-hidden="true" tabindex="-1"></a>    A_rest <span class="op">=</span> submdspan<span class="op">(</span>A_rest,</span>
+<span id="cb143-38"><a href="#cb143-38" aria-hidden="true" tabindex="-1"></a>      tuple<span class="op">{</span>num_rows_per_block, A_rest<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)}</span>,</span>
+<span id="cb143-39"><a href="#cb143-39" aria-hidden="true" tabindex="-1"></a>      full_extent<span class="op">)</span>;</span>
+<span id="cb143-40"><a href="#cb143-40" aria-hidden="true" tabindex="-1"></a>    <span class="co">// R = R + A_cur^T * A_cur</span></span>
+<span id="cb143-41"><a href="#cb143-41" aria-hidden="true" tabindex="-1"></a>    <span class="kw">using</span> std<span class="op">::</span>linalg<span class="op">::</span>symmetric_matrix_rank_k_update;</span>
+<span id="cb143-42"><a href="#cb143-42" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> R_element_type ONE<span class="op">(</span><span class="fl">1.0</span><span class="op">)</span>;</span>
+<span id="cb143-43"><a href="#cb143-43" aria-hidden="true" tabindex="-1"></a>    <span class="co">// The Triangle argument applies to R,</span></span>
+<span id="cb143-44"><a href="#cb143-44" aria-hidden="true" tabindex="-1"></a>    <span class="co">// not transposed(A_cur), so we don&#39;t flip it.</span></span>
+<span id="cb143-45"><a href="#cb143-45" aria-hidden="true" tabindex="-1"></a>    symmetric_matrix_rank_k_update<span class="op">(</span>ONE,</span>
+<span id="cb143-46"><a href="#cb143-46" aria-hidden="true" tabindex="-1"></a>      std<span class="op">::</span>linalg<span class="op">::</span>transposed<span class="op">(</span>A_cur<span class="op">)</span>,</span>
+<span id="cb143-47"><a href="#cb143-47" aria-hidden="true" tabindex="-1"></a>      R, upper_triangle<span class="op">)</span>;</span>
+<span id="cb143-48"><a href="#cb143-48" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb143-49"><a href="#cb143-49" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb143-50"><a href="#cb143-50" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> <span class="kw">auto</span> info <span class="op">=</span> cholesky_factor<span class="op">(</span>R, upper_triangle<span class="op">)</span>;</span>
+<span id="cb143-51"><a href="#cb143-51" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span><span class="op">(</span>info<span class="op">.</span>has_value<span class="op">())</span> <span class="op">{</span></span>
+<span id="cb143-52"><a href="#cb143-52" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> info;</span>
+<span id="cb143-53"><a href="#cb143-53" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb143-54"><a href="#cb143-54" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> std<span class="op">::</span>linalg<span class="op">::</span>triangular_matrix_matrix_left_solve;</span>
+<span id="cb143-55"><a href="#cb143-55" aria-hidden="true" tabindex="-1"></a>  triangular_matrix_matrix_left_solve<span class="op">(</span>R, upper_triangle, A<span class="op">)</span>;</span>
+<span id="cb143-56"><a href="#cb143-56" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> std<span class="op">::</span>nullopt;</span>
+<span id="cb143-57"><a href="#cb143-57" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
+<span id="cb143-58"><a href="#cb143-58" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb143-59"><a href="#cb143-59" aria-hidden="true" tabindex="-1"></a><span class="co">// Compute QR factorization A = Q R.</span></span>
+<span id="cb143-60"><a href="#cb143-60" aria-hidden="true" tabindex="-1"></a><span class="co">// Use R_tmp as temporary R factor storage</span></span>
+<span id="cb143-61"><a href="#cb143-61" aria-hidden="true" tabindex="-1"></a><span class="co">// for iterative refinement.</span></span>
+<span id="cb143-62"><a href="#cb143-62" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><em>in-matrix</em> InMat,</span>
+<span id="cb143-63"><a href="#cb143-63" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat1,</span>
+<span id="cb143-64"><a href="#cb143-64" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat2,</span>
+<span id="cb143-65"><a href="#cb143-65" aria-hidden="true" tabindex="-1"></a>         <em>out-matrix</em> OutMat3<span class="op">&gt;</span></span>
+<span id="cb143-66"><a href="#cb143-66" aria-hidden="true" tabindex="-1"></a>std<span class="op">::</span>optional<span class="op">&lt;</span><span class="kw">typename</span> OutMat1<span class="op">::</span>size_type<span class="op">&gt;</span></span>
+<span id="cb143-67"><a href="#cb143-67" aria-hidden="true" tabindex="-1"></a>cholesky_tsqr<span class="op">(</span></span>
+<span id="cb143-68"><a href="#cb143-68" aria-hidden="true" tabindex="-1"></a>  InMat A,</span>
+<span id="cb143-69"><a href="#cb143-69" aria-hidden="true" tabindex="-1"></a>  OutMat1 Q,</span>
+<span id="cb143-70"><a href="#cb143-70" aria-hidden="true" tabindex="-1"></a>  OutMat2 R_tmp,</span>
+<span id="cb143-71"><a href="#cb143-71" aria-hidden="true" tabindex="-1"></a>  OutMat3 R<span class="op">)</span></span>
+<span id="cb143-72"><a href="#cb143-72" aria-hidden="true" tabindex="-1"></a><span class="op">{</span></span>
+<span id="cb143-73"><a href="#cb143-73" aria-hidden="true" tabindex="-1"></a>  <span class="ot">assert</span><span class="op">(</span>R<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">==</span> R<span class="op">.</span>extent<span class="op">(</span><span class="dv">1</span><span class="op">))</span>;</span>
+<span id="cb143-74"><a href="#cb143-74" aria-hidden="true" tabindex="-1"></a>  <span class="ot">assert</span><span class="op">(</span>A<span class="op">.</span>extent<span class="op">(</span><span class="dv">1</span><span class="op">)</span> <span class="op">==</span> R<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">))</span>;</span>
+<span id="cb143-75"><a href="#cb143-75" aria-hidden="true" tabindex="-1"></a>  <span class="ot">assert</span><span class="op">(</span>R_tmp<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">==</span> R_tmp<span class="op">.</span>extent<span class="op">(</span><span class="dv">1</span><span class="op">))</span>;</span>
+<span id="cb143-76"><a href="#cb143-76" aria-hidden="true" tabindex="-1"></a>  <span class="ot">assert</span><span class="op">(</span>A<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">==</span> Q<span class="op">.</span>extent<span class="op">(</span><span class="dv">0</span><span class="op">))</span>;</span>
+<span id="cb143-77"><a href="#cb143-77" aria-hidden="true" tabindex="-1"></a>  <span class="ot">assert</span><span class="op">(</span>A<span class="op">.</span>extent<span class="op">(</span><span class="dv">1</span><span class="op">)</span> <span class="op">==</span> Q<span class="op">.</span>extent<span class="op">(</span><span class="dv">1</span><span class="op">))</span>;</span>
+<span id="cb143-78"><a href="#cb143-78" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb143-79"><a href="#cb143-79" aria-hidden="true" tabindex="-1"></a>  std<span class="op">::</span>linalg<span class="op">::</span>copy<span class="op">(</span>A, Q<span class="op">)</span>;</span>
+<span id="cb143-80"><a href="#cb143-80" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> <span class="kw">auto</span> info1 <span class="op">=</span> cholesky_tsqr_one_step<span class="op">(</span>Q, R<span class="op">)</span>;</span>
+<span id="cb143-81"><a href="#cb143-81" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span><span class="op">(</span>info1<span class="op">.</span>has_value<span class="op">())</span> <span class="op">{</span></span>
+<span id="cb143-82"><a href="#cb143-82" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> info1;</span>
+<span id="cb143-83"><a href="#cb143-83" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb143-84"><a href="#cb143-84" aria-hidden="true" tabindex="-1"></a>  <span class="co">// Use one step of iterative refinement to improve accuracy.</span></span>
+<span id="cb143-85"><a href="#cb143-85" aria-hidden="true" tabindex="-1"></a>  <span class="kw">const</span> <span class="kw">auto</span> info2 <span class="op">=</span> cholesky_tsqr_one_step<span class="op">(</span>Q, R_tmp<span class="op">)</span>;</span>
+<span id="cb143-86"><a href="#cb143-86" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span><span class="op">(</span>info2<span class="op">.</span>has_value<span class="op">())</span> <span class="op">{</span></span>
+<span id="cb143-87"><a href="#cb143-87" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> info2;</span>
+<span id="cb143-88"><a href="#cb143-88" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb143-89"><a href="#cb143-89" aria-hidden="true" tabindex="-1"></a>  <span class="co">// R = R_tmp * R</span></span>
+<span id="cb143-90"><a href="#cb143-90" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> std<span class="op">::</span>linalg<span class="op">::</span>triangular_matrix_product;</span>
+<span id="cb143-91"><a href="#cb143-91" aria-hidden="true" tabindex="-1"></a>  triangular_matrix_product<span class="op">(</span>R_tmp, upper_triangle,</span>
+<span id="cb143-92"><a href="#cb143-92" aria-hidden="true" tabindex="-1"></a>                            explicit_diagonal, R<span class="op">)</span>;</span>
+<span id="cb143-93"><a href="#cb143-93" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> std<span class="op">::</span>nullopt;</span>
+<span id="cb143-94"><a href="#cb143-94" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 </div>
 </div>
 </body>

--- a/D1673/P1673.md
+++ b/D1673/P1673.md
@@ -719,6 +719,13 @@ toc: true
 
     * fix numbering via dummy sections
 
+    * Define what it means for two mdspan to "overlap" each other.
+        Replace "shall view a disjoint set of elements of"
+        wording (was [linalg.concepts] 3 in R12) with "shall not overlap."
+        "Alias" retains its R12 meaning
+        (view the same elements in the same order).
+        This lets us retain existing use of "alias" in describing algorithms.
+
 # Purpose of this paper
 
 This paper proposes a C++ Standard Library dense linear algebra
@@ -5777,7 +5784,22 @@ any calls to `abs`, `conj`, `imag`, and `real` are unqualified.
 
 [6]{.pnum} Two `mdspan` `x` and `y`
 *alias* each other,
-if there exist packs of integers `i` and `j` which are multidimensional indices into `e`, such that `x[i...]` and `y[j...]` refer to the same element.
+if they have the same extents `e`,
+and for any pack of integers `i` which is a multidimensional index in `e`,
+`x[i...]` and `y[i...]` refer to the same element.
+<i>[Note:</i>
+This means that the two `mdspan` view the same elements in the same order.
+<i>-- end note]</i>
+
+[7]{.pnum} Two `mdspan` `x` and `y`
+*overlap* each other,
+if for some pack of integers `i` that is a multidimensional index in `x.extents()`,
+there exists a pack of integers `j` that is a multidimensional index in `y.extents()`,
+such that `x[i...]` and `y[j...]` refer to the same element.
+<i>[Note:</i>
+Aliasing is a special case of overlapping.
+Two `mdspan` that do not overlap also do not alias each other.
+<i>-- end note]</i>
 
 ### Requirements [linalg.reqs]
 
@@ -6380,8 +6402,8 @@ it will do so in read-only fashion.
 any _`inout-vector`_, _`inout-matrix`_, _`inout-object`_,
 _`out-vector`_, _`out-matrix`_, or _`out-object`_
 parameter of a function in *[linalg.algs]*
-shall view a disjoint set of elements
-of any other `mdspan` parameter of the function.
+shall not overlap
+any other `mdspan` parameter of the function.
 
 #### Helpers for algorithm mandates [linalg.helpers.mandates]
 


### PR DESCRIPTION
This implements changes discussed in LWG 2023/09/20, and resolved via later e-mail list discussion.

Define what it means for two mdspan to "overlap" each other.  Replace "shall view a disjoint set of elements of" wording (was [linalg.concepts] 3 in R12) with "shall not overlap." "Alias" retains its R12 meaning (view the same elements in the same order).  This lets us retain existing use of "alias" in describing algorithms.