### PR TITLE
minor fixes for mdarray

### DIFF
--- a/P0009/wg21/data/index.yaml
+++ b/P0009/wg21/data/index.yaml
@@ -83180,7 +83180,14 @@ references:
       - family: H. Carter Edwards, Bryce Adelstein Lelbach, Daniel Sunderland, David Hollman, Christian Trott, Mauro Bianco, Ben Sander, Athanasios Iliopoulos, John Michopoulos, Mark Hoemmen
     issued:
       year: 2019
-    URL: https://wg21.link/p0009r9
+  - id: P0009R18
+    citation-label: P0009R18
+    title: "mdspan"
+    author:
+      - family: Christian Trott, D.S. Hollman, Damien Lebrun-Grandie, Mark Hoemmen, Daniel Sunderland, H. Carter Edwards, Bryce Adelstein Lelbach, Mauro Bianco, Ben Sander, Athanasios Iliopoulos, John Michopoulos, Nevin Liber
+    issued:
+      year: 2022
+    URL: https://wg21.link/p0009r18
   - id: P0010R0
     citation-label: P0010R0
     title: "Adding a subsection for concurrent random number generation in C++17"

--- a/P1684-mdarray/P1684.html
+++ b/P1684-mdarray/P1684.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="generator" content="mpark/wg21" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <meta name="dcterms.date" content="2023-05-19" />
+  <meta name="dcterms.date" content="2024-02-27" />
   <title>mdarray: An Owning Multidimensional Array Analog of mdspan</title>
   <style>
 code{white-space: pre-wrap;}
@@ -79,7 +79,7 @@ code span.va { }
 code span.vs { color: #9f6807; } 
 code span.wa { color: #008000; font-weight: bold; } 
 code.diff {color: #898887}
-code.diff span.va {color: #6.0e28}
+code.diff span.va {color: #00AA00}
 code.diff span.st {color: #bf0303}
 </style>
   <style type="text/css">
@@ -406,7 +406,7 @@ code.sourceCode > span { display: inline; }
 
 div#refs p { padding-left: 32px; text-indent: -32px; }
 </style>
-  <link href="data:text/html; charset=utf-8;charset=utf-8,%3Chtml%3E%0A%3Chead%3E%0A%3Ctitle%3EBIG%2DIP%20Per%20Request%20Policy%20Resource%20blocked%20page%3C%2Ftitle%3E%0A%3Cstyle%3E%0Abody%2C%20html%20%7B%0A%20%20%20%20padding%3A%200%3B%0A%20%20%20%20margin%3A%200%3B%0A%20%20%20%20height%3A%20100%25%3B%0A%7D%0Atable%2C%20td%2C%20th%2C%20div%20%7B%0A%20%20%20%20border%3A%200%3B%0A%20%20%20%20padding%3A%200%3B%0A%20%20%20%20margin%3A%200%3B%0A%7D%0Abody%2C%20table%2C%20td%2C%20th%2C%20div%2C%20input%2C%20h1%2C%20h2%2C%20h3%2C%20h4%2C%20h5%2C%20h6%20%7B%0A%20%20%20%20font%2Dfamily%20%3A%20Calibri%2C%20Tahoma%2C%20Verdana%2C%20Arial%2C%20Helvetica%2C%20Sans%2DSerif%3B%0A%20%20%20%20color%3A%20%23000000%3B%0A%20%20%20%20text%2Dalign%3A%20center%3B%0A%7D%0Abody%2C%20table%2C%20td%2C%20th%2C%20div%2C%20input%20%7B%0A%20%20%20%20font%2Dsize%20%3A%2014px%3B%0A%7D%0Ah1%2C%20h2%2C%20h3%2C%20h4%2C%20h5%2C%20h6%20%7B%0A%20%20%20%20font%2Dsize%20%3A%2018px%3B%0A%20%20%20%20text%2Ddecoration%3A%20none%3B%0A%20%20%20%20margin%2Dbottom%3A%200px%3B%0A%7D%0Abody%0A%7B%0A%20%20%20%20background%2Dcolor%3A%20%23FFFFFF%3B%0A%7D%0Atable%23page%5Fheader%0A%7B%0A%20%20%20%20width%3A%20100%25%3B%0A%20%20%20%20height%3A%2080px%3B%0A%20%20%20%20background%2Dcolor%3A%20%23FFFFFF%3B%0A%20%20%20%20background%2Drepeat%3A%20repeat%2Dx%3B%0A%7D%0Atable%23main%5Ftable%0A%7B%0A%20%20%20%20width%3A100%25%3B%0A%7D%0A%3C%2Fstyle%3E%0A%3C%2Fhead%3E%0A%0A%3Cscript%20language%3D%22javascript%22%3E%0Afunction%20OnLoad%28%29%20%7B%0A%20%20%20%20var%20category%20%3D%20%22Information%20Technology%22%3B%0A%20%20%20%20var%20categoryDiv%20%3D%20document%2EgetElementById%28%27display%5Fcategory%27%29%3B%0A%20%20%20%20if%20%28category%20%3D%3D%3D%20%22%22%29%20%7B%0A%20%20%20%20%20%20%20%20categoryDiv%2Estyle%2Evisibility%20%3D%20%27hidden%27%3B%0A%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20categoryDiv%2Estyle%2Evisibility%20%3D%20%27visible%27%3B%0A%20%20%20%20%20%20%20%20categoryDiv%2EinnerHTML%20%2B%3D%20%27%3Ctd%3E%27%20%2B%20%22The%20category%20reference%20is%3A%22%20%2B%20%27%20%27%20%2B%20category%20%2B%20%27%3C%2Ftd%3E%27%3B%0A%20%20%20%20%7D%0A%7D%0A%3C%2Fscript%3E%0A%3Cbody%20onload%3D%22OnLoad%28%29%3B%22%3E%0A%20%20%20%20%3Ctable%20id%3D%22page%5Fheader%22%3E%0A%20%20%20%20%20%20%20%20%3Ctr%3E%3Ctd%20style%3D%22padding%2Dleft%3A10px%3B%22%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Ch1%3ETransparent%20proxy%20access%20blocked%2E%20%3Cbr%3E%20Please%20verify%20your%20proxy%20setting%20are%20correct%2E%20%3Cbr%3E%20Contact%20CCHD%20if%20you%20need%20assistance%2E%3C%2Fh1%3E%20%20%20%20%20%20%20%20%3C%2Ftd%3E%3C%2Ftr%3E%0A%20%20%20%20%3C%2Ftable%3E%0A%20%20%20%20%3Ctable%20id%3D%27main%5Ftable%27%3E%0A%20%20%20%20%20%20%20%20%3Ctr%20id%3D%27display%5Fcategory%27%3E%3C%2Ftr%3E%0A%20%20%20%20%3C%2Ftable%3E%0A%3C%2Fbody%3E%0A%3C%2Fhtml%3E%0A" rel="icon" />
+  <link href="data:image/vnd.microsoft.icon;base64,AAABAAIAEBAAAAEAIABoBAAAJgAAACAgAAABACAAqBAAAI4EAAAoAAAAEAAAACAAAAABACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA////AIJEAACCRAAAgkQAAIJEAACCRAAAgkQAVoJEAN6CRADegkQAWIJEAACCRAAAgkQAAIJEAACCRAAA////AP///wCCRAAAgkQAAIJEAACCRAAsgkQAvoJEAP+CRAD/gkQA/4JEAP+CRADAgkQALoJEAACCRAAAgkQAAP///wD///8AgkQAAIJEABSCRACSgkQA/IJEAP99PQD/dzMA/3czAP99PQD/gkQA/4JEAPyCRACUgkQAFIJEAAD///8A////AHw+AFiBQwDqgkQA/4BBAP9/PxP/uZd6/9rJtf/bybX/upd7/39AFP+AQQD/gkQA/4FDAOqAQgBc////AP///wDKklv4jlEa/3o7AP+PWC//8+3o///////////////////////z7un/kFox/35AAP+GRwD/mVYA+v///wD///8A0Zpk+NmibP+0d0T/8evj///////+/fv/1sKz/9bCs//9/fr//////+/m2/+NRwL/nloA/5xYAPj///8A////ANKaZPjRmGH/5cKh////////////k149/3UwAP91MQD/lmQ//86rhv+USg3/m1YA/5hSAP+bVgD4////AP///wDSmmT4zpJY/+/bx///////8+TV/8mLT/+TVx//gkIA/5lVAP+VTAD/x6B//7aEVv/JpH7/s39J+P///wD///8A0ppk+M6SWP/u2sf///////Pj1f/Nj1T/2KFs/8mOUv+eWhD/lEsA/8aee/+0glT/x6F7/7J8Rvj///8A////ANKaZPjRmGH/48Cf///////+/v7/2qt//82PVP/OkFX/37KJ/86siv+USg7/mVQA/5hRAP+bVgD4////AP///wDSmmT40ppk/9CVXP/69O////////7+/v/x4M//8d/P//7+/f//////9u7n/6tnJf+XUgD/nFgA+P///wD///8A0ppk+NKaZP/RmWL/1qNy//r07///////////////////////+vXw/9akdP/Wnmn/y5FY/6JfFvj///8A////ANKaZFTSmmTo0ppk/9GYYv/Ql1//5cWm//Hg0P/x4ND/5cWm/9GXYP/RmGH/0ppk/9KaZOjVnmpY////AP///wDSmmQA0ppkEtKaZI7SmmT60ppk/9CWX//OkVb/zpFW/9CWX//SmmT/0ppk/NKaZJDSmmQS0ppkAP///wD///8A0ppkANKaZADSmmQA0ppkKtKaZLrSmmT/0ppk/9KaZP/SmmT/0ppkvNKaZCrSmmQA0ppkANKaZAD///8A////ANKaZADSmmQA0ppkANKaZADSmmQA0ppkUtKaZNzSmmTc0ppkVNKaZADSmmQA0ppkANKaZADSmmQA////AP5/AAD4HwAA4AcAAMADAACAAQAAgAEAAIABAACAAQAAgAEAAIABAACAAQAAgAEAAMADAADgBwAA+B8AAP5/AAAoAAAAIAAAAEAAAAABACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA////AP///wCCRAAAgkQAAIJEAACCRAAAgkQAAIJEAACCRAAAgkQAAIJEAACCRAAAgkQAAIJEAAyCRACMgkQA6oJEAOqCRACQgkQAEIJEAACCRAAAgkQAAIJEAACCRAAAgkQAAIJEAACCRAAAgkQAAIJEAACCRAAA////AP///wD///8A////AIJEAACCRAAAgkQAAIJEAACCRAAAgkQAAIJEAACCRAAAgkQAAIJEAACCRABigkQA5oJEAP+CRAD/gkQA/4JEAP+CRADqgkQAZoJEAACCRAAAgkQAAIJEAACCRAAAgkQAAIJEAACCRAAAgkQAAIJEAAD///8A////AP///wD///8AgkQAAIJEAACCRAAAgkQAAIJEAACCRAAAgkQAAIJEAACCRAA4gkQAwoJEAP+CRAD/gkQA/4JEAP+CRAD/gkQA/4JEAP+CRAD/gkQAxIJEADyCRAAAgkQAAIJEAACCRAAAgkQAAIJEAACCRAAAgkQAAP///wD///8A////AP///wCCRAAAgkQAAIJEAACCRAAAgkQAAIJEAACCRAAWgkQAmIJEAP+CRAD/gkQA/4JEAP+CRAD/gkQA/4JEAP+CRAD/gkQA/4JEAP+CRAD/gkQA/4JEAJyCRAAYgkQAAIJEAACCRAAAgkQAAIJEAACCRAAA////AP///wD///8A////AIJEAACCRAAAgkQAAIJEAACCRAAAgkQAdIJEAPCCRAD/gkQA/4JEAP+CRAD/gkQA/4JEAP+CRAD/gkQA/4JEAP+CRAD/gkQA/4JEAP+CRAD/gkQA/4JEAPSCRAB4gkQAAIJEAACCRAAAgkQAAIJEAAD///8A////AP///wD///8AgkQAAIJEAACCRAAAgkQASoJEANKCRAD/gkQA/4JEAP+CRAD/g0YA/39AAP9zLgD/bSQA/2shAP9rIQD/bSQA/3MuAP9/PwD/g0YA/4JEAP+CRAD/gkQA/4JEAP+CRADUgkQAToJEAACCRAAAgkQAAP///wD///8A////AP///wB+PwAAgkUAIoJEAKiCRAD/gkQA/4JEAP+CRAD/hEcA/4BBAP9sIwD/dTAA/5RfKv+viF7/vp56/76ee/+wiF7/lWAr/3YxAP9sIwD/f0AA/4RHAP+CRAD/gkQA/4JEAP+CRAD/gkQArIJEACaBQwAA////AP///wD///8A////AIBCAEBzNAD6f0EA/4NFAP+CRAD/gkQA/4VIAP92MwD/bSUA/6N1Tv/ezsL/////////////////////////////////38/D/6V3Uv9uJgD/dTEA/4VJAP+CRAD/gkQA/4JEAP+BQwD/fUAA/4FDAEj///8A////AP///wD///8AzJRd5qBlKf91NgD/dDUA/4JEAP+FSQD/cy4A/3YyAP/PuKP//////////////////////////////////////////////////////9K7qP94NQD/ciwA/4VJAP+CRAD/fkEA/35BAP+LSwD/mlYA6v///wD///8A////AP///wDdpnL/4qx3/8KJUv+PUhf/cTMA/3AsAP90LgD/4dK+/////////////////////////////////////////////////////////////////+TYxf91MAD/dTIA/31CAP+GRwD/llQA/6FcAP+gWwD8////AP///wD///8A////ANGZY/LSm2X/4ap3/92mcP+wdT3/byQA/8mwj////////////////////////////////////////////////////////////////////////////+LYxv9zLgP/jUoA/59bAP+hXAD/nFgA/5xYAPL///8A////AP///wD///8A0ppk8tKaZP/RmWL/1p9q/9ubXv/XqXj////////////////////////////7+fD/vZyG/6BxS/+gcUr/vJuE//r37f//////////////////////3MOr/5dQBf+dVQD/nVkA/5xYAP+cWAD/nFgA8v///wD///8A////AP///wDSmmTy0ppk/9KaZP/SmWP/yohJ//jo2P//////////////////////4NTG/4JDFf9lGAD/bSQA/20kAP9kGAD/fz8S/+Xb0f//////5NG9/6txN/+LOgD/m1QA/51aAP+cWAD/m1cA/5xYAP+cWADy////AP///wD///8A////ANKaZPLSmmT/0ppk/8+TWf/Unmv//v37//////////////////////+TWRr/VwsA/35AAP+ERgD/g0UA/4JGAP9lHgD/kFga/8KXX/+TRwD/jT4A/49CAP+VTQD/n10A/5xYAP+OQQD/lk4A/55cAPL///8A////AP///wD///8A0ppk8tKaZP/SmmT/y4tO/92yiP//////////////////////8NnE/8eCQP+rcTT/ez0A/3IyAP98PgD/gEMA/5FSAP+USwD/jj8A/5lUAP+JNwD/yqV2/694Mf+HNQD/jkAA/82rf/+laBj/jT4A8v///wD///8A////AP///wDSmmTy0ppk/9KaZP/LiUr/4byY///////////////////////gupX/0I5P/+Wuev/Lklz/l1sj/308AP+QSwD/ol0A/59aAP+aVQD/k0oA/8yoh///////+fXv/6pwO//Lp3v///////Pr4f+oay7y////AP///wD///8A////ANKaZPLSmmT/0ppk/8uJSv/hvJj//////////////////////+G7l//Jhkb/0ppk/96nc//fqXX/x4xO/6dkFP+QSQD/llEA/5xXAP+USgD/yaOA///////38uv/qG05/8ijdv//////8efb/6ZpLPL///8A////AP///wD///8A0ppk8tKaZP/SmmT/zIxO/9yxh///////////////////////7dbA/8iEQf/Sm2X/0Zlj/9ScZv/eqHf/2KJv/7yAQf+XTgD/iToA/5lSAP+JNgD/yKFv/611LP+HNQD/jT8A/8qmeP+kZRT/jT4A8v///wD///8A////AP///wDSmmTy0ppk/9KaZP/Pk1n/1J5q//78+//////////////////+/fv/1aFv/8iEQv/Tm2b/0ppl/9GZY//Wn2z/1pZc/9eldf/Bl2b/kUcA/4w9AP+OQAD/lUwA/59eAP+cWQD/jT8A/5ZOAP+eXADy////AP///wD///8A////ANKaZPLSmmT/0ppk/9KZY//KiEn/8d/P///////////////////////47+f/05tm/8iCP//KiEj/yohJ/8eCP//RmGH//vfy///////n1sP/rXQ7/4k4AP+TTAD/nVoA/5xYAP+cVwD/nFgA/5xYAPL///8A////AP///wD///8A0ppk8tKaZP/SmmT/0ptl/8uLTf/aq37////////////////////////////+/fz/6c2y/961jv/etY7/6Myx//78+v//////////////////////3MWv/5xXD/+ORAD/mFQA/51ZAP+cWAD/nFgA8v///wD///8A////AP///wDSmmTy0ppk/9KaZP/SmmT/0ppk/8mFRP/s1b//////////////////////////////////////////////////////////////////////////////+PD/0JFU/7NzMv+WUQD/kUsA/5tXAP+dWQDy////AP///wD///8A////ANKaZP/SmmT/0ppk/9KaZP/Sm2X/z5NZ/8yMT//z5NX/////////////////////////////////////////////////////////////////9Ofa/8yNUP/UmGH/36p5/8yTWv+qaSD/kksA/5ROAPz///8A////AP///wD///8A0ppk5NKaZP/SmmT/0ppk/9KaZP/TnGf/zY9T/82OUv/t1sD//////////////////////////////////////////////////////+7Yw//OkFX/zI5R/9OcZ//SmmP/26V0/9ymdf/BhUf/ol8R6P///wD///8A////AP///wDSmmQ80ppk9tKaZP/SmmT/0ppk/9KaZP/TnGj/zpFW/8qJSv/dson/8uHS//////////////////////////////////Lj0//etIv/y4lL/86QVf/TnGj/0ppk/9KaZP/RmWP/05xn/9ymdfjUnWdC////AP///wD///8A////ANKaZADSmmQc0ppkotKaZP/SmmT/0ppk/9KaZP/Tm2b/0Zli/8qJSf/NjlH/16Z3/+G8mP/myKr/5siq/+G8mP/Xp3f/zY5S/8qISf/RmGH/05tm/9KaZP/SmmT/0ppk/9KaZP/SmmSm0pljINWdaQD///8A////AP///wD///8A0ppkANKaZADSmmQA0ppkQtKaZMrSmmT/0ppk/9KaZP/SmmT/0ptl/9GYYf/Nj1P/y4lL/8qISP/KiEj/y4lK/82PU//RmGH/0ptl/9KaZP/SmmT/0ppk/9KaZP/SmmTO0ppkRtKaZADSmmQA0ppkAP///wD///8A////AP///wDSmmQA0ppkANKaZADSmmQA0ppkANKaZGzSmmTu0ppk/9KaZP/SmmT/0ppk/9KaZP/SmmT/0ppk/9KaZP/SmmT/0ppk/9KaZP/SmmT/0ppk/9KaZP/SmmTw0ppkcNKaZADSmmQA0ppkANKaZADSmmQA////AP///wD///8A////ANKaZADSmmQA0ppkANKaZADSmmQA0ppkANKaZBLSmmSQ0ppk/9KaZP/SmmT/0ppk/9KaZP/SmmT/0ppk/9KaZP/SmmT/0ppk/9KaZP/SmmT/0ppklNKaZBTSmmQA0ppkANKaZADSmmQA0ppkANKaZAD///8A////AP///wD///8A0ppkANKaZADSmmQA0ppkANKaZADSmmQA0ppkANKaZADSmmQy0ppkutKaZP/SmmT/0ppk/9KaZP/SmmT/0ppk/9KaZP/SmmT/0ppkvtKaZDbSmmQA0ppkANKaZADSmmQA0ppkANKaZADSmmQA0ppkAP///wD///8A////AP///wDSmmQA0ppkANKaZADSmmQA0ppkANKaZADSmmQA0ppkANKaZADSmmQA0ppkXNKaZODSmmT/0ppk/9KaZP/SmmT/0ppk5NKaZGDSmmQA0ppkANKaZADSmmQA0ppkANKaZADSmmQA0ppkANKaZADSmmQA////AP///wD///8A////ANKaZADSmmQA0ppkANKaZADSmmQA0ppkANKaZADSmmQA0ppkANKaZADSmmQA0ppkBtKaZIbSmmTo0ppk6tKaZIrSmmQK0ppkANKaZADSmmQA0ppkANKaZADSmmQA0ppkANKaZADSmmQA0ppkANKaZAD///8A////AP/8P///+B///+AH//+AAf//AAD//AAAP/AAAA/gAAAHwAAAA8AAAAPAAAADwAAAA8AAAAPAAAADwAAAA8AAAAPAAAADwAAAA8AAAAPAAAADwAAAA8AAAAPAAAADwAAAA+AAAAfwAAAP/AAAP/8AAP//gAH//+AH///4H////D//" rel="icon" />
   <!--[if lt IE 9]>
     <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
   <![endif]-->
@@ -425,7 +425,7 @@ Owning Multidimensional Array Analog of <code>mdspan</code></h1>
   </tr>
   <tr>
     <td>Date: </td>
-    <td>2023-05-19</td>
+    <td>2024-02-27</td>
   </tr>
   <tr>
     <td style="vertical-align:top">Project: </td>
@@ -593,18 +593,17 @@ argument</li>
 <li>added wording</li>
 </ul>
 <h1 data-number="2" id="motivation"><span class="header-section-number">2</span> Motivation<a href="#motivation" class="self-link"></a></h1>
-<p><span class="citation" data-cites="P0009R18">[<a href="#ref-P0009R18" role="doc-biblioref"><strong>P0009R18?</strong></a>]</span> proposed
-<code>mdspan</code>, a nonowning multidimensional array abstraction. It
-was voted into the C++23 draft. This proposal builds on
-<code>mdspan</code> by introducing <code>mdarray</code>, an
-<em>owning</em> multidimensional array that interoperates with
-<code>mdspan</code>. The <code>mdarray</code> class is to
-<code>vector</code> as <code>mdspan</code> is to <code>span</code>.
-Owning semantics can make it easier for users to express common cases,
-like returning an array from a function. It also makes it much easier to
-create a multi dimensional array for use:</p>
+<p><span class="citation" data-cites="P0009R18">[<a href="#ref-P0009R18" role="doc-biblioref">P0009R18</a>]</span> proposed <code>mdspan</code>,
+a nonowning multidimensional array abstraction. It was voted into the
+C++23 draft. This proposal builds on <code>mdspan</code> by introducing
+<code>mdarray</code>, an <em>owning</em> multidimensional array that
+interoperates with <code>mdspan</code>. The <code>mdarray</code> class
+is to <code>vector</code> as <code>mdspan</code> is to
+<code>span</code>. Owning semantics can make it easier for users to
+express common cases, like returning an array from a function. It also
+makes it much easier to create a multi dimensional array for use:</p>
 <p><strong>C++23:</strong></p>
-<div class="sourceCode" id="cb1"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Create a mapping so one knows how many </span></span>
+<div class="sourceCode" id="cb1"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="co">// Create a mapping so one knows how many</span></span>
 <span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="co">// elements the buffer needs to have</span></span>
 <span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a>layout_right<span class="op">::</span>mapping<span class="op">&lt;</span>dextents<span class="op">&lt;</span><span class="dt">int</span>, <span class="dv">2</span><span class="op">&gt;&gt;</span> map<span class="op">(</span>N,M<span class="op">)</span>;</span>
 <span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a></span>
@@ -626,9 +625,9 @@ for compilers to deduce that the data could be stored in registers.</p>
 the design of <code>mdspan</code> as much as possible, with the goals of
 reducing cognitive load for users already familiar with
 <code>mdspan</code> and of incorporating the lessons learned from over a
-decade of experience with <span class="citation" data-cites="P0009R18">[<a href="#ref-P0009R18" role="doc-biblioref"><strong>P0009R18?</strong></a>]</span> and
-libraries of similar design. This paper assumes the reader has read and
-is already familiar with <span class="citation" data-cites="P0009R18">[<a href="#ref-P0009R18" role="doc-biblioref"><strong>P0009R18?</strong></a>]</span>.</p>
+decade of experience with <span class="citation" data-cites="P0009R18">[<a href="#ref-P0009R18" role="doc-biblioref">P0009R18</a>]</span> and libraries of similar
+design. This paper assumes the reader has read and is already familiar
+with <span class="citation" data-cites="P0009R18">[<a href="#ref-P0009R18" role="doc-biblioref">P0009R18</a>]</span>.</p>
 <h2 data-number="3.1" id="design-overview"><span class="header-section-number">3.1</span> Design overview<a href="#design-overview" class="self-link"></a></h2>
 <p>The analogy to <code>mdspan</code> can be seen in the declaration of
 the proposed design for <code>mdarray</code>.</p>
@@ -638,8 +637,8 @@ the proposed design for <code>mdarray</code>.</p>
 <span id="cb3-4"><a href="#cb3-4" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Container <span class="op">=</span> <em>see-below</em><span class="op">&gt;</span></span>
 <span id="cb3-5"><a href="#cb3-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">class</span> mdarray;</span></code></pre></div>
 <p>This intentionally parallels the design of <code>mdspan</code> in
-<span class="citation" data-cites="P0009R18">[<a href="#ref-P0009R18" role="doc-biblioref"><strong>P0009R18?</strong></a>]</span>, which has
-the following signature.</p>
+<span class="citation" data-cites="P0009R18">[<a href="#ref-P0009R18" role="doc-biblioref">P0009R18</a>]</span>, which has the following
+signature.</p>
 <div class="sourceCode" id="cb4"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ElementType,</span>
 <span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> Extents,</span>
 <span id="cb4-3"><a href="#cb4-3" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> LayoutPolicy <span class="op">=</span> layout_right,</span>
@@ -735,7 +734,7 @@ LEWG.</p>
 <div class="sourceCode" id="cb6"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ElementType, <span class="kw">class</span> Extents, <span class="kw">class</span> LayoutPolicy, <span class="kw">class</span> Container<span class="op">&gt;</span></span>
 <span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a><span class="kw">class</span> mdarray <span class="op">{</span></span>
 <span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a>  <span class="co">/* ... */</span></span>
-<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a>  </span>
+<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb6-5"><a href="#cb6-5" aria-hidden="true" tabindex="-1"></a>  <span class="co">// only in mdarray:</span></span>
 <span id="cb6-6"><a href="#cb6-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> mdspan_type <span class="op">=</span> <span class="co">/* ... */</span>;</span>
 <span id="cb6-7"><a href="#cb6-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> const_mdspan_type <span class="op">=</span> <span class="co">/* ... */</span>;</span>
@@ -744,10 +743,10 @@ LEWG.</p>
 <span id="cb6-10"><a href="#cb6-10" aria-hidden="true" tabindex="-1"></a>    <span class="kw">operator</span> mdspan<span class="op">()</span> <span class="kw">const</span>;</span>
 <span id="cb6-11"><a href="#cb6-11" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb6-12"><a href="#cb6-12" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherAccessorType <span class="op">=</span> default_accessor<span class="op">&lt;</span>element_type<span class="op">&gt;&gt;</span></span>
-<span id="cb6-13"><a href="#cb6-13" aria-hidden="true" tabindex="-1"></a>    <span class="kw">auto</span> to_mdspan<span class="op">(</span><span class="kw">const</span> OtherAccessorType<span class="op">&amp;</span> a <span class="op">=</span> </span>
+<span id="cb6-13"><a href="#cb6-13" aria-hidden="true" tabindex="-1"></a>    <span class="kw">auto</span> to_mdspan<span class="op">(</span><span class="kw">const</span> OtherAccessorType<span class="op">&amp;</span> a <span class="op">=</span></span>
 <span id="cb6-14"><a href="#cb6-14" aria-hidden="true" tabindex="-1"></a>                     default_accessor<span class="op">&lt;</span>element_type<span class="op">&gt;())</span> <span class="kw">const</span> <span class="kw">noexcept</span>;</span>
 <span id="cb6-15"><a href="#cb6-15" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherAccessorType <span class="op">=</span> default_accessor<span class="op">&lt;</span><span class="kw">const</span> element_type<span class="op">&gt;&gt;</span></span>
-<span id="cb6-16"><a href="#cb6-16" aria-hidden="true" tabindex="-1"></a>    <span class="kw">auto</span> to_mdspan<span class="op">(</span><span class="kw">const</span> OtherAccessorType<span class="op">&amp;</span> a <span class="op">=</span> </span>
+<span id="cb6-16"><a href="#cb6-16" aria-hidden="true" tabindex="-1"></a>    <span class="kw">auto</span> to_mdspan<span class="op">(</span><span class="kw">const</span> OtherAccessorType<span class="op">&amp;</span> a <span class="op">=</span></span>
 <span id="cb6-17"><a href="#cb6-17" aria-hidden="true" tabindex="-1"></a>                     default_accessor<span class="op">&lt;</span><span class="kw">const</span> element_type<span class="op">&gt;())</span> <span class="kw">const</span> <span class="kw">noexcept</span>;</span>
 <span id="cb6-18"><a href="#cb6-18" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb6-19"><a href="#cb6-19" aria-hidden="true" tabindex="-1"></a>  <span class="co">/* ... */</span></span>
@@ -761,7 +760,7 @@ parameter.</p>
 <div class="sourceCode" id="cb7"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ElementType, <span class="kw">class</span> Extents, <span class="kw">class</span> LayoutPolicy, <span class="kw">class</span> Container<span class="op">&gt;</span></span>
 <span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a><span class="kw">class</span> mdarray <span class="op">{</span></span>
 <span id="cb7-3"><a href="#cb7-3" aria-hidden="true" tabindex="-1"></a>  <span class="co">/* ... */</span></span>
-<span id="cb7-4"><a href="#cb7-4" aria-hidden="true" tabindex="-1"></a>  </span>
+<span id="cb7-4"><a href="#cb7-4" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb7-5"><a href="#cb7-5" aria-hidden="true" tabindex="-1"></a>  <span class="co">// only in mdarray</span></span>
 <span id="cb7-6"><a href="#cb7-6" aria-hidden="true" tabindex="-1"></a> <span class="kw">using</span> container_type <span class="op">=</span> Container;</span>
 <span id="cb7-7"><a href="#cb7-7" aria-hidden="true" tabindex="-1"></a></span>
@@ -779,7 +778,7 @@ versions of these:</p>
 <div class="sourceCode" id="cb8"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ElementType, <span class="kw">class</span> Extents, <span class="kw">class</span> LayoutPolicy, <span class="kw">class</span> ContainerPolicy<span class="op">&gt;</span></span>
 <span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a><span class="kw">class</span> mdarray <span class="op">{</span></span>
 <span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a>  <span class="co">/* ... */</span></span>
-<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a>  </span>
+<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb8-5"><a href="#cb8-5" aria-hidden="true" tabindex="-1"></a>  <span class="co">// analogous to mdspan:</span></span>
 <span id="cb8-6"><a href="#cb8-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ET, <span class="kw">class</span> Exts, <span class="kw">class</span> LP, <span class="kw">class</span> CP<span class="op">&gt;</span></span>
 <span id="cb8-7"><a href="#cb8-7" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> mdarray<span class="op">&lt;</span>ET, Exts, LP, CP<span class="op">&gt;&amp;)</span>;</span>
@@ -871,10 +870,10 @@ instance, in the case where the <code>container</code> happens to be an
 reused<a href="#extents-design-reused" class="self-link"></a></h2>
 <p>As with <code>mdspan</code>, the <code>Extents</code> template
 parameter to <code>mdarray</code> shall be a template instantiation of
-<code>std::extents</code>, as described in <span class="citation" data-cites="P0009R18">[<a href="#ref-P0009R18" role="doc-biblioref"><strong>P0009R18?</strong></a>]</span>. The
-concerns addressed by this aspect of the design are exactly the same in
-<code>mdarray</code> and <code>mdspan</code>, so using the same form and
-mechanism seems like the right thing to do here.</p>
+<code>std::extents</code>, as described in <span class="citation" data-cites="P0009R18">[<a href="#ref-P0009R18" role="doc-biblioref">P0009R18</a>]</span>. The concerns addressed by
+this aspect of the design are exactly the same in <code>mdarray</code>
+and <code>mdspan</code>, so using the same form and mechanism seems like
+the right thing to do here.</p>
 <h2 data-number="3.4" id="layoutpolicy-design-reused"><span class="header-section-number">3.4</span> <code>LayoutPolicy</code>
 design reused<a href="#layoutpolicy-design-reused" class="self-link"></a></h2>
 <p>While not quite as straightforward, the decision to use the same
@@ -919,7 +918,7 @@ entirely fixed sizes, we would expect the default implementation to
 return something that is (at the very least) convertible to
 <code>array</code> of the correct size:</p>
 <div class="sourceCode" id="cb13"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="kw">auto</span> a <span class="op">=</span> mdarray<span class="op">&lt;</span><span class="dt">int</span>, <span class="dv">3</span>, <span class="dv">3</span><span class="op">&gt;()</span>;</span>
-<span id="cb13-2"><a href="#cb13-2" aria-hidden="true" tabindex="-1"></a>std<span class="op">::</span>array<span class="op">&lt;</span><span class="dt">int</span>, <span class="dv">9</span><span class="op">&gt;</span> data <span class="op">=</span> <em>get-underlying-container</em><span class="op">(</span>a<span class="op">)</span>; </span></code></pre></div>
+<span id="cb13-2"><a href="#cb13-2" aria-hidden="true" tabindex="-1"></a>std<span class="op">::</span>array<span class="op">&lt;</span><span class="dt">int</span>, <span class="dv">9</span><span class="op">&gt;</span> data <span class="op">=</span> <em>get-underlying-container</em><span class="op">(</span>a<span class="op">)</span>;</span></code></pre></div>
 <p>(Whether or not a reference to the underlying container should be
 obtainable is slightly less clear, though we see no reason why this
 should not be allowed.) The default for an <code>mdarray</code> with
@@ -930,7 +929,7 @@ model for <em>contiguous container</em> of variable size in the standard
 library is <code>vector</code>, so an entirely reasonable outcome would
 be to have:</p>
 <div class="sourceCode" id="cb14"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="kw">auto</span> a <span class="op">=</span> mdarray<span class="op">&lt;</span><span class="dt">int</span>, <span class="dv">3</span>, dynamic_extent<span class="op">&gt;()</span>;</span>
-<span id="cb14-2"><a href="#cb14-2" aria-hidden="true" tabindex="-1"></a>std<span class="op">::</span>vector<span class="op">&lt;</span><span class="dt">int</span><span class="op">&gt;</span> data <span class="op">=</span> <em>get-underlying-container</em><span class="op">(</span>a<span class="op">)</span>; </span></code></pre></div>
+<span id="cb14-2"><a href="#cb14-2" aria-hidden="true" tabindex="-1"></a>std<span class="op">::</span>vector<span class="op">&lt;</span><span class="dt">int</span><span class="op">&gt;</span> data <span class="op">=</span> <em>get-underlying-container</em><span class="op">(</span>a<span class="op">)</span>;</span></code></pre></div>
 <p>Moreover, taking a view of a <code>mdarray</code> should yield an
 analogous <code>mdspan</code> with consistent semantics (except, of
 course, that the latter is nonowning). We provisionally call the method
@@ -1765,7 +1764,7 @@ an observer of the underlying container’s size.</p>
 <code>mdarray</code> is a multidimensional array of elements.</p>
 <div class="sourceCode" id="cb29"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb29-1"><a href="#cb29-1" aria-hidden="true" tabindex="-1"></a><span class="kw">namespace</span> std <span class="op">{</span></span>
 <span id="cb29-2"><a href="#cb29-2" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb29-3"><a href="#cb29-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ElementType, <span class="kw">class</span> Extents, <span class="kw">class</span> LayoutPolicy, <span class="kw">class</span> Container <span class="op">=</span> </span>
+<span id="cb29-3"><a href="#cb29-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> ElementType, <span class="kw">class</span> Extents, <span class="kw">class</span> LayoutPolicy, <span class="kw">class</span> Container <span class="op">=</span></span>
 <span id="cb29-4"><a href="#cb29-4" aria-hidden="true" tabindex="-1"></a>         vector<span class="op">&lt;</span>ElementType<span class="op">&gt;&gt;</span></span>
 <span id="cb29-5"><a href="#cb29-5" aria-hidden="true" tabindex="-1"></a><span class="kw">class</span> mdarray <span class="op">{</span></span>
 <span id="cb29-6"><a href="#cb29-6" aria-hidden="true" tabindex="-1"></a><span class="kw">public</span><span class="op">:</span></span>
@@ -1811,7 +1810,7 @@ an observer of the underlying container’s size.</p>
 <span id="cb29-46"><a href="#cb29-46" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> mapping_type<span class="op">&amp;</span> m, container_type<span class="op">&amp;&amp;</span> c,<span class="op">)</span>;</span>
 <span id="cb29-47"><a href="#cb29-47" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb29-48"><a href="#cb29-48" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb29-49"><a href="#cb29-49" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherElementType, <span class="kw">class</span> OtherExtents, </span>
+<span id="cb29-49"><a href="#cb29-49" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherElementType, <span class="kw">class</span> OtherExtents,</span>
 <span id="cb29-50"><a href="#cb29-50" aria-hidden="true" tabindex="-1"></a>           <span class="kw">class</span> OtherLayoutPolicy, <span class="kw">class</span> OtherContainer<span class="op">&gt;</span></span>
 <span id="cb29-51"><a href="#cb29-51" aria-hidden="true" tabindex="-1"></a>    <span class="kw">explicit</span><span class="op">(</span><em>see below</em><span class="op">)</span></span>
 <span id="cb29-52"><a href="#cb29-52" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span></span>
@@ -1846,12 +1845,12 @@ an observer of the underlying container’s size.</p>
 <span id="cb29-81"><a href="#cb29-81" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> mapping_type<span class="op">&amp;</span> m, container_type<span class="op">&amp;&amp;</span> c, <span class="kw">const</span> Alloc<span class="op">&amp;</span> a<span class="op">)</span>;</span>
 <span id="cb29-82"><a href="#cb29-82" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb29-83"><a href="#cb29-83" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb29-84"><a href="#cb29-84" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherElementType, <span class="kw">class</span> OtherExtents, </span>
-<span id="cb29-85"><a href="#cb29-85" aria-hidden="true" tabindex="-1"></a>           <span class="kw">class</span> OtherLayoutPolicy, <span class="kw">class</span> OtherContainer, </span>
+<span id="cb29-84"><a href="#cb29-84" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherElementType, <span class="kw">class</span> OtherExtents,</span>
+<span id="cb29-85"><a href="#cb29-85" aria-hidden="true" tabindex="-1"></a>           <span class="kw">class</span> OtherLayoutPolicy, <span class="kw">class</span> OtherContainer,</span>
 <span id="cb29-86"><a href="#cb29-86" aria-hidden="true" tabindex="-1"></a>           <span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
 <span id="cb29-87"><a href="#cb29-87" aria-hidden="true" tabindex="-1"></a>    <span class="kw">explicit</span><span class="op">(</span><em>see below</em><span class="op">)</span></span>
 <span id="cb29-88"><a href="#cb29-88" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdarray<span class="op">(</span></span>
-<span id="cb29-89"><a href="#cb29-89" aria-hidden="true" tabindex="-1"></a>      <span class="kw">const</span> mdarray<span class="op">&lt;</span>OtherElementType, OtherExtents, </span>
+<span id="cb29-89"><a href="#cb29-89" aria-hidden="true" tabindex="-1"></a>      <span class="kw">const</span> mdarray<span class="op">&lt;</span>OtherElementType, OtherExtents,</span>
 <span id="cb29-90"><a href="#cb29-90" aria-hidden="true" tabindex="-1"></a>                    OtherLayoutPolicy, OtherContainer<span class="op">&gt;&amp;</span> other, <span class="kw">const</span> Alloc<span class="op">&amp;</span> a<span class="op">)</span>;</span>
 <span id="cb29-91"><a href="#cb29-91" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb29-92"><a href="#cb29-92" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherElementType, <span class="kw">class</span> OtherExtents,</span>
@@ -1891,8 +1890,8 @@ an observer of the underlying container’s size.</p>
 <span id="cb29-126"><a href="#cb29-126" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> <span class="kw">const</span> mapping_type<span class="op">&amp;</span> mapping<span class="op">()</span> <span class="kw">const</span> <span class="op">{</span> <span class="cf">return</span> <em>map_</em>; <span class="op">}</span></span>
 <span id="cb29-127"><a href="#cb29-127" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb29-128"><a href="#cb29-128" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherElementType, <span class="kw">class</span> OtherExtents,</span>
-<span id="cb29-129"><a href="#cb29-129" aria-hidden="true" tabindex="-1"></a>           <span class="kw">class</span> OtherLayoutType, <span class="kw">class</span> OtherAccessorType<span class="op">&gt;</span></span>
-<span id="cb29-130"><a href="#cb29-130" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> <span class="kw">operator</span> mdspan <span class="op">()</span> <span class="kw">const</span>;</span>
+<span id="cb29-129"><a href="#cb29-129" aria-hidden="true" tabindex="-1"></a>           <span class="kw">class</span> OtherLayoutPolicy, <span class="kw">class</span> OtherAccessorType<span class="op">&gt;</span></span>
+<span id="cb29-130"><a href="#cb29-130" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> <span class="kw">operator</span> mdspan<span class="op">&lt;</span>OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessorType<span class="op">&gt;</span> <span class="op">()</span> <span class="kw">const</span>;</span>
 <span id="cb29-131"><a href="#cb29-131" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb29-132"><a href="#cb29-132" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherAccessorType <span class="op">=</span> default_accessor<span class="op">&lt;</span>element_type<span class="op">&gt;&gt;</span></span>
 <span id="cb29-133"><a href="#cb29-133" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> mdspan<span class="op">&lt;</span>element_type, extents_type, layout_type, OtherAccessorType<span class="op">&gt;</span></span>
@@ -2291,7 +2290,7 @@ Direct-non-list-initializes <code>ctr_</code> with
 <div class="sourceCode" id="cb40"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb40-1"><a href="#cb40-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherElementType, <span class="kw">class</span> OtherExtents,</span>
 <span id="cb40-2"><a href="#cb40-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> OtherLayoutPolicy, <span class="kw">class</span> OtherContainer<span class="op">&gt;</span></span>
 <span id="cb40-3"><a href="#cb40-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">explicit</span><span class="op">(</span><em>see below</em><span class="op">)</span></span>
-<span id="cb40-4"><a href="#cb40-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> mdarray<span class="op">&lt;</span>OtherElementType, OtherExtents, </span>
+<span id="cb40-4"><a href="#cb40-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> mdarray<span class="op">&lt;</span>OtherElementType, OtherExtents,</span>
 <span id="cb40-5"><a href="#cb40-5" aria-hidden="true" tabindex="-1"></a>                                OtherLayoutPolicy, OtherContainer<span class="op">&gt;&amp;</span> other<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">24</a></span>
 <em>Mandates:</em></p>
@@ -2639,7 +2638,7 @@ the second argument.</p></li>
 <div class="sourceCode" id="cb52"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb52-1"><a href="#cb52-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherElementType, <span class="kw">class</span> OtherExtents,</span>
 <span id="cb52-2"><a href="#cb52-2" aria-hidden="true" tabindex="-1"></a>         <span class="kw">class</span> OtherLayoutPolicy, <span class="kw">class</span> OtherContainer, <span class="kw">class</span> Alloc<span class="op">&gt;</span></span>
 <span id="cb52-3"><a href="#cb52-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">explicit</span><span class="op">(</span><em>see below</em><span class="op">)</span></span>
-<span id="cb52-4"><a href="#cb52-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> mdarray<span class="op">&lt;</span>OtherElementType, OtherExtents, </span>
+<span id="cb52-4"><a href="#cb52-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> mdarray<span class="op">(</span><span class="kw">const</span> mdarray<span class="op">&lt;</span>OtherElementType, OtherExtents,</span>
 <span id="cb52-5"><a href="#cb52-5" aria-hidden="true" tabindex="-1"></a>                                  OtherLayoutPolicy, OtherContainer<span class="op">&gt;&amp;</span> other,</span>
 <span id="cb52-6"><a href="#cb52-6" aria-hidden="true" tabindex="-1"></a>                    <span class="kw">const</span> Alloc<span class="op">&amp;</span> a<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">25</a></span>
@@ -2834,16 +2833,17 @@ index space <code>extents()</code> is 0, otherwise
 <div class="sourceCode" id="cb61"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb61-1"><a href="#cb61-1" aria-hidden="true" tabindex="-1"></a>swap<span class="op">(</span>x<span class="op">.</span>ctr_, y<span class="op">.</span>ctr_<span class="op">)</span>;</span>
 <span id="cb61-2"><a href="#cb61-2" aria-hidden="true" tabindex="-1"></a>swap<span class="op">(</span>x<span class="op">.</span><em>map</em>_, y<span class="op">.</span><em>map</em>_<span class="op">)</span>;</span></code></pre></div>
 <div class="sourceCode" id="cb62"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb62-1"><a href="#cb62-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> OtherElementType, <span class="kw">class</span> OtherExtents,</span>
-<span id="cb62-2"><a href="#cb62-2" aria-hidden="true" tabindex="-1"></a>           <span class="kw">class</span> OtherLayoutType, <span class="kw">class</span> OtherAccessorType<span class="op">&gt;</span></span>
+<span id="cb62-2"><a href="#cb62-2" aria-hidden="true" tabindex="-1"></a>           <span class="kw">class</span> OtherLayoutPolicy, <span class="kw">class</span> OtherAccessorType<span class="op">&gt;</span></span>
 <span id="cb62-3"><a href="#cb62-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">operator</span> mdspan <span class="op">()</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">11</a></span>
 <em>Constraints:</em></p>
 <ul>
-<li><p>[11.1]{pnum}
-<code>is_assignable_v&lt;mdspan&lt;element_type, extents_type, layout_type&gt;, mdspan&lt;OtherElementType, OtherExtents, OtherLayoutType, OtherAccessorType&gt;&gt;</code>
+<li><p><span class="marginalizedparent"><a class="marginalized">(11.1)</a></span>
+<code>is_assignable_v&lt;mdspan_type &amp;, mdspan&lt;OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessorType&gt;&gt;</code>
 is <code>true</code>.</p></li>
-<li><p>[11.2]{pnum} <code>is_same_v&lt;pointer, element_type*&gt;</code>
-is <code>true</code>.</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized">(11.2)</a></span>
+<code>is_same_v&lt;pointer, element_type*&gt;</code> is
+<code>true</code>.</p></li>
 </ul>
 <p><span class="marginalizedparent"><a class="marginalized">12</a></span>
 <em>Preconditions:</em>
@@ -2857,7 +2857,7 @@ is <code>true</code>.</p>
 <span id="cb63-3"><a href="#cb63-3" aria-hidden="true" tabindex="-1"></a>      to_mdspan<span class="op">(</span><span class="kw">const</span> OtherAccessorType<span class="op">&amp;</span> a <span class="op">=</span> default_accessor<span class="op">&lt;</span>element_type<span class="op">&gt;())</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">14</a></span>
 <em>Constraints:</em>
-<code>is_assignable_v&lt;pointer, typename OtherAccessorType::data_handle_type&gt;</code>
+<code>is_assignable_v&lt;pointer &amp;, typename OtherAccessorType::data_handle_type&gt;</code>
 is <code>true</code>.</p>
 <p><span class="marginalizedparent"><a class="marginalized">15</a></span>
 <em>Preconditions:</em>
@@ -2871,7 +2871,7 @@ is <code>true</code>.</p>
 <span id="cb64-3"><a href="#cb64-3" aria-hidden="true" tabindex="-1"></a>      to_mdspan<span class="op">(</span><span class="kw">const</span> OtherAccessorType<span class="op">&amp;</span> a <span class="op">=</span> default_accessor<span class="op">&lt;</span><span class="kw">const</span> element_type<span class="op">&gt;())</span> <span class="kw">const</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized">17</a></span>
 <em>Constraints:</em>
-<code>is_assignable_v&lt;const_pointer, typename OtherAccessorType::data_handle_type&gt;</code>
+<code>is_assignable_v&lt;const_pointer &amp;, typename OtherAccessorType::data_handle_type&gt;</code>
 is <code>true</code>.</p>
 <p><span class="marginalizedparent"><a class="marginalized">18</a></span>
 <em>Preconditions:</em>
@@ -2899,6 +2899,12 @@ under contract DE-NA-0003525.</p>
 Office of Science and the National Nuclear Security Administration.</p>
 <h1 data-number="8" id="references"><span class="header-section-number">8</span> References<a href="#references" class="self-link"></a></h1>
 <div id="refs" class="references csl-bib-body" role="doc-bibliography">
+<div id="ref-P0009R18" class="csl-entry" role="doc-biblioentry">
+<div class="csl-left-margin">[P0009R18] </div><div class="csl-right-inline">Christian Trott, D.S. Hollman, Damien
+Lebrun-Grandie, Mark Hoemmen, Daniel Sunderland, H. Carter Edwards,
+Bryce Adelstein Lelbach, Mauro Bianco, Ben Sander, Athanasios
+Iliopoulos, John Michopoulos, Nevin Liber. 2022. mdspan. <a href="https://wg21.link/p0009r18"><div class="csl-block">https://wg21.link/p0009r18</div></a></div>
+</div>
 <div id="ref-P1684R0" class="csl-entry" role="doc-biblioentry">
 <div class="csl-left-margin">[P1684R0] </div><div class="csl-right-inline">David Hollman, Christian Trott, Mark Hoemmen,
 Daniel Sundernland. 2019. mdarray: An Owning Multidimensional Array

--- a/P1684-mdarray/P1684.md
+++ b/P1684-mdarray/P1684.md
@@ -27,17 +27,17 @@ author:
 - disambiguate deduction guides
 - add precondition to relevant functions about container size being large enough: this fixes issues in moved-from state
 - add function `extract_container` to move the container out of `mdarray`
-- rename `data()` to `container_data()` and add `container_size()` 
+- rename `data()` to `container_data()` and add `container_size()`
   - `data()` did actually not go together with `size()` for example for non-unique layouts
   - in moved from state `data()` also may not work together with `mapping().required_span_size()`.
 - work around the fact that `data()` and `pointer` is not a thing required by contiguous container requirements ...
-- fix `to_mdspan` and `mdspan` conversion operator 
+- fix `to_mdspan` and `mdspan` conversion operator
 
 ## P1684R4: 2023-01 Mailing
 
 #### Changes from R3
 
-- drop the "size constructible container" requirements and simply use preconditions on relevant constructors 
+- drop the "size constructible container" requirements and simply use preconditions on relevant constructors
 
 ## P1684R3: 2022-07 Mailing
 
@@ -77,12 +77,12 @@ author:
 
 # Motivation
 
-[@P0009R18] proposed `mdspan`, a nonowning multidimensional array abstraction.  It was voted into the C++23 draft.  This proposal builds on `mdspan` by introducing `mdarray`, an *owning* multidimensional array that interoperates with `mdspan`.  The `mdarray` class is to `vector` as `mdspan` is to `span`.  Owning semantics can make it easier for users to express common cases, like returning an array from a function. 
+[@P0009R18] proposed `mdspan`, a nonowning multidimensional array abstraction.  It was voted into the C++23 draft.  This proposal builds on `mdspan` by introducing `mdarray`, an *owning* multidimensional array that interoperates with `mdspan`.  The `mdarray` class is to `vector` as `mdspan` is to `span`.  Owning semantics can make it easier for users to express common cases, like returning an array from a function.
 It also makes it much easier to create a multi dimensional array for use:
 
 **C++23:**
 ```cpp
-// Create a mapping so one knows how many 
+// Create a mapping so one knows how many
 // elements the buffer needs to have
 layout_right::mapping<dextents<int, 2>> map(N,M);
 
@@ -216,7 +216,7 @@ We would be happy to change this based on design direction from LEWG.
 template<class ElementType, class Extents, class LayoutPolicy, class Container>
 class mdarray {
   /* ... */
-  
+
   // only in mdarray:
   using mdspan_type = /* ... */;
   using const_mdspan_type = /* ... */;
@@ -225,10 +225,10 @@ class mdarray {
     operator mdspan() const;
 
   template<class OtherAccessorType = default_accessor<element_type>>
-    auto to_mdspan(const OtherAccessorType& a = 
+    auto to_mdspan(const OtherAccessorType& a =
                      default_accessor<element_type>()) const noexcept;
   template<class OtherAccessorType = default_accessor<const element_type>>
-    auto to_mdspan(const OtherAccessorType& a = 
+    auto to_mdspan(const OtherAccessorType& a =
                      default_accessor<const element_type>()) const noexcept;
 
   /* ... */
@@ -245,7 +245,7 @@ while `mdarray` has a `Container` template parameter.
 template<class ElementType, class Extents, class LayoutPolicy, class Container>
 class mdarray {
   /* ... */
-  
+
   // only in mdarray
  using container_type = Container;
 
@@ -264,7 +264,7 @@ Since `mdarray` has owning semantics, we also need move-like versions of these:
 template<class ElementType, class Extents, class LayoutPolicy, class ContainerPolicy>
 class mdarray {
   /* ... */
-  
+
   // analogous to mdspan:
   template<class ET, class Exts, class LP, class CP>
     constexpr mdarray(const mdarray<ET, Exts, LP, CP>&);
@@ -334,7 +334,7 @@ class mdarray {
 
 Moreover, containers such as `vector` and container adapters like `queue` have a significant number of other constructors which copy the data on input, such as constructors taking ranges, input iterator pairs, and initializer lists.
 The R2 version of this paper had a number of those, but in combination with allocator arguments it lead to an explosion of constructors.
-A draft version seen by LEWG on 2022-07-12 sported 41 constructors. 
+A draft version seen by LEWG on 2022-07-12 sported 41 constructors.
 However almost all these constructors would simply forward arguments to the constructor of the container owned by `mdarray`.
 LEWG provided feedback that we should consider reducing the amount of constructors, since at a minimum one could inline construct the `container` itself, and move it into the `mdarray` upon construction.
 
@@ -346,7 +346,7 @@ mdarray a(first, last, N, M);
 mdarray a(std::move(vector(first, last)), N, M);
 ```
 
-In R3 we decided to radically cut back on constructors and simply leave those out. 
+In R3 we decided to radically cut back on constructors and simply leave those out.
 
 Finally, `mdarray` does not have the analog of `mdspan`'s constructor that takes an `array<IndexType, N>` of dynamic extents.  This avoids any ambiguity or confusion with a constructor that takes a container instance, in the case where the `container` happens to be an `array<IndexType, N>`.
 
@@ -376,7 +376,7 @@ Regardless of the form of the solution, there are several use cases where we hav
 
 ```cpp
 auto a = mdarray<int, 3, 3>();
-std::array<int, 9> data = @*get-underlying-container*@(a); 
+std::array<int, 9> data = @*get-underlying-container*@(a);
 ```
 
 (Whether or not a reference to the underlying container should be obtainable is slightly less clear, though we see no reason why this should not be allowed.)  The default for an `mdarray` with variable extents is only slightly less clear, though it should almost certainly meet the requirements of *contiguous container* (**[container.requirements.general]**/13).
@@ -384,7 +384,7 @@ The default model for *contiguous container* of variable size in the standard li
 
 ```cpp
 auto a = mdarray<int, 3, dynamic_extent>();
-std::vector<int> data = @*get-underlying-container*@(a); 
+std::vector<int> data = @*get-underlying-container*@(a);
 ```
 
 Moreover, taking a view of a `mdarray` should yield an analogous `mdspan` with consistent semantics (except, of course, that the latter is nonowning).  We provisionally call the method for taking a view of an `mdarray` "`to_mdspan()`":
@@ -398,7 +398,7 @@ void frobnicate(mdarray<T, Extents, LayoutPolicy, ContainerPolicy> data)
 }
 ```
 
-In order for this to work, `Container::data()` should be required to return `T*`. 
+In order for this to work, `Container::data()` should be required to return `T*`.
 That way, interoperability with `mdspan` is trivial, since it can simply be created as:
 
 ```cpp
@@ -417,14 +417,14 @@ since they imbue additional semantics to what is otherwise an ordinary container
 These all take a `Container` template parameter, which defaults to `deque` for `stack` and `queue`, and to `vector` for `priority_queue`.
 The allocation concern is thus delegated to the container concept, reducing the cognitive load associated with the design.
 While this design approach overconstrains the template parameter slightly
-(that is, not all of the requirements of the `Container` concept are needed by the container adaptors), 
+(that is, not all of the requirements of the `Container` concept are needed by the container adaptors),
 the simplicity arising from concept reuse more than justifies the cost of the extra constraints.
 
 It is difficult to say whether the use of `Container` directly, as with the container adaptors, is also the correct approach for `mdarray`.
 There are pieces of information that may need to be customized in some very reasonable use cases that are not provided by the standard container concept.
 The most important of these is the ability to produce a semantically consistent `AccessorPolicy` when creating a `mdspan` that refers to a `mdarray`.
 (Interoperability between `mdspan` and `mdarray` is considered a critical design requirement because of the nearly complete overlap in the set of algorithms that operate on them.)
-For instance, given a `Container` instance `c` and an `AccessorPolicy` instance `a`, the behavior of `a.access(p, n)` should be consistent with the behavior of `c[n]` 
+For instance, given a `Container` instance `c` and an `AccessorPolicy` instance `a`, the behavior of `a.access(p, n)` should be consistent with the behavior of `c[n]`
 for a `mdspan` wrapping `a` that is a view of a `mdarray` wrapping `c` (if `p` is `c.begin()`).
 But because `c[n]` is part of the container requirements and thus may encapsulate any arbitrary mapping from an offset of `c.begin()` to a reference,
 the only reasonable means of preserving these semantics for arbitrary container types is to reference the original container directly in the corresponding `AccessorPolicy`.
@@ -590,7 +590,7 @@ public:
 
 The above sketch makes clear the biggest challenge with this approach: the mismatch in shallow versus deep `const`ness in for an abstractions designed to support `mdspan` and `mdarray`, respectively.
 The `ContainerPolicy` concept thus requires additional `const`-qualified overloads of the basis operations.
-Moreover, while the `ContainerPolicy` itself can be obtained directly from the corresponding `AccessorPolicy` 
+Moreover, while the `ContainerPolicy` itself can be obtained directly from the corresponding `AccessorPolicy`
 in the case of the non-`const` method for creating the corresponding `mdspan` (provisionally called `view()`),
 the `const`-qualified version needs to adapt the policy, since the nested types have the wrong names
 (e.g., `const_pointer` should be named `pointer` from the perspective of the `mdspan` that the `const`-qualified `view()` needs to return).
@@ -617,7 +617,7 @@ private:
 Compared to simply using a `container` as the argument, this approach has the benefit of enabling `mdarray` to use containers for which `data()[i]` is not giving access to
 the same element as `container[i]`.
 However, after more consideration we believe that the need for supporting such containers as underlying storage for `mdarray` is likely fairly niche.
-Furthermore, we believe one could later extent the design of `mdarray` to allow for such ContainerPolicies, even if the initial design only allows for a restricted set of containers. 
+Furthermore, we believe one could later extent the design of `mdarray` to allow for such ContainerPolicies, even if the initial design only allows for a restricted set of containers.
 
 ### Extension for accessor policy from container
 
@@ -633,7 +633,7 @@ We have to somehow guarantee that containers constructed from sizes (or if such 
 are actually large enough after the construction so we can index into them.
 However, we don't want full sequence container requirements (also there is no named requirement for a constructor which takes an integral only).
 
-To illustrate the problem consider a user defined container with a static size but that has a constructor which takes an init value. 
+To illustrate the problem consider a user defined container with a static size but that has a constructor which takes an init value.
 
 ```c++
 user::static_vector<int, 200> vec(1000);
@@ -641,7 +641,7 @@ user::static_vector<int, 200> vec(1000);
 assert(vec.size()==200);
 ```
 
-From the perspective of `mdarray` this container looks like its constructible from a size, but that is not actually what the container does. 
+From the perspective of `mdarray` this container looks like its constructible from a size, but that is not actually what the container does.
 
 We previously proposed a new set of named optional requirements for containers which guarantee the desired behavior.
 
@@ -673,7 +673,7 @@ We put the emphasis on easy usability in most common cases, while preserving cla
 There are two alternatives we considered based on received feedback:
 
  - A minimal approach just providing the extents/mapping overloads and versions of it which take a container
- - A variadic approach with perfect forwarding of arguments to the internal container constructor. 
+ - A variadic approach with perfect forwarding of arguments to the internal container constructor.
 
 All variants have the converting constructors, and also the constructors from mdspan in addition to the combinations listed here.
 
@@ -718,7 +718,7 @@ However, it would make some common use cases very verbose to write when using va
 some_mdarray_t a(extents{...}, vector(layout_right::mapping{extents{...}}.required_span_size(), value));
 ```
 
-instead of 
+instead of
 
 ```c++
 some_mdarray_t a(extents{...}, value);
@@ -786,149 +786,149 @@ In this table we use these shorthands:
 - `mda`: an `mdarray` object, not necessarily the same type as `mda_t`
 - `mds`: an `mdspan` obejct, not necessarily the same  as returned by `mda_t::to_mdspan`
 
-<table> 
-<thead> 
-<tr> 
-<th>Arguments</th> 
-<th>Current</th> 
-<th>Minimal</th> 
-<th>Variadic</th> 
-</tr> 
-</thead> 
-<tbody> 
-<tr> 
-<td> `default` </td> 
-<td> `mda_t()` </td> 
-<td> `mda_t()` </td> 
-<td> `mda_t()` </td> 
+<table>
+<thead>
+<tr>
+<th>Arguments</th>
+<th>Current</th>
+<th>Minimal</th>
+<th>Variadic</th>
 </tr>
-<tr> 
-<td> integrals </td> 
-<td> `mda_t(10, 10)` </td> 
-<td> `mda_t(10, 10)` </td> 
-<td> `mda_t(10, 10)` </td> 
-</tr>
-<tr> 
-<td> mapping/extents </td> 
-<td> `mda_t(me)` </td> 
-<td> `mda_t(me)` </td> 
-<td> `mda_t(me)` </td> 
-</tr>
-<tr> 
-<td> container + integrals</td> 
-<td> `mda_t(extents{10, 10}, c)` </td> 
-<td> `mda_t(extents{10, 10}, c)` </td> 
-<td> `mda_t(extents{10, 10}, c)` </td> 
-</tr>
-<tr> 
-<td> move container + integrals</td> 
-<td> `mda_t(extents{10, 10}, move(c))` </td> 
-<td> `mda_t(extents{10, 10}, move(c))` </td> 
-<td> `mda_t(extents{10, 10}, move(c))` </td> 
-</tr>
-<tr> 
-<td> container + mapping/extents </td> 
-<td> `mda_t(me, c)` </td> 
-<td> `mda_t(me, c)` </td> 
-<td> `mda_t(me, c)` </td> 
-</tr>
-<tr> 
-<td> move container + mapping </td> 
-<td> `mda_t(me, move(c))` </td> 
-<td> `mda_t(me, move(c))` </td> 
-<td> `mda_t(me, move(c))` </td> 
-</tr>
-<td> container + alloc + mapping/extents </td> 
-<td> `mda_t(me, c, a)` </td> 
-<td> `mda_t(me, c_t(c,a))` </td> 
-<td> `mda_t(me, c, a)` </td> 
-</tr>
-<tr> 
-<td> move container + alloc + mapping </td> 
-<td> `mda_t(me, move(c), a)` </td> 
-<td> `mda_t(me, c_t(move(c),a))` </td> 
-<td> `mda_t(me, move(c), a)` </td> 
+</thead>
+<tbody>
+<tr>
+<td> `default` </td>
+<td> `mda_t()` </td>
+<td> `mda_t()` </td>
+<td> `mda_t()` </td>
 </tr>
 <tr>
-<td> extents + value </td> 
-<td> `mda_t(e, v)` </td> 
-<td> `mda_t(e, c_t(map_t(e).required_span_size(), v))` </td> 
-<td> `mda_t(e, v)` </td> 
-</tr>
-<tr> 
-<td>  mapping + value</td> 
-<td> `mda_t(m, v)` </td> 
-<td> `mda_t(m, c_t(m.required_span_size(), v))` </td> 
-<td> `mda_t(m, v)` </td> 
-</tr>
-<tr> 
-<td>  mapping + custom container size</td> 
-<td> `mda_t(m, c_t(s))` </td> 
-<td> `mda_t(m, c_t(s))` </td> 
-<td> `mda_t(m, c_t(s))` or `mda_t(m, s)` for integrals not convertible to `value_type`</td> 
-</tr>
-<tr> 
-<td>  mapping + custom container size + value</td> 
-<td> `mda_t(m, c_t(s, v))` </td> 
-<td> `mda_t(m, c_t(s, v))` </td> 
-<td> `mda_t(m, s, v)` </td> 
+<td> integrals </td>
+<td> `mda_t(10, 10)` </td>
+<td> `mda_t(10, 10)` </td>
+<td> `mda_t(10, 10)` </td>
 </tr>
 <tr>
-<td> extents + value + alloc</td> 
-<td> `mda_t(e, v, a)` </td> 
-<td> `mda_t(e, c_t(map_t(e).required_span_size(), v, a)))` </td> 
-<td> `mda_t(e, v , a)` </td> 
+<td> mapping/extents </td>
+<td> `mda_t(me)` </td>
+<td> `mda_t(me)` </td>
+<td> `mda_t(me)` </td>
 </tr>
-<tr> 
-<td>  mapping + value + alloc</td> 
-<td> `mda_t(m, v, a)` </td> 
-<td> `mda_t(m, move(c_t(m.required_span_size(), v, a)))` </td> 
-<td> `mda_t(m, v, a)` </td> 
+<tr>
+<td> container + integrals</td>
+<td> `mda_t(extents{10, 10}, c)` </td>
+<td> `mda_t(extents{10, 10}, c)` </td>
+<td> `mda_t(extents{10, 10}, c)` </td>
 </tr>
-<tr> 
-<td>  mapping + custom container size + alloc</td> 
-<td> `mda_t(m, c_t(s, a))` </td> 
-<td> `mda_t(m, c_t(s, a))` </td> 
-<td> `mda_t(m, c_t(s, a))` or `mda_t(m, s, a)` for integrals not convertible to `value_type`</td> 
+<tr>
+<td> move container + integrals</td>
+<td> `mda_t(extents{10, 10}, move(c))` </td>
+<td> `mda_t(extents{10, 10}, move(c))` </td>
+<td> `mda_t(extents{10, 10}, move(c))` </td>
 </tr>
-<tr> 
-<td>  mapping + custom container size + value + alloc</td> 
-<td> `mda_t(m, c_t(s, v, a))` </td> 
-<td> `mda_t(m, c_t(s, v, a))` </td> 
-<td> `mda_t(m, s, v, a)` </td> 
+<tr>
+<td> container + mapping/extents </td>
+<td> `mda_t(me, c)` </td>
+<td> `mda_t(me, c)` </td>
+<td> `mda_t(me, c)` </td>
 </tr>
-<tr> 
-<td> iterators</td> 
-<td> `mda_t(m, c_t(begin, end))` </td> 
-<td> `mda_t(m, c_t(begin, end))` </td> 
-<td> `mda_t(m, begin, end)` </td> 
+<tr>
+<td> move container + mapping </td>
+<td> `mda_t(me, move(c))` </td>
+<td> `mda_t(me, move(c))` </td>
+<td> `mda_t(me, move(c))` </td>
 </tr>
-<tr> 
-<td> range</td> 
-<td> `mda_t(m, c_t(r))` </td> 
-<td> `mda_t(m, c_t(r))` </td> 
-<td> `mda_t(m, r)` </td> 
+<td> container + alloc + mapping/extents </td>
+<td> `mda_t(me, c, a)` </td>
+<td> `mda_t(me, c_t(c,a))` </td>
+<td> `mda_t(me, c, a)` </td>
 </tr>
-<tr> 
-<td> converting mdarray</td> 
-<td> `mda_t(mda)` </td> 
-<td> `mda_t(mda)` </td> 
-<td> `mda_t(mda)` </td> 
+<tr>
+<td> move container + alloc + mapping </td>
+<td> `mda_t(me, move(c), a)` </td>
+<td> `mda_t(me, c_t(move(c),a))` </td>
+<td> `mda_t(me, move(c), a)` </td>
 </tr>
-<tr> 
-<td> compatible mdspan</td> 
-<td> `mda_t(mds)` </td> 
-<td> `mda_t(mds)` </td> 
-<td> `mda_t(mds)` </td> 
+<tr>
+<td> extents + value </td>
+<td> `mda_t(e, v)` </td>
+<td> `mda_t(e, c_t(map_t(e).required_span_size(), v))` </td>
+<td> `mda_t(e, v)` </td>
 </tr>
-<td> compatible mdspan + allocator</td> 
-<td> `mda_t(mds, a)` </td> 
-<td> `mda_t(mds, a)` </td> 
-<td> `mda_t(mds, a)` </td> 
+<tr>
+<td>  mapping + value</td>
+<td> `mda_t(m, v)` </td>
+<td> `mda_t(m, c_t(m.required_span_size(), v))` </td>
+<td> `mda_t(m, v)` </td>
+</tr>
+<tr>
+<td>  mapping + custom container size</td>
+<td> `mda_t(m, c_t(s))` </td>
+<td> `mda_t(m, c_t(s))` </td>
+<td> `mda_t(m, c_t(s))` or `mda_t(m, s)` for integrals not convertible to `value_type`</td>
+</tr>
+<tr>
+<td>  mapping + custom container size + value</td>
+<td> `mda_t(m, c_t(s, v))` </td>
+<td> `mda_t(m, c_t(s, v))` </td>
+<td> `mda_t(m, s, v)` </td>
+</tr>
+<tr>
+<td> extents + value + alloc</td>
+<td> `mda_t(e, v, a)` </td>
+<td> `mda_t(e, c_t(map_t(e).required_span_size(), v, a)))` </td>
+<td> `mda_t(e, v , a)` </td>
+</tr>
+<tr>
+<td>  mapping + value + alloc</td>
+<td> `mda_t(m, v, a)` </td>
+<td> `mda_t(m, move(c_t(m.required_span_size(), v, a)))` </td>
+<td> `mda_t(m, v, a)` </td>
+</tr>
+<tr>
+<td>  mapping + custom container size + alloc</td>
+<td> `mda_t(m, c_t(s, a))` </td>
+<td> `mda_t(m, c_t(s, a))` </td>
+<td> `mda_t(m, c_t(s, a))` or `mda_t(m, s, a)` for integrals not convertible to `value_type`</td>
+</tr>
+<tr>
+<td>  mapping + custom container size + value + alloc</td>
+<td> `mda_t(m, c_t(s, v, a))` </td>
+<td> `mda_t(m, c_t(s, v, a))` </td>
+<td> `mda_t(m, s, v, a)` </td>
+</tr>
+<tr>
+<td> iterators</td>
+<td> `mda_t(m, c_t(begin, end))` </td>
+<td> `mda_t(m, c_t(begin, end))` </td>
+<td> `mda_t(m, begin, end)` </td>
+</tr>
+<tr>
+<td> range</td>
+<td> `mda_t(m, c_t(r))` </td>
+<td> `mda_t(m, c_t(r))` </td>
+<td> `mda_t(m, r)` </td>
+</tr>
+<tr>
+<td> converting mdarray</td>
+<td> `mda_t(mda)` </td>
+<td> `mda_t(mda)` </td>
+<td> `mda_t(mda)` </td>
+</tr>
+<tr>
+<td> compatible mdspan</td>
+<td> `mda_t(mds)` </td>
+<td> `mda_t(mds)` </td>
+<td> `mda_t(mds)` </td>
+</tr>
+<td> compatible mdspan + allocator</td>
+<td> `mda_t(mds, a)` </td>
+<td> `mda_t(mds, a)` </td>
+<td> `mda_t(mds, a)` </td>
 </tr>
 
-</tbody> 
-</table> 
+</tbody>
+</table>
 
 # Move Behavior
 
@@ -966,7 +966,7 @@ Insert the following after section 24.6.6
 ```c++
 namespace std {
 
-template<class ElementType, class Extents, class LayoutPolicy, class Container = 
+template<class ElementType, class Extents, class LayoutPolicy, class Container =
          vector<ElementType>>
 class mdarray {
 public:
@@ -1012,7 +1012,7 @@ public:
   constexpr mdarray(const mapping_type& m, container_type&& c,);
 
 
-  template<class OtherElementType, class OtherExtents, 
+  template<class OtherElementType, class OtherExtents,
            class OtherLayoutPolicy, class OtherContainer>
     explicit(@_see below_@)
     constexpr mdarray(
@@ -1047,12 +1047,12 @@ public:
     constexpr mdarray(const mapping_type& m, container_type&& c, const Alloc& a);
 
 
-  template<class OtherElementType, class OtherExtents, 
-           class OtherLayoutPolicy, class OtherContainer, 
+  template<class OtherElementType, class OtherExtents,
+           class OtherLayoutPolicy, class OtherContainer,
            class Alloc>
     explicit(@_see below_@)
     constexpr mdarray(
-      const mdarray<OtherElementType, OtherExtents, 
+      const mdarray<OtherElementType, OtherExtents,
                     OtherLayoutPolicy, OtherContainer>& other, const Alloc& a);
 
   template<class OtherElementType, class OtherExtents,
@@ -1092,8 +1092,8 @@ public:
   constexpr const mapping_type& mapping() const { return @_map\__@; }
 
   template<class OtherElementType, class OtherExtents,
-           class OtherLayoutType, class OtherAccessorType>
-  constexpr operator mdspan () const;
+           class OtherLayoutPolicy, class OtherAccessorType>
+  constexpr operator mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessorType> () const;
 
   template<class OtherAccessorType = default_accessor<element_type>>
     constexpr mdspan<element_type, extents_type, layout_type, OtherAccessorType>
@@ -1190,7 +1190,7 @@ mdarray(const mdspan<ElementType, Extents, Layout, Accessor>&, const Alloc&)
    * [5.1]{.pnum} `is_nothrow_move_constructible_v<MDA>` is `true` if `is_nothrow_move_constructible_v<Container>` is `true`,
 
    * [5.2]{.pnum} `is_nothrow_move_assignable_v<MDA>` is `true` if `is_nothrow_move_assignable_v<Container>` is `true` , and
-   
+
    * [5.3]{.pnum} `is_nothrow_swappable_v<MDA>` is `true` if `is_nothrow_swappable_v<Container>` is `true`.
 
 [6]{.pnum} A specialization of `mdarray` is a trivially copyable type if its `container_type` and `mapping_type` are
@@ -1246,7 +1246,7 @@ template<class... OtherIndexTypes>
 [2]{.pnum} *Preconditions:*
 
    * [2.1] Let `map` be `mapping_type(extents_type(static_cast<index_type>(std::move(exts)...)))`, then
-  
+
    * [2.2]{.pnum} if `container_type` is a specialization of `array`, `map.required_span_size() <= size(container_type())` is `true`, otherwise
 
    * [2.3]{.pnum} `map.required_span_size() <= size(container_type(map.required_span_size()))` is `true`.
@@ -1267,10 +1267,10 @@ constexpr mdarray(const extents_type& ext);
 
    * [4.2]{.pnum} if `container_type` is not a specialization of `array`, `is_constructible_v<container_type, size_t>` is `true`.
 
-[5]{.pnum} *Preconditions:* 
+[5]{.pnum} *Preconditions:*
 
    * [5.1]{.pnum} Let `map` be `mapping_type(ext)`, then
-  
+
    * [5.2]{.pnum} if `container_type` is a specialization of `array`, `map.required_span_size() <= size(container_type())` is `true`, otherwise
 
    * [5.3]{.pnum} `map.required_span_size() <= size(container_type(map.required_span_size()))` is `true`.
@@ -1288,7 +1288,7 @@ constexpr mdarray(const mapping_type& map);
 
 [7]{.pnum} *Constraints:* if `container_type` is not a specialization of `array`, `is_constructible_v<container_type, size_t>` is `true`.
 
-[8]{.pnum} *Preconditions:* 
+[8]{.pnum} *Preconditions:*
 
    * [8.1]{.pnum} if `container_type` is a specialization of `array`, `map.required_span_size() <= size(container_type())` is `true`, otherwise
 
@@ -1311,10 +1311,10 @@ constexpr mdarray(const extents_type& ext, const value_type& val);
 
    * [10.2]{.pnum} if `container_type` is not a specialization of `array`, `is_constructible_v<container_type, size_t, value_type>` is `true`.
 
-[11]{.pnum} *Preconditions:* 
+[11]{.pnum} *Preconditions:*
 
    * [11.1]{.pnum} Let `map` be `mapping_type(ext)`, then
-  
+
    * [11.2]{.pnum} if `container_type` is a specialization of `array`, `map.required_span_size() <= size(container_type())` is `true`, otherwise
 
    * [11.3]{.pnum} `map.required_span_size() <= size(container_type(map.required_span_size()))` is `true`.
@@ -1324,7 +1324,7 @@ constexpr mdarray(const extents_type& ext, const value_type& val);
    * [12.1]{.pnum} Direct-non-list-initializes _`map_`_ with `ext`, and
 
    * [12.2]{.pnum} if `is_constructible_v<container_type, size_t, value_type>` is `true`,
-                  direct-non-list-initializes `ctr_` with `container_type(`_`map_`_`.required_span_size(), val)`, otherwise 
+                  direct-non-list-initializes `ctr_` with `container_type(`_`map_`_`.required_span_size(), val)`, otherwise
                   direct-non-list-initializes `ctr_` with _`value-to-array`_`<element_type, size(declval<container_type>())>()`.
 
 
@@ -1334,7 +1334,7 @@ constexpr mdarray(const mapping_type& m, const value_type& val);
 
 [13]{.pnum} *Constraints:* if `container_type` is not a specialization of `array`, `is_constructible_v<container_type, size_t, value_type>` is `true`.
 
-[14]{.pnum} *Preconditions:* 
+[14]{.pnum} *Preconditions:*
 
    * [14.1]{.pnum} if `container_type` is a specialization of `array`, `map.required_span_size() <= size(container_type())` is `true`, otherwise
 
@@ -1345,7 +1345,7 @@ constexpr mdarray(const mapping_type& m, const value_type& val);
    * [15.1]{.pnum} Direct-non-list-initializes _`map_`_ with `m`, and
 
    * [15.2]{.pnum} if `is_constructible_v<container_type, size_t, value_type>` is `true`,
-                  direct-non-list-initializes `ctr_` with `container_type(`_`map_`_`.required_span_size(), val)`, otherwise 
+                  direct-non-list-initializes `ctr_` with `container_type(`_`map_`_`.required_span_size(), val)`, otherwise
                   direct-non-list-initializes `ctr_` with _`value-to-array`_`<element_type, size(declval<container_type>())>()`.
 
 ```c++
@@ -1407,17 +1407,17 @@ constexpr mdarray(const mapping_type& m, container_type&& c);
 template<class OtherElementType, class OtherExtents,
          class OtherLayoutPolicy, class OtherContainer>
   explicit(@_see below_@)
-  constexpr mdarray(const mdarray<OtherElementType, OtherExtents, 
+  constexpr mdarray(const mdarray<OtherElementType, OtherExtents,
                                 OtherLayoutPolicy, OtherContainer>& other);
 ```
 
-[24]{.pnum} *Mandates:* 
+[24]{.pnum} *Mandates:*
 
    * [24.1]{.pnum} `is_constructible_v<Container, const OtherContainer&>` is `true`, and
 
    * [24.2]{.pnum} `is_constructible_v<extents_type, OtherExtents>` is `true`.
 
-[25]{.pnum} *Constraints:* 
+[25]{.pnum} *Constraints:*
 
    * [25.1]{.pnum} `is_constructible_v<mapping_type, const OtherLayoutPolicy::template mapping<OtherExtents>&>` is `true`, and
 
@@ -1455,9 +1455,9 @@ template<class OtherElementType, class OtherExtents,
    * [30.2]{.pnum} `is_assignable_v<Accessor::reference, value_type>` is `true`,
 
    * [30.3]{.pnum} `is_default_constructible_v<value_type>` is `true`,
-   
+
    * [30.4]{.pnum} `is_constructible_v<mapping_type, const OtherLayoutPolicy::template mapping<OtherExtents>&>` is `true`, and
-   
+
    * [30.5]{.pnum} if `container_type` is not a specialization of `array`, `is_constructible_v<container_type, size_t>` is `true`.
 
 [31]{.pnum} *Preconditions:*
@@ -1496,10 +1496,10 @@ template<class Alloc>
 
    * [1.2]{.pnum} `is_constructible_v<container_type, size_t, Alloc>` is `true`.
 
-[2]{.pnum} *Preconditions:* 
+[2]{.pnum} *Preconditions:*
 
    * [2.1]{.pnum} Let `map` be `mapping_type(ext)`, then
-  
+
    * [2.2]{.pnum} if `container_type` is a specialization of `array`, `map.required_span_size() <= size(container_type())` is `true`, otherwise
 
    * [2.3]{.pnum} `map.required_span_size() <= size(container_type(map.required_span_size(), a))` is `true`.
@@ -1518,7 +1518,7 @@ template<class Alloc>
 
 [4]{.pnum} *Constraints:* `is_constructible_v<container_type, size_t, Alloc>` is `true`.
 
-[5]{.pnum} *Preconditions:* 
+[5]{.pnum} *Preconditions:*
 
    * [5.1]{.pnum} if `container_type` is a specialization of `array`, `map.required_span_size() <= size(container_type())` is `true`, otherwise
 
@@ -1541,10 +1541,10 @@ constexpr mdarray(const extents_type& ext, const value_type& val, const Alloc& a
 
    * [7.2]{.pnum} if `container_type` is not a specialization of `array`, `is_constructible_v<container_type, size_t, value_type, Alloc>` is `true`.
 
-[8]{.pnum} *Preconditions:* 
+[8]{.pnum} *Preconditions:*
 
    * [8.1]{.pnum} Let `map` be `mapping_type(ext)`, then
-  
+
    * [8.2]{.pnum} if `container_type` is a specialization of `array`, `map.required_span_size() <= size(container_type())` is `true`, otherwise
 
    * [8.3]{.pnum} `map.required_span_size() <= size(container_type(map.required_span_size(), val, a))` is `true`.
@@ -1554,7 +1554,7 @@ constexpr mdarray(const extents_type& ext, const value_type& val, const Alloc& a
    * [9.1]{.pnum} Direct-non-list-initializes _`map_`_ with `ext`, and
 
    * [9.2]{.pnum} if `is_constructible_v<container_type, size_t, value_type>` is `true`,
-                  direct-non-list-initializes `ctr_` with `container_type(`_`map_`_`.required_span_size(), val)`, otherwise 
+                  direct-non-list-initializes `ctr_` with `container_type(`_`map_`_`.required_span_size(), val)`, otherwise
                   direct-non-list-initializes `ctr_` with _`value-to-array`_`<element_type, size(declval<container_type>())>()`.
 
 
@@ -1565,7 +1565,7 @@ constexpr mdarray(const mapping_type& map, const value_type& val, const Alloc& a
 
 [10]{.pnum} *Constraints:* if `container_type` is not a specialization of `array`, `is_constructible_v<container_type, size_t, value_type>` is `true`.
 
-[11]{.pnum} *Preconditions:* 
+[11]{.pnum} *Preconditions:*
 
    * [11.1]{.pnum} if `container_type` is a specialization of `array`, `map.required_span_size() <= size(container_type())` is `true`, otherwise
 
@@ -1576,7 +1576,7 @@ constexpr mdarray(const mapping_type& map, const value_type& val, const Alloc& a
    * [12.1]{.pnum} Direct-non-list-initializes _`map_`_ with `map`, and
 
    * [12.2]{.pnum} if `is_constructible_v<container_type, size_t, value_type>` is `true`,
-                  direct-non-list-initializes `ctr_` with `container_type(`_`map_`_`.required_span_size(), val)`, otherwise 
+                  direct-non-list-initializes `ctr_` with `container_type(`_`map_`_`.required_span_size(), val)`, otherwise
                   direct-non-list-initializes `ctr_` with _`value-to-array`_`<element_type, size(declval<container_type>())>()`.
 
 
@@ -1656,12 +1656,12 @@ template<class Alloc>
 template<class OtherElementType, class OtherExtents,
          class OtherLayoutPolicy, class OtherContainer, class Alloc>
   explicit(@_see below_@)
-  constexpr mdarray(const mdarray<OtherElementType, OtherExtents, 
+  constexpr mdarray(const mdarray<OtherElementType, OtherExtents,
                                   OtherLayoutPolicy, OtherContainer>& other,
                     const Alloc& a);
 ```
 
-[25]{.pnum} *Mandates:* 
+[25]{.pnum} *Mandates:*
 
    * [25.1]{.pnum} `is_constructible_v<Container, OtherContainer, Alloc>` is `true`, and
 
@@ -1710,7 +1710,7 @@ template<class OtherElementType, class OtherExtents,
    * [31.3]{.pnum} `is_assignable_v<Accessor::reference, value_type>` is `true`,
 
    * [31.4]{.pnum} `is_default_constructible_v<value_type>` is `true`, and
-   
+
    * [31.5]{.pnum} `is_constructible_v<mapping_type, const OtherLayoutPolicy::template mapping<OtherExtents>&>` is `true`.
 
 
@@ -1767,10 +1767,10 @@ template<class... OtherIndexTypes>
 
 [2]{.pnum} Let `I` be `extents_type::`_`index-cast`_`(std::move(indices))`.
 
-[3]{.pnum} *Preconditions:* 
-   
+[3]{.pnum} *Preconditions:*
+
    * [3.1]{.pnum} `I` is a multidimensional index in `extents()`.
-                  <i>[Note:</i> This implies that _`map_`_`(I...) < `_`map_`_`.required_span_size()` is `true`.<i>— end note]</i>; 
+                  <i>[Note:</i> This implies that _`map_`_`(I...) < `_`map_`_`.required_span_size()` is `true`.<i>— end note]</i>;
    * [3.2]{.pnum} `container_size() >= `_`map_`_`.required_span_size()` is `true`.
 
 [4]{.pnum} *Effects:* Equivalent to: `return ` _`acc_`_`.access(`_`ptr_`_`, `_`map_`_`(static_cast<index_type>(std::move(indices))...));`
@@ -1790,7 +1790,7 @@ template<class OtherIndexType>
 [5]{.pnum} *Constraints:*
 
    * [5.1]{.pnum} `is_convertible_v<const OtherIndexType&, index_type>` is `true`, and
-   
+
    * [5.2]{.pnum} `is_nothrow_constructible_v<index_type, const OtherIndexType&>` is `true`.
 
 [6]{.pnum} *Effects:* Let `P` be a parameter pack such that
@@ -1822,15 +1822,15 @@ swap(x.@_map_@_, y.@_map_@_);
 
 ```c++
   template<class OtherElementType, class OtherExtents,
-           class OtherLayoutType, class OtherAccessorType>
+           class OtherLayoutPolicy, class OtherAccessorType>
   operator mdspan ();
 ```
 
 [11]{.pnum} *Constraints:*
 
-   * [11.1]{pnum} `is_assignable_v<mdspan<element_type, extents_type, layout_type>, mdspan<OtherElementType, OtherExtents, OtherLayoutType, OtherAccessorType>>` is `true`.
+   * [11.1]{.pnum} `is_assignable_v<mdspan_type &, mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessorType>>` is `true`.
 
-   * [11.2]{pnum} `is_same_v<pointer, element_type*>` is `true`.
+   * [11.2]{.pnum} `is_same_v<pointer, element_type*>` is `true`.
 
 [12]{.pnum} *Preconditions:* `container_size() >= `_`map_`_`.required_span_size()` is `true`.
 
@@ -1842,7 +1842,7 @@ swap(x.@_map_@_, y.@_map_@_);
       to_mdspan(const OtherAccessorType& a = default_accessor<element_type>());
 ```
 
-[14]{.pnum} *Constraints:* `is_assignable_v<pointer, typename OtherAccessorType::data_handle_type>` is `true`.
+[14]{.pnum} *Constraints:* `is_assignable_v<pointer &, typename OtherAccessorType::data_handle_type>` is `true`.
 
 [15]{.pnum} *Preconditions:* `container_size() >= `_`map_`_`.required_span_size()` is `true`.
 
@@ -1854,7 +1854,7 @@ swap(x.@_map_@_, y.@_map_@_);
       to_mdspan(const OtherAccessorType& a = default_accessor<const element_type>()) const;
 ```
 
-[17]{.pnum} *Constraints:* `is_assignable_v<const_pointer, typename OtherAccessorType::data_handle_type>` is `true`.
+[17]{.pnum} *Constraints:* `is_assignable_v<const_pointer &, typename OtherAccessorType::data_handle_type>` is `true`.
 
 [18]{.pnum} *Preconditions:* `container_size() >= `_`map_`_`.required_span_size()` is `true`.
 


### PR DESCRIPTION
Making this just a draft for now in case it's useful.

This
1. fixes the reference to mdspan
2. apparently cleans up line endings (sorry, my editor...)
3. OtherLayoutType -> OtherLayoutPolicy
4. Simplifies expression that evaluates to `mdspan_type`
5. Makes `is_assignable_v` correct by giving it a reference